### PR TITLE
Fix stuck preloader on history back

### DIFF
--- a/static/js/page-loader.js
+++ b/static/js/page-loader.js
@@ -6,6 +6,16 @@ document.addEventListener('DOMContentLoaded', function () {
     }, 300);
 });
 
+// When navigating back using the browser's history the page might be
+// restored from the bfcache and `DOMContentLoaded` will not fire again.
+// Listen to the `pageshow` event so the loader can be hidden in that case.
+window.addEventListener('pageshow', function () {
+    const loader = document.getElementById('loader');
+    if (loader) {
+        loader.classList.add('hidden');
+    }
+});
+
 window.addEventListener('beforeunload', function () {
     const loader = document.getElementById('loader');
     if (loader) {


### PR DESCRIPTION
## Summary
- avoid loader sticking when pressing back by listening to `pageshow`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==5.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_684786b3fc1883218e18cd04e9f95a54