### PR TITLE
Fix preloader stuck on back navigation

### DIFF
--- a/static/js/page-loader.js
+++ b/static/js/page-loader.js
@@ -1,10 +1,13 @@
-document.addEventListener('DOMContentLoaded', function () {
+function hideLoader() {
     const loader = document.getElementById('loader');
-    if (!loader) return;
-    setTimeout(() => {
+    if (loader) {
         loader.classList.add('hidden');
-    }, 300);
-});
+    }
+}
+
+document.addEventListener('DOMContentLoaded', hideLoader);
+window.addEventListener('load', hideLoader);
+window.addEventListener('pageshow', hideLoader);
 
 window.addEventListener('beforeunload', function () {
     const loader = document.getElementById('loader');


### PR DESCRIPTION
## Summary
- hide loader reliably on back/forward navigation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684628a1ee1483218154b342b8d441f6