### PR TITLE
Restore username field on login page

### DIFF
--- a/apps/users/tests/test_user.py
+++ b/apps/users/tests/test_user.py
@@ -50,3 +50,11 @@ class LoginRememberMeTests(TestCase):
         self.assertTrue("_auth_user_id" in self.client.session)
         self.assertFalse(self.client.session.get_expire_at_browser_close())
 
+
+class LoginPageTests(TestCase):
+    def test_login_form_shows_username_and_password_fields(self):
+        url = reverse("login")
+        response = self.client.get(url)
+        self.assertContains(response, 'name="username"')
+        self.assertContains(response, 'name="password"')
+

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -39,12 +39,29 @@
 
                 <div class="mb-3">
                     {{ form.username.label_tag }}
-                    {{ form.username }}
+                    <input type="text"
+                           name="{{ form.username.name }}"
+                           value="{{ form.username.value|default_if_none:'' }}"
+                           class="form-control"
+                           id="{{ form.username.id_for_label }}">
+                    {% if form.username.errors %}
+                      <div class="invalid-feedback d-block">
+                        {{ form.username.errors.as_text|striptags }}
+                      </div>
+                    {% endif %}
                 </div>
 
                 <div class="mb-3">
                     {{ form.password.label_tag }}
-                    {{ form.password }}
+                    <input type="password"
+                           name="{{ form.password.name }}"
+                           class="form-control"
+                           id="{{ form.password.id_for_label }}">
+                    {% if form.password.errors %}
+                      <div class="invalid-feedback d-block">
+                        {{ form.password.errors.as_text|striptags }}
+                      </div>
+                    {% endif %}
                 </div>
 
                 <div class="form-check mb-3">


### PR DESCRIPTION
## Summary
- show username input on login page again using explicit markup
- add test ensuring login page contains username and password fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_6848b56bf25c83219eca1a5a51f52b34