### PR TITLE
Configure Django via environment vars

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -37,12 +37,19 @@ STATICFILES_DIRS = [
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-$7vs#$s_tmzf+&g(h^@xm1mk9@i6*3keei77zn=btl$4lmif@k'
+SECRET_KEY = os.environ.get(
+    "SECRET_KEY",
+    "django-insecure-$7vs#$s_tmzf+&g(h^@xm1mk9@i6*3keei77zn=btl$4lmif@k",
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get("DEBUG", "True") == "True"
 
-ALLOWED_HOSTS = []
+_hosts = os.environ.get("ALLOWED_HOSTS")
+if _hosts:
+    ALLOWED_HOSTS = [host.strip() for host in _hosts.split(",") if host.strip()]
+else:
+    ALLOWED_HOSTS = []
 
 
 INSTALLED_APPS = [

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,3 +1,2 @@
 from .base import *
-DEBUG = True
-ALLOWED_HOSTS = []
+

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -1,3 +1,5 @@
 from .base import *
-DEBUG = True
-ALLOWED_HOSTS = []
+
+# Override debug regardless of environment variable
+DEBUG = False
+


### PR DESCRIPTION
## Summary
- load `SECRET_KEY`, `DEBUG`, and `ALLOWED_HOSTS` from environment variables
- clean up dev settings
- force `DEBUG = False` in production settings

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68476c9f6bc8832192cb5f5a8ff21eb2