### PR TITLE
Implement field validation messages

### DIFF
--- a/apps/core/services/email_service.py
+++ b/apps/core/services/email_service.py
@@ -8,5 +8,5 @@ def send_welcome_email(user_email):
         'Gracias por unirte a nuestra comunidad.',
         'noreply@clubsdeboxeo.com',
         [user_email],
-        fail_silently=False,
+        fail_silently=True,
     )

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -3,18 +3,26 @@ from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import AuthenticationForm
+from django.utils.translation import gettext_lazy as _
 from .models import Profile
 
 
 class LoginForm(AuthenticationForm):
+    error_messages = {
+        "invalid_login": _("El usuario o la contraseña introducida no es correcta, por favor intente de nuevo"),
+        "inactive": _("This account is inactive."),
+    }
+
     username = forms.CharField(
         label="Usuario",
-        widget=forms.TextInput(attrs={'class': 'form-control'})
+        widget=forms.TextInput(attrs={'class': 'form-control'}),
+        error_messages={"required": "Rellene este campo"},
     )
     password = forms.CharField(
         label="Contraseña",
         strip=False,
-        widget=forms.PasswordInput(attrs={'class': 'form-control'})
+        widget=forms.PasswordInput(attrs={'class': 'form-control'}),
+        error_messages={"required": "Rellene este campo"},
     )
     remember_me = forms.BooleanField(
         label="Recordarme",
@@ -23,7 +31,7 @@ class LoginForm(AuthenticationForm):
     )
  
 class RegistroUsuarioForm(UserCreationForm):
-    email = forms.EmailField(label='Correo electrónico', required=True)
+    email = forms.EmailField(label='Correo electrónico', required=True, error_messages={"required": "Rellene este campo"})
 
     class Meta:
         model = User
@@ -43,6 +51,9 @@ class RegistroUsuarioForm(UserCreationForm):
         super().__init__(*args, **kwargs)
         self.fields['password1'].label = 'Contraseña'
         self.fields['password2'].label = 'Confirmar contraseña'
+        # Custom required messages
+        for field in ['username', 'password1', 'password2', 'email']:
+            self.fields[field].error_messages['required'] = 'Rellene este campo'
 
 class ProfileForm(forms.ModelForm):
     class Meta:

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -35,7 +35,6 @@
 
             <form method="post">
                 {% csrf_token %}
-                {{ form.non_field_errors }}
 
                 <div class="mb-3">
                     <label for="{{ form.username.id_for_label }}">Nombre de usuario o correo electrónico</label>
@@ -44,7 +43,8 @@
                            name="{{ form.username.name }}"
                            value="{{ form.username.value|default_if_none:'' }}"
                            class="form-control"
-                           id="{{ form.username.id_for_label }}">
+                           id="{{ form.username.id_for_label }}"
+                           required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
                     {% if form.username.errors %}
                       <div class="invalid-feedback d-block">
                         {{ form.username.errors.as_text|striptags }}
@@ -58,7 +58,8 @@
                         <input type="password"
                                name="{{ form.password.name }}"
                                class="form-control"
-                               id="{{ form.password.id_for_label }}">
+                               id="{{ form.password.id_for_label }}"
+                               required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
                         <button type="button" class="btn btn-outline-secondary" id="toggle-password">
 
 
@@ -71,6 +72,11 @@
                     {% if form.password.errors %}
                       <div class="invalid-feedback d-block">
                         {{ form.password.errors.as_text|striptags }}
+                      </div>
+                    {% endif %}
+                    {% if form.non_field_errors %}
+                      <div class="invalid-feedback d-block">
+                        {{ form.non_field_errors }}
                       </div>
                     {% endif %}
                 </div>

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -61,7 +61,7 @@
           <!-- Username -->
 <div class="mb-3">
     {{ form.username.label_tag }}
-    <input type="text" name="{{ form.username.name }}" value="{{ form.username.value|default_if_none:'' }}" class="form-control" id="{{ form.username.id_for_label }}">
+    <input type="text" name="{{ form.username.name }}" value="{{ form.username.value|default_if_none:'' }}" class="form-control" id="{{ form.username.id_for_label }}" required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
     {% if form.username.errors %}
       <div class="invalid-feedback d-block">
         {{ form.username.errors.as_text|striptags }}
@@ -72,7 +72,7 @@
 <!-- Email -->
 <div class="mb-3">
     {{ form.email.label_tag }}
-    <input type="email" name="{{ form.email.name }}" value="{{ form.email.value|default_if_none:'' }}" class="form-control" id="{{ form.email.id_for_label }}">
+    <input type="email" name="{{ form.email.name }}" value="{{ form.email.value|default_if_none:'' }}" class="form-control" id="{{ form.email.id_for_label }}" required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
     {% if form.email.errors %}
       <div class="invalid-feedback d-block">
         {{ form.email.errors.as_text|striptags }}
@@ -83,7 +83,7 @@
 <!-- Password1 -->
 <div class="mb-3">
     {{ form.password1.label_tag }}
-    <input type="password" name="{{ form.password1.name }}" class="form-control" id="{{ form.password1.id_for_label }}">
+    <input type="password" name="{{ form.password1.name }}" class="form-control" id="{{ form.password1.id_for_label }}" required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
     {% if form.password1.errors %}
       <div class="invalid-feedback d-block">
         {{ form.password1.errors.as_text|striptags }}
@@ -94,7 +94,7 @@
 <!-- Password2 -->
 <div class="mb-3">
     {{ form.password2.label_tag }}
-    <input type="password" name="{{ form.password2.name }}" class="form-control" id="{{ form.password2.id_for_label }}">
+    <input type="password" name="{{ form.password2.name }}" class="form-control" id="{{ form.password2.id_for_label }}" required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
     {% if form.password2.errors %}
       <div class="invalid-feedback d-block">
         {{ form.password2.errors.as_text|striptags }}


### PR DESCRIPTION
## Summary
- show required field messages in LoginForm and RegistroUsuarioForm
- customize invalid login message
- add required attributes and custom browser messages on login/register templates
- display login error below password field
- allow registration to continue even if welcome email can't be sent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL' and 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848ca1fc644832186ec55c7da7a8b9d