### PR TITLE
Fix sticky shrinking header

### DIFF
--- a/static/css/_header.css
+++ b/static/css/_header.css
@@ -1,1 +1,4 @@
- 
+header.navbar {
+    transition: height 0.3s ease;
+}
+

--- a/static/js/sticky-header.js
+++ b/static/js/sticky-header.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const header = document.querySelector('header.navbar');
+    if (!header) return;
+
+    const initialHeight = header.offsetHeight;
+    const scrolledHeight = initialHeight - 10;
+    header.style.height = initialHeight + 'px';
+
+    window.addEventListener('scroll', function() {
+        if (window.scrollY > 0) {
+            header.style.height = scrolledHeight + 'px';
+        } else {
+            header.style.height = initialHeight + 'px';
+        }
+    });
+});
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,7 @@
 
 <script src="{% static 'js/geolocator.js' %}"></script>
 <script src="{% static 'js/dropdown.js' %}"></script>
+<script src="{% static 'js/sticky-header.js' %}"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 
 </body>

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -1,7 +1,7 @@
 {% load static %}
  
 <!-- Header con Bootstrap -->
-<header class="navbar navbar-expand-lg bg-white border-bottom">
+<header class="navbar navbar-expand-lg bg-white border-bottom sticky-top">
     <div class="container-fluid px-3">
         
         <!-- Logo -->


### PR DESCRIPTION
## Summary
- ensure header uses Bootstrap `sticky-top`
- keep header height with transition
- adjust JavaScript to shrink height on scroll

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844eaed72a8832182bb1fe32c426eeb