### PR TITLE
Prevent empty search submissions

### DIFF
--- a/static/css/_search-form.css
+++ b/static/css/_search-form.css
@@ -24,6 +24,12 @@
     box-shadow: none;
 }
 
+/* Highlight for empty search */
+#search-input.input-alert {
+    border: 2px solid #dc3545;
+    border-radius: 4px;
+}
+
 .custom-dropdown {
     position: relative;
     user-select: none;

--- a/static/js/geolocator.js
+++ b/static/js/geolocator.js
@@ -85,6 +85,23 @@ document.addEventListener('DOMContentLoaded', function () {
             wrapper.style.display = 'none';
         }
     });
-    
+
+    // Prevent empty searches
+    const form = document.getElementById('main-search-form');
+    if (form && input) {
+        form.addEventListener('submit', function (e) {
+            if (input.value.trim() === '') {
+                e.preventDefault();
+                input.classList.add('input-alert');
+                input.focus();
+            }
+        });
+
+        input.addEventListener('input', function () {
+            if (input.value.trim() !== '') {
+                input.classList.remove('input-alert');
+            }
+        });
+    }
 
 });


### PR DESCRIPTION
## Summary
- prevent empty search submissions
- highlight empty search form input if user tries to submit it

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68462d88433c832186723211cddca097