### PR TITLE
Fix preloader stuck on back navigation

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -158,9 +158,10 @@ p {
     display: flex;
     justify-content: center;
     align-items: center;
-    transition: opacity 0.3s ease, visibility 0.3s ease;
+    pointer-events: none;
+    transition: opacity 0.4s ease, visibility 0.4s ease;
 }
-#loader.hidden {
+#loader.is-hidden {
     opacity: 0;
     visibility: hidden;
 }

--- a/static/js/page-loader.js
+++ b/static/js/page-loader.js
@@ -1,14 +1,21 @@
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', () => {
     const loader = document.getElementById('loader');
     if (!loader) return;
-    setTimeout(() => {
-        loader.classList.add('hidden');
-    }, 300);
-});
 
-window.addEventListener('beforeunload', function () {
-    const loader = document.getElementById('loader');
-    if (loader) {
-        loader.classList.remove('hidden');
-    }
+    const hide = () => loader.classList.add('is-hidden');
+    const show = () => loader.classList.remove('is-hidden');
+
+    hide();
+    window.addEventListener('load', hide);
+    window.addEventListener('pageshow', hide);
+
+    document.body.addEventListener('click', (e) => {
+        const link = e.target.closest('a[href]');
+        if (link && link.target !== '_blank' && !link.href.startsWith('#')) {
+            show();
+        }
+    });
+
+    document.body.addEventListener('submit', show, true);
+    window.addEventListener('pagehide', show);
 });


### PR DESCRIPTION
## Summary
- update loader CSS with `.is-hidden` state and pointer-events disabled
- reimplement loader script to show and hide reliably across navigations

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684628a1ee1483218154b342b8d441f6