### PR TITLE
Add remember me option on login

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -15,6 +15,11 @@ class LoginForm(AuthenticationForm):
         label="Contraseña",
         widget=forms.PasswordInput(attrs={'class': 'form-control'})
     )
+    remember_me = forms.BooleanField(
+        label="Recordarme",
+        required=False,
+        widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
+    )
  
 class RegistroUsuarioForm(UserCreationForm):
     email = forms.EmailField(label='Correo electrónico', required=True)

--- a/apps/users/tests/test_user.py
+++ b/apps/users/tests/test_user.py
@@ -31,3 +31,22 @@ class RegistrationTests(TestCase):
             self.client.post(url, data)
             mock_send.assert_called_once_with("email@example.com")
 
+
+class LoginRememberMeTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="loginuser", password="pass")
+
+    def test_unchecked_remember_me_expires_on_close(self):
+        url = reverse("login")
+        data = {"username": "loginuser", "password": "pass"}
+        self.client.post(url, data)
+        self.assertTrue("_auth_user_id" in self.client.session)
+        self.assertTrue(self.client.session.get_expire_at_browser_close())
+
+    def test_checked_remember_me_persists_session(self):
+        url = reverse("login")
+        data = {"username": "loginuser", "password": "pass", "remember_me": "on"}
+        self.client.post(url, data)
+        self.assertTrue("_auth_user_id" in self.client.session)
+        self.assertFalse(self.client.session.get_expire_at_browser_close())
+

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,16 +1,13 @@
 from django.urls import path
 from django.contrib.auth import views as auth_views
 
-from .forms import LoginForm
 from .views import auth, review, follow
 from .views import profile as profile_views
+from .views.auth import LoginView
 
 urlpatterns = [
     path('register/', auth.register, name='register'),
-    path('login/', auth_views.LoginView.as_view(
-        template_name='users/login.html',
-        authentication_form=LoginForm
-    ), name='login'),
+    path('login/', LoginView.as_view(), name='login'),
     path('logout/', auth_views.LogoutView.as_view(next_page='/'), name='logout'),
     path('profile/', profile_views.profile, name='profile'),
     path('favoritos/', profile_views.favorites, name='favoritos'),

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -47,6 +47,11 @@
                     {{ form.password }}
                 </div>
 
+                <div class="form-check mb-3">
+                    {{ form.remember_me }}
+                    {{ form.remember_me.label_tag }}
+                </div>
+
 
                 <button type="submit" class="btn btn-primary w-100">Iniciar Sesión</button>
             </form>


### PR DESCRIPTION
## Summary
- extend `LoginForm` with `remember_me`
- display remember me checkbox in login page
- add custom login view that sets session expiry
- update urls to use new view
- test remember me behaviour

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684840a357008321b76fd68ee0041191