### PR TITLE
Restore username field on login page

### DIFF
--- a/apps/users/tests/test_user.py
+++ b/apps/users/tests/test_user.py
@@ -50,3 +50,19 @@ class LoginRememberMeTests(TestCase):
         self.assertTrue("_auth_user_id" in self.client.session)
         self.assertFalse(self.client.session.get_expire_at_browser_close())
 
+
+class LoginPageTests(TestCase):
+    def test_login_form_shows_username_and_password_fields(self):
+        url = reverse("login")
+        response = self.client.get(url)
+        self.assertContains(response, 'name="username"')
+        self.assertContains(response, 'name="password"')
+
+    def test_login_page_includes_labels_and_toggle(self):
+        url = reverse("login")
+        response = self.client.get(url)
+        self.assertContains(response, 'Nombre de usuario o correo electrónico')
+        self.assertContains(response, 'Contraseña')
+        self.assertContains(response, 'Recordar contraseña')
+        self.assertContains(response, 'toggle-password')
+

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -38,22 +38,44 @@
                 {{ form.non_field_errors }}
 
                 <div class="mb-3">
-                    {{ form.username.label_tag }}
-                    {{ form.username }}
+                    <label for="{{ form.username.id_for_label }}">Nombre de usuario o correo electrónico</label>
+                    <input type="text"
+                           name="{{ form.username.name }}"
+                           value="{{ form.username.value|default_if_none:'' }}"
+                           class="form-control"
+                           id="{{ form.username.id_for_label }}">
+                    {% if form.username.errors %}
+                      <div class="invalid-feedback d-block">
+                        {{ form.username.errors.as_text|striptags }}
+                      </div>
+                    {% endif %}
                 </div>
 
                 <div class="mb-3">
-                    {{ form.password.label_tag }}
-                    {{ form.password }}
+                    <label for="{{ form.password.id_for_label }}">Contraseña</label>
+                    <div class="input-group">
+                        {{ form.password }}
+                        <button type="button" class="btn btn-outline-secondary" id="toggle-password">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye" viewBox="0 0 16 16">
+                                <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8z"/>
+                                <path d="M8 5.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5z"/>
+                            </svg>
+                        </button>
+                    </div>
+                    {% if form.password.errors %}
+                      <div class="invalid-feedback d-block">
+                        {{ form.password.errors.as_text|striptags }}
+                      </div>
+                    {% endif %}
                 </div>
 
                 <div class="form-check mb-3">
-                    {{ form.remember_me }}
-                    {{ form.remember_me.label_tag }}
+                    <input type="checkbox" name="{{ form.remember_me.name }}" class="form-check-input" id="{{ form.remember_me.id_for_label }}">
+                    <label class="form-check-label" for="{{ form.remember_me.id_for_label }}">Recordar contraseña</label>
                 </div>
 
 
-                <button type="submit" class="btn btn-primary w-100">Iniciar Sesión</button>
+                <button type="submit" class="btn btn-dark w-100">Iniciar Sesión</button>
             </form>
 
             <div class="text-center my-3">
@@ -65,7 +87,7 @@
             </div>
 
             <div class="border-top mt-4 pt-3 text-center">
-                <p class="mb-0">¿Nuevo en nuestra página? <a href="{% url 'register' %}">Crea tu cuenta</a></p>
+                <p class="mb-0">¿Nuevo en nuestra comunidad? <a href="{% url 'register' %}">Crea tu cuenta</a></p>
             </div>
         </div>
     </main>
@@ -85,5 +107,11 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{% static 'js/page-loader.js' %}"></script>
+<script>
+document.getElementById('toggle-password').addEventListener('click', function () {
+    var input = document.getElementById('{{ form.password.id_for_label }}');
+    input.type = input.type === 'password' ? 'text' : 'password';
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show username input on login page again using explicit markup
- add eye toggle button for password field
- change text to "¿Nuevo en nuestra comunidad?" and tweak styling
- rename remember-me option to "Recordar contraseña"
- remove duplicated password input
- add tests for login page labels and toggle

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL' and 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848b56bf25c83219eca1a5a51f52b34