### PR TITLE
Add sticky shrinking header

### DIFF
--- a/static/css/_header.css
+++ b/static/css/_header.css
@@ -1,1 +1,7 @@
- 
+header.navbar {
+    position: sticky;
+    top: 0;
+    z-index: 1030;
+    transition: height 0.3s ease;
+}
+

--- a/static/js/sticky-header.js
+++ b/static/js/sticky-header.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const header = document.querySelector('header.navbar');
+    if (!header) return;
+
+    const initialHeight = header.offsetHeight;
+    const scrolledHeight = initialHeight - 10;
+
+    header.style.position = 'sticky';
+    header.style.top = '0';
+    header.style.zIndex = '1030';
+
+    window.addEventListener('scroll', function() {
+        if (window.scrollY > 0) {
+            header.style.height = scrolledHeight + 'px';
+        } else {
+            header.style.height = initialHeight + 'px';
+        }
+    });
+});
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,7 @@
 
 <script src="{% static 'js/geolocator.js' %}"></script>
 <script src="{% static 'js/dropdown.js' %}"></script>
+<script src="{% static 'js/sticky-header.js' %}"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- make navbar sticky via `_header.css`
- shrink navbar by 10px on scroll with JS
- include new script in `base.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844eaed72a8832182bb1fe32c426eeb