### PR TITLE
Fix preloader stuck on back navigation

### DIFF
--- a/static/js/page-loader.js
+++ b/static/js/page-loader.js
@@ -6,6 +6,14 @@ document.addEventListener('DOMContentLoaded', function () {
     }, 300);
 });
 
+// Ensure the loader is hidden when navigating back from bfcache
+window.addEventListener('pageshow', function (event) {
+    const loader = document.getElementById('loader');
+    if (loader && event.persisted) {
+        loader.classList.add('hidden');
+    }
+});
+
 window.addEventListener('beforeunload', function () {
     const loader = document.getElementById('loader');
     if (loader) {


### PR DESCRIPTION
## Summary
- hide loader on pageshow to avoid stuck loader when navigating back

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684628a1ee1483218154b342b8d441f6