### PR TITLE
Integrar django-allauth y botones sociales

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -57,10 +57,16 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
   # Local apps
     'apps.core',
     'apps.clubs',
-    'apps.users'
+    'apps.users',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.google',
+    'allauth.socialaccount.providers.facebook',
 ]
 
 # Ensure Django uses the migrations from the legacy "clubs" app path.
@@ -74,6 +80,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -152,3 +159,15 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = 'home'
+
+SITE_ID = 1
+
+AUTHENTICATION_BACKENDS = [
+    'django.contrib.auth.backends.ModelBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
+]
+
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_USERNAME_REQUIRED = True
+ACCOUNT_EMAIL_VERIFICATION = 'none'
+

--- a/config/urls.py
+++ b/config/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('clubs/', include('apps.clubs.urls')),
 
 
+    path('accounts/', include('allauth.urls')),
     path('accounts/', include('apps.users.urls')),  # <-- Aquí incluimos las rutas de registro
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==5.1.2
 Pillow>=10.0
+django-allauth

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,0 +1,1 @@
+{% extends "users/login.html" %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -1,0 +1,1 @@
+{% extends "users/register.html" %}

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load load_css %}
+{% load socialaccount %}
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -46,8 +47,14 @@
                     {{ form.password }}
                 </div>
 
+
                 <button type="submit" class="btn btn-primary w-100">Iniciar Sesión</button>
             </form>
+
+            <div class="text-center my-3">
+                <a href="{% provider_login_url 'google' %}" class="btn btn-outline-danger w-100 mb-2">Continuar con Google</a>
+                <a href="{% provider_login_url 'facebook' %}" class="btn btn-outline-primary w-100">Continuar con Facebook</a>
+            </div>
 
             <div class="mt-3 text-center">
                 <a href="#">¿Olvidaste tu contraseña?</a>

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -1,5 +1,6 @@
   {% load static %}
 {% load load_css %}
+{% load socialaccount %}
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -102,6 +103,11 @@
 </div>
             <button type="submit" class="btn btn-primary w-100">Iniciar Sesión</button>
         </form>
+
+        <div class="text-center my-3">
+            <a href="{% provider_login_url 'google' %}" class="btn btn-outline-danger w-100 mb-2">Continuar con Google</a>
+            <a href="{% provider_login_url 'facebook' %}" class="btn btn-outline-primary w-100">Continuar con Facebook</a>
+        </div>
 
         <div class="mt-3 text-center">
             <a href="{% url 'login' %}">¿Ya estas registrado? Iniciar Sesión</a>


### PR DESCRIPTION
## Summary
- añade `django-allauth` a las dependencias
- configura `allauth` y autenticación en settings/base
- expone las URLs de `allauth`
- crea plantillas `templates/account/` para personalizar vistas
- muestra botones de Google y Facebook en login y registro
- agrega `AccountMiddleware` de `allauth`

## Testing
- `python manage.py check` *(falla: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6847aaefda788321a52d392763983e6f