### PR TITLE
Fix login/register routes

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -12,6 +12,7 @@ class LoginForm(AuthenticationForm):
     )
     password = forms.CharField(
         label="Contraseña",
+        strip=False,
         widget=forms.PasswordInput(attrs={'class': 'form-control'})
     )
  

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -13,6 +13,7 @@ class LoginForm(AuthenticationForm):
     )
     password = forms.CharField(
         label="Contraseña",
+        strip=False,
         widget=forms.PasswordInput(attrs={'class': 'form-control'})
     )
     remember_me = forms.BooleanField(

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -6,7 +6,8 @@ from .views import profile as profile_views
 from .views.auth import LoginView
 
 urlpatterns = [
-    path('register/', auth.register, name='register'),
+    # Registro de usuarios
+    path('signup/', auth.register, name='signup'),
     path('login/', LoginView.as_view(), name='login'),
     path('logout/', auth_views.LogoutView.as_view(next_page='/'), name='logout'),
     path('profile/', profile_views.profile, name='profile'),

--- a/config/urls.py
+++ b/config/urls.py
@@ -26,8 +26,9 @@ urlpatterns = [
     path('clubs/', include('apps.clubs.urls')),
 
 
-    path('accounts/', include('allauth.urls')),
-    path('accounts/', include('apps.users.urls')),  # <-- Aquí incluimos las rutas de registro
+    # Rutas de autenticación sin el prefijo "accounts/"
+    path('', include('apps.users.urls')),
+    path('', include('allauth.urls')),
 ]
 
 # Archivos estáticos en modo DEBUG

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -59,7 +59,7 @@
                         <a href="{% url 'login' %}" class="nav-link text-dark">Iniciar Sesión</a>
                     </li>
                     <li class="nav-item">
-                        <a href="{% url 'register' %}" class="btn btn-dark text-light ms-2">Registro</a>
+                        <a href="{% url 'signup' %}" class="btn btn-dark text-light ms-2">Registro</a>
                     </li>
                 {% endif %}
             </ul>

--- a/templates/partials/_register_modal.html
+++ b/templates/partials/_register_modal.html
@@ -6,7 +6,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <form method="post" action="{% url 'register' %}">
+        <form method="post" action="{% url 'signup' %}">
           {% csrf_token %}
           {{ register_form.as_p }}
           <button type="submit" class="btn btn-primary w-100">Registrarse</button>

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -92,7 +92,7 @@
             </div>
 
             <div class="border-top mt-4 pt-3 text-center">
-                <p class="mb-0">¿Nuevo en nuestra comunidad? <a href="{% url 'register' %}">Crea tu cuenta</a></p>
+                <p class="mb-0">¿Nuevo en nuestra comunidad? <a href="{% url 'signup' %}">Crea tu cuenta</a></p>
             </div>
         </div>
     </main>


### PR DESCRIPTION
## Summary
- expose authentication routes without the `accounts/` prefix
- rename registration route to `/signup`
- adjust templates to use the new signup URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for PIL and Django)*

------
https://chatgpt.com/codex/tasks/task_e_6848bd964274832190359b6aafbec2b3