### PR TITLE
Add pagination to club search results

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -23,3 +23,36 @@ class SearchResultsTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.club.name)
+
+    def test_pagination_limits_results(self):
+        """Only 12 results should appear on the first page."""
+        for i in range(13):
+            Club.objects.create(
+                name=f"Extra Club {i}",
+                city="NY",
+                address="addr",
+                phone="123",
+                email=f"{i}@ex.com",
+            )
+
+        url = reverse("search_results")
+        response = self.client.get(url, {"q": "Club", "page": 1})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["clubs"]), 12)
+
+    def test_second_page_contains_remaining_results(self):
+        for i in range(13):
+            Club.objects.create(
+                name=f"Another Club {i}",
+                city="NY",
+                address="addr",
+                phone="123",
+                email=f"{i}@ex2.com",
+            )
+
+        url = reverse("search_results")
+        response = self.client.get(url, {"q": "Club", "page": 2})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["clubs"]), 1)

--- a/apps/clubs/views/search.py
+++ b/apps/clubs/views/search.py
@@ -2,6 +2,7 @@
 from django.shortcuts import render, redirect
 from django.db.models import Q, F, FloatField, Avg, Count, ExpressionWrapper
 from django.db.models.functions import Round
+from django.core.paginator import Paginator
 from apps.clubs.models import Club
 
 
@@ -49,8 +50,14 @@ def search_results(request):
     elif sort_option == 'recent':
         clubs = clubs.order_by('-created_at')
 
+    # Paginación: 12 resultados por página
+    paginator = Paginator(clubs, 12)
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
     return render(request, 'clubs/search_results.html', {
-        'clubs': clubs,
+        'clubs': page_obj,
+        'page_obj': page_obj,
         'search_query': search_query,
         'selected_category': selected_category,
         'sort_option': sort_option,

--- a/templates/clubs/search_results.html
+++ b/templates/clubs/search_results.html
@@ -59,6 +59,38 @@
         </div>
         {% endfor %}
     </div>
+
+    {% if page_obj.has_other_pages %}
+    <nav class="mt-4" aria-label="Resultados de búsqueda">
+        <ul class="pagination justify-content-center">
+            {% if page_obj.has_previous %}
+            <li class="page-item">
+                <a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}&page={{ page_obj.previous_page_number }}" aria-label="Anterior">
+                    &laquo;
+                </a>
+            </li>
+            {% else %}
+            <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+            {% endif %}
+            {% for num in page_obj.paginator.page_range %}
+            {% if page_obj.number == num %}
+            <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+            {% else %}
+            <li class="page-item"><a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}&page={{ num }}">{{ num }}</a></li>
+            {% endif %}
+            {% endfor %}
+            {% if page_obj.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}&page={{ page_obj.next_page_number }}" aria-label="Siguiente">
+                    &raquo;
+                </a>
+            </li>
+            {% else %}
+            <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+            {% endif %}
+        </ul>
+    </nav>
+    {% endif %}
     {% else %}
     <p>No se encontraron resultados para "{{ search_query }}"</p>
     {% endif %}


### PR DESCRIPTION
## Summary
- paginate club search results with Django `Paginator`
- show pagination controls in search results page
- test pagination behavior of search results

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684840a19f98832196ee58f7184506b1