### PR TITLE
Enable dynamic review filtering with AJAX

### DIFF
--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -2,13 +2,14 @@
 
 from django.urls import path
 from .views import (
-    dashboard, 
+    dashboard,
     search,
-    public, 
+    public,
 )
 
 urlpatterns = [
     path('resultados/', search.search_results, name='search_results'),
+    path('valoraciones/<slug:slug>/', public.ajax_reviews, name='ajax_reviews'),
     
     # El perfil público ahora se maneja desde config.urls con la ruta '@slug'
  

--- a/apps/clubs/views/__init__.py
+++ b/apps/clubs/views/__init__.py
@@ -1,5 +1,2 @@
- # views.py
-  
-
 from .search import search_results
-from .public import club_profile 
+from .public import club_profile, ajax_reviews

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -45,5 +45,25 @@ def club_profile(request, slug):
         'reseña_existente': reseña_existente,
         'detallado': detallado,
         'competidores': competidores,
-        
+
     })
+
+
+def ajax_reviews(request, slug):
+    """Devolver la lista de reseñas ordenada sin recargar la página."""
+    club = get_object_or_404(Club, slug=slug)
+    reseñas = club.reseñas.select_related('usuario').all()
+    orden = request.GET.get('orden', 'relevantes')
+
+    if orden == 'recientes':
+        reseñas = reseñas.order_by('-creado')
+    elif orden == 'antiguos':
+        reseñas = reseñas.order_by('creado')
+    elif orden == 'puntuacion_alta':
+        reseñas = sorted(reseñas, key=lambda r: r.promedio(), reverse=True)
+    elif orden == 'puntuacion_baja':
+        reseñas = sorted(reseñas, key=lambda r: r.promedio())
+    else:
+        reseñas = reseñas.order_by('-creado')
+
+    return render(request, 'clubs/reviews_list.html', {'reseñas': reseñas})

--- a/static/js/review-filter.js
+++ b/static/js/review-filter.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.getElementById('review-filter-form');
+    if (!form) return;
+    const sortDropdown = document.getElementById('sort-dropdown');
+    const sortSelected = sortDropdown.querySelector('.selected-text');
+    const sortMenu = document.getElementById('sort-menu');
+    const sortInput = document.getElementById('sort-input');
+    const reviewsContainer = document.getElementById('review-list');
+
+    sortDropdown.querySelector('.selected').addEventListener('click', function (e) {
+        e.stopPropagation();
+        sortMenu.style.display = sortMenu.style.display === 'block' ? 'none' : 'block';
+    });
+
+    sortMenu.querySelectorAll('.dropdown-item').forEach(function (item) {
+        item.addEventListener('click', function () {
+            sortSelected.textContent = item.textContent;
+            sortInput.value = item.dataset.value;
+            sortMenu.style.display = 'none';
+            const url = form.getAttribute('action');
+            const params = new URLSearchParams(new FormData(form));
+            fetch(url + '?' + params.toString(), {
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            })
+                .then(res => res.text())
+                .then(html => {
+                    reviewsContainer.innerHTML = html;
+                })
+                .catch(err => console.error(err));
+        });
+    });
+
+    document.addEventListener('click', function () {
+        sortMenu.style.display = 'none';
+    });
+});

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -202,25 +202,9 @@
 
   </div>
 
- {% for reseña in reseñas %}
-  <div class="mb-3 rounded p-4 border position-relative" style="min-height: 120px;">
-    <div class="d-flex justify-content-between align-items-center mb-2">
-      <div class="d-flex align-items-center">
-        <div class="review-avatar">{{ reseña.usuario.username|first|upper }}</div>
-        <div class="fw-medium ms-2">{{ reseña.usuario.username }}</div>
-      </div>
-      <div class=" fw-bold text-warning">⭐ {{ reseña.promedio }}</div>
-    </div>
-
-    <p class="mb-3">{{ reseña.comentario }}</p>
-
-    <div class="position-absolute text-muted small " style="bottom: 1rem; right: 1rem;">
-      {{ reseña.creado|date:"SHORT_DATE_FORMAT" }}
-    </div>
+  <div id="review-list">
+      {% include 'clubs/reviews_list.html' %}
   </div>
-{% empty %}
-  <p class="text-muted">Este club todavía no tiene comentarios escritos.</p>
-{% endfor %}
 
 </div>
 
@@ -330,7 +314,7 @@
     </div>
   </div>
 </div>
-<script src="{% static 'js/sort.js' %}"></script>
+<script src="{% static 'js/review-filter.js' %}"></script>
 <script src="{% static 'js/slides.js' %}"></script>
 <script src="{% static 'js/stars.js' %}"></script>
 <script src="{% static 'js/star-rating.js' %}"></script>

--- a/templates/clubs/reviews_list.html
+++ b/templates/clubs/reviews_list.html
@@ -1,0 +1,17 @@
+{% for reseña in reseñas %}
+  <div class="mb-3 rounded p-4 border position-relative" style="min-height: 120px;">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <div class="d-flex align-items-center">
+        <div class="review-avatar">{{ reseña.usuario.username|first|upper }}</div>
+        <div class="fw-medium ms-2">{{ reseña.usuario.username }}</div>
+      </div>
+      <div class=" fw-bold text-warning">⭐ {{ reseña.promedio }}</div>
+    </div>
+    <p class="mb-3">{{ reseña.comentario }}</p>
+    <div class="position-absolute text-muted small " style="bottom: 1rem; right: 1rem;">
+      {{ reseña.creado|date:"SHORT_DATE_FORMAT" }}
+    </div>
+  </div>
+{% empty %}
+  <p class="text-muted">Este club todavía no tiene comentarios escritos.</p>
+{% endfor %}

--- a/templates/partials/_review-filter.html
+++ b/templates/partials/_review-filter.html
@@ -1,5 +1,5 @@
  
-      <form method="get" class="d-flex align-items-center" style="gap: 10px;">
+      <form method="get" id="review-filter-form" action="{% url 'ajax_reviews' club.slug %}" class="d-flex align-items-center" style="gap: 10px;">
         <input type="hidden" name="orden" id="sort-input" value="{{ request.GET.orden|default:'' }}">
 
     <div class="custom-dropdown small" id="sort-dropdown">


### PR DESCRIPTION
## Summary
- create partial for club review list
- return review list via new `ajax_reviews` view
- wire up URL pattern for reviews
- load review filter with AJAX and update club profile
- add new script `review-filter.js`
- fix corrupted imports in clubs views

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844f658e1c08321aba74a0afe543190