### PR TITLE
Implement image resizing utility

### DIFF
--- a/apps/clubs/models/club.py
+++ b/apps/clubs/models/club.py
@@ -1,8 +1,10 @@
 from django.db import models
 from django.utils.text import slugify
-from django.contrib.auth.models import User 
-from django.db.models import Avg, Count 
+from django.contrib.auth.models import User
+from django.db.models import Avg, Count
 from django.utils.translation import gettext_lazy as _
+
+from apps.core.utils.image_utils import resize_image
 
  
 class Club(models.Model):
@@ -70,4 +72,10 @@ class ClubPhoto(models.Model):
     def __str__(self):
         return f"Foto de {self.club.name if self.club else 'Sin club'}"
 
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        if self.image and hasattr(self.image, 'path'):
+            resize_image(self.image.path)
+
  
+

--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -1,7 +1,11 @@
-from django.test import TestCase
+import io
+import tempfile
+from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image
 
-from .models import Club
+from .models import Club, ClubPhoto
 
 
 class SearchResultsTests(TestCase):
@@ -23,3 +27,26 @@ class SearchResultsTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.club.name)
+
+
+class ClubPhotoResizeTests(TestCase):
+    def test_photo_resized_on_save(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(MEDIA_ROOT=tmpdir):
+                club = Club.objects.create(
+                    name="Club",
+                    city="City",
+                    address="Add",
+                    phone="1",
+                    email="c@example.com",
+                )
+                img = Image.new("RGB", (1000, 1000), "white")
+                buf = io.BytesIO()
+                img.save(buf, format="JPEG")
+                buf.seek(0)
+                upload = SimpleUploadedFile("test.jpg", buf.getvalue(), content_type="image/jpeg")
+                photo = ClubPhoto.objects.create(club=club, image=upload)
+                width, height = Image.open(photo.image.path).size
+                self.assertLessEqual(width, 800)
+                self.assertLessEqual(height, 800)
+

--- a/apps/core/utils/image_utils.py
+++ b/apps/core/utils/image_utils.py
@@ -1,0 +1,10 @@
+from PIL import Image, ImageOps
+
+
+def resize_image(image_path, max_size=(800, 800)):
+    """Resize the image at ``image_path`` keeping aspect ratio."""
+    img = Image.open(image_path)
+    img = ImageOps.exif_transpose(img)
+    img.thumbnail(max_size, Image.LANCZOS)
+    img.save(image_path, format=img.format)
+

--- a/apps/users/models/profile.py
+++ b/apps/users/models/profile.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.contrib.auth.models import User
 
+from apps.core.utils.image_utils import resize_image
+
 
 class Profile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="profile")
@@ -10,3 +12,9 @@ class Profile(models.Model):
 
     def __str__(self):
         return f"Perfil de {self.user.username}"
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        if self.avatar and hasattr(self.avatar, 'path'):
+            resize_image(self.avatar.path)
+

--- a/apps/users/tests/test_avatar_resize.py
+++ b/apps/users/tests/test_avatar_resize.py
@@ -1,0 +1,25 @@
+import io
+import tempfile
+from PIL import Image
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+
+from apps.users.models import Profile
+
+
+class AvatarResizeTests(TestCase):
+    def test_avatar_resized_on_save(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(MEDIA_ROOT=tmpdir):
+                user = User.objects.create_user(username="u", password="pass")
+                img = Image.new("RGB", (1000, 1000), "white")
+                buf = io.BytesIO()
+                img.save(buf, format="JPEG")
+                buf.seek(0)
+                upload = SimpleUploadedFile("test.jpg", buf.getvalue(), content_type="image/jpeg")
+                profile = Profile.objects.create(user=user, avatar=upload)
+                width, height = Image.open(profile.avatar.path).size
+                self.assertLessEqual(width, 800)
+                self.assertLessEqual(height, 800)
+


### PR DESCRIPTION
## Summary
- create `resize_image` helper with Pillow
- resize uploaded club photos and user avatars on save
- test resizing behaviour for avatars and club photos

## Testing
- `python manage.py test -v 0` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68484091f9408321b5ad3f80a6fe2d07