### PR TITLE
Add page loader

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -149,3 +149,18 @@ p {
 .container-fluid {
     max-width: 1600px;
 }
+
+#loader {
+    position: fixed;
+    inset: 0;
+    background-color: #fff;
+    z-index: 2000;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+#loader.hidden {
+    opacity: 0;
+    visibility: hidden;
+}

--- a/static/js/page-loader.js
+++ b/static/js/page-loader.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const loader = document.getElementById('loader');
+    if (!loader) return;
+    setTimeout(() => {
+        loader.classList.add('hidden');
+    }, 600);
+});
+
+window.addEventListener('beforeunload', function () {
+    const loader = document.getElementById('loader');
+    if (loader) {
+        loader.classList.remove('hidden');
+    }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,9 @@
 </head>
 
 <body class="{% block body_class %}{% endblock %}">
+    <div id="loader" class="page-loader">
+        <div class="spinner-border" role="status"></div>
+    </div>
 
     {% include 'partials/_header.html' %}
 
@@ -26,6 +29,7 @@
 <script src="{% static 'js/dropdown.js' %}"></script>
 <script src="{% static 'js/sticky-header.js' %}"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{% static 'js/page-loader.js' %}"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a page loading overlay
- style page loading overlay
- include loader in base template

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844f7c4b1dc832197494cccac80a5be