### PR TITLE
Add club verification badge

### DIFF
--- a/apps/clubs/admin.py
+++ b/apps/clubs/admin.py
@@ -27,10 +27,10 @@ class HorarioInline(admin.TabularInline):
 
 @admin.register(Club)
 class ClubAdmin(admin.ModelAdmin):
-    list_display = ('name', 'city', 'phone', 'email')
+    list_display = ('name', 'verified', 'city', 'phone', 'email')
     prepopulated_fields = {'slug': ('name',)}
     inlines = [ClubPhotoInline, HorarioInline]  
-    fields = ('logo', 'name', 'slug', 'city', 'address', 'phone', 'whatsapp_link', 'email', 'about', 'features')   
+    fields = ('logo', 'name', 'verified', 'slug', 'city', 'address', 'phone', 'whatsapp_link', 'email', 'about', 'features')
 
 @admin.register(Feature)
 class FeatureAdmin(admin.ModelAdmin):

--- a/apps/clubs/models/club.py
+++ b/apps/clubs/models/club.py
@@ -18,6 +18,7 @@ class Club(models.Model):
     features = models.ManyToManyField('Feature', blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+    verified = models.BooleanField(default=False)
     CATEGORY_CHOICES = [
         ('club', 'Club'),
         ('entrenador', 'Entrenador'),

--- a/clubs/admin.py
+++ b/clubs/admin.py
@@ -27,10 +27,10 @@ class HorarioInline(admin.TabularInline):
 
 @admin.register(Club)
 class ClubAdmin(admin.ModelAdmin):
-    list_display = ('name', 'city', 'phone', 'email')
+    list_display = ('name', 'verified', 'city', 'phone', 'email')
     prepopulated_fields = {'slug': ('name',)}
     inlines = [ClubPhotoInline, HorarioInline]  
-    fields = ('logo', 'name', 'slug', 'city', 'address', 'phone', 'whatsapp_link', 'email', 'about', 'features')   
+    fields = ('logo', 'name', 'verified', 'slug', 'city', 'address', 'phone', 'whatsapp_link', 'email', 'about', 'features')
 
 @admin.register(Feature)
 class FeatureAdmin(admin.ModelAdmin):

--- a/clubs/migrations/0007_club_verified.py
+++ b/clubs/migrations/0007_club_verified.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0006_horario'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='club',
+            name='verified',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/clubs/models.py
+++ b/clubs/models.py
@@ -18,6 +18,7 @@ class Club(models.Model):
     features = models.ManyToManyField('Feature', blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+    verified = models.BooleanField(default=False)
     CATEGORY_CHOICES = [
         ('club', 'Club'),
         ('entrenador', 'Entrenador'),

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -58,6 +58,11 @@ INSTALLED_APPS = [
     'apps.users'
 ]
 
+# Ensure Django uses the migrations from the legacy "clubs" app path.
+MIGRATION_MODULES = {
+    'clubs': 'clubs.migrations',
+}
+
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -18,7 +18,16 @@
     <div class="d-flex align-items-start mt-4 mb-4 gap-3 ">
        <div>
         
-       <h1 class="h3 mb-1 " style="font-weight:900;">{{ club.name }}</h1>
+      <h1 class="h3 mb-1 " style="font-weight:900;">{{ club.name }}
+        {% if club.verified %}
+          <span class="ms-1" title="Verificado">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 16 16" fill="#0d6efd">
+              <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0z"/>
+              <path fill="#fff" d="M12.03 5.97a.75.75 0 0 0-1.06-1.06L7 8.94 5.03 6.97a.75.75 0 1 0-1.06 1.06L6.47 10l5.56-5.53z"/>
+            </svg>
+          </span>
+        {% endif %}
+      </h1>
       <span class="badge mb-3 bg-secondary mb-1">{{ club.get_category_display }}</span>
 
     <p class="mb-1 small d-flex align-items-center">


### PR DESCRIPTION
## Summary
- add `verified` boolean field to `Club`
- show verification badge in club profile
- expose `verified` in admin
- add migration for club verification flag
- configure MIGRATION_MODULES to use existing migrations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68472934111c8321ba887e5004467c20