### PR TITLE
Add welcome email on register

### DIFF
--- a/apps/users/tests/test_user.py
+++ b/apps/users/tests/test_user.py
@@ -1,7 +1,7 @@
-# tests.py
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
+from unittest.mock import patch
 
 
 class RegistrationTests(TestCase):
@@ -16,7 +16,18 @@ class RegistrationTests(TestCase):
         url = reverse("register")
         response = self.client.post(url, data)
 
-        # A new user should be created
         self.assertTrue(User.objects.filter(username="newuser").exists())
-        # And the view should redirect to home
         self.assertRedirects(response, reverse("home"))
+
+    def test_welcome_email_sent(self):
+        data = {
+            "username": "emailuser",
+            "email": "email@example.com",
+            "password1": "secretpass123",
+            "password2": "secretpass123",
+        }
+        url = reverse("register")
+        with patch("apps.users.views.auth.send_welcome_email") as mock_send:
+            self.client.post(url, data)
+            mock_send.assert_called_once_with("email@example.com")
+

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -4,6 +4,7 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth import login
 from ..forms import RegistroUsuarioForm
+from apps.core.services.email_service import send_welcome_email
 
 
 def register(request):
@@ -12,6 +13,7 @@ def register(request):
         form = RegistroUsuarioForm(request.POST)
         if form.is_valid():
             user = form.save()
+            send_welcome_email(user.email)
             login(request, user)
             return redirect('home')
     else:


### PR DESCRIPTION
## Summary
- send a welcome email when registering
- test that registering users triggers the email

## Testing
- `python manage.py test apps.users.tests.test_user --verbosity 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68483cc225848321ba8c7bf7a2674152