### PR TITLE
Remove bottom margin from search form

### DIFF
--- a/templates/partials/_search_form.html
+++ b/templates/partials/_search_form.html
@@ -1,5 +1,5 @@
 <form method="GET" action="{% url 'search_results' %}" id="main-search-form"
-      class="d-flex align-items-center my-3 position-relative  " style="max-width: 600px; margin: 0 auto; z-index:10;">
+      class="d-flex align-items-center position-relative" style="max-width: 600px; margin: 0 auto; z-index:10;">
 
     <!-- Input de texto -->
     <input 


### PR DESCRIPTION
## Summary
- remove margin utility class from the search form to avoid extra space under the dropdown

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844e6f65b848321ab3390339a160b71