### PR TITLE
Add search modal with icon trigger

### DIFF
--- a/static/css/search_modal.css
+++ b/static/css/search_modal.css
@@ -1,0 +1,48 @@
+#searchModal.modal {
+    padding: 0 !important;
+}
+
+#searchModal .modal-dialog {
+    margin: 0;
+    width: 100%;
+    height: 100vh;
+}
+
+#searchModal .modal-content {
+    height: 100%;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+#searchModal .modal-header {
+    background: #000;
+    justify-content: center;
+    position: relative;
+}
+
+#searchModal .modal-header img {
+    height: 60px;
+}
+
+#searchModal .close-btn {
+    position: absolute;
+    right: 1rem;
+    top: 1rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    background: #000;
+    border-radius: 50%;
+    opacity: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    filter: invert(1);
+}
+
+#searchModal .modal-body {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,9 @@
     </div>
 
     {% include 'partials/_header.html' %}
+    {% if request.path != '/' %}
+        {% include 'partials/_search_modal.html' %}
+    {% endif %}
 
     {% block content %}{% endblock %}
 

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -13,9 +13,6 @@
                 <span>.COM</span>
             </div>
         </a>
-        {% if not request.path == '/' %}
-    {% include 'partials/_search_form.html' %}
-{% endif %}
 
         <!-- Botón Responsive -->
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
@@ -25,6 +22,15 @@
         <!-- Links de Navegación -->
         <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
             <ul class="navbar-nav align-items-center">
+                {% if request.path != '/' %}
+                <li class="nav-item">
+                    <button class="btn nav-link text-dark" data-bs-toggle="modal" data-bs-target="#searchModal">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" width="24" height="24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35m1.15-5.15a7 7 0 1 1-14 0 7 7 0 0 1 14 0z"/>
+                        </svg>
+                    </button>
+                </li>
+                {% endif %}
                 {% if user.is_authenticated %}
                     <li class="nav-item">
                         <span class="nav-link">Hola, {{ user.username }}</span>

--- a/templates/partials/_search_modal.html
+++ b/templates/partials/_search_modal.html
@@ -1,0 +1,14 @@
+{% load static %}
+<div class="modal fade" id="searchModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-fullscreen">
+        <div class="modal-content border-0 bg-white">
+            <div class="modal-header border-0">
+                <img src="{% static 'img/logo.svg' %}" alt="Logo">
+                <button type="button" class="btn-close close-btn" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body d-flex justify-content-center align-items-center">
+                {% include 'partials/_search_form.html' %}
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- show search icon in header that opens modal
- include search modal partial in base template
- style fullscreen modal
- hide modal and button on homepage

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684508d5e80c8321abab44d06617ccf8