### PR TITLE
Fix password input trimming on login

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -12,6 +12,7 @@ class LoginForm(AuthenticationForm):
     )
     password = forms.CharField(
         label="Contraseña",
+        strip=False,
         widget=forms.PasswordInput(attrs={'class': 'form-control'})
     )
  

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -13,6 +13,7 @@ class LoginForm(AuthenticationForm):
     )
     password = forms.CharField(
         label="Contraseña",
+        strip=False,
         widget=forms.PasswordInput(attrs={'class': 'form-control'})
     )
     remember_me = forms.BooleanField(


### PR DESCRIPTION
## Summary
- ensure password is not stripped when authenticating
- apply the same fix for club logins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for PIL and Django)*

------
https://chatgpt.com/codex/tasks/task_e_6848bd964274832190359b6aafbec2b3