### PR TITLE
Implement field validation messages

### DIFF
--- a/apps/core/services/email_service.py
+++ b/apps/core/services/email_service.py
@@ -8,5 +8,16 @@ def send_welcome_email(user_email):
         'Gracias por unirte a nuestra comunidad.',
         'noreply@clubsdeboxeo.com',
         [user_email],
-        fail_silently=False,
+        fail_silently=True,
+    )
+
+
+def send_confirmation_email(user_email):
+    """Envía un correo de confirmación de registro"""
+    send_mail(
+        'Registro completado',
+        'Tu cuenta ha sido creada exitosamente.',
+        'noreply@clubsdeboxeo.com',
+        [user_email],
+        fail_silently=True,
     )

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -3,27 +3,45 @@ from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import AuthenticationForm
+from django.utils.translation import gettext_lazy as _
 from .models import Profile
 
 
 class LoginForm(AuthenticationForm):
+    error_messages = {
+        "invalid_login": _("El usuario o la contraseña introducida no es correcta, por favor intente de nuevo"),
+        "inactive": _("This account is inactive."),
+    }
+
     username = forms.CharField(
         label="Usuario",
-        widget=forms.TextInput(attrs={'class': 'form-control'})
+        widget=forms.TextInput(attrs={'class': 'form-control'}),
+        error_messages={"required": "Rellene este campo"},
     )
     password = forms.CharField(
         label="Contraseña",
         strip=False,
-        widget=forms.PasswordInput(attrs={'class': 'form-control'})
+        widget=forms.PasswordInput(attrs={'class': 'form-control'}),
+        error_messages={"required": "Rellene este campo"},
     )
     remember_me = forms.BooleanField(
         label="Recordarme",
         required=False,
         widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Mark "recordar contraseña" checked by default
+        self.fields["remember_me"].initial = True
  
 class RegistroUsuarioForm(UserCreationForm):
-    email = forms.EmailField(label='Correo electrónico', required=True)
+    email = forms.EmailField(label='Correo electrónico', required=True, error_messages={"required": "Rellene este campo"})
+
+    error_messages = {
+        **UserCreationForm.error_messages,
+        'password_mismatch': _('Las contraseñas no coinciden'),
+    }
 
     class Meta:
         model = User
@@ -39,10 +57,27 @@ class RegistroUsuarioForm(UserCreationForm):
         }
 
     def __init__(self, *args, **kwargs):
-
         super().__init__(*args, **kwargs)
         self.fields['password1'].label = 'Contraseña'
         self.fields['password2'].label = 'Confirmar contraseña'
+        # Custom required messages
+        for field in ['username', 'password1', 'password2', 'email']:
+            self.fields[field].error_messages['required'] = 'Rellene este campo'
+
+    def clean_email(self):
+        email = self.cleaned_data['email']
+        if User.objects.filter(email=email).exists():
+            raise forms.ValidationError('Este correo electrónico ya está registrado')
+        return email
+
+    def clean_password1(self):
+        password = self.cleaned_data.get('password1')
+        if password:
+            if len(password) < 6 or not any(c.islower() for c in password) or not any(c.isupper() for c in password) or not any(c.isdigit() for c in password):
+                raise forms.ValidationError(
+                    'La contraseña debe tener al menos 6 caracteres e incluir mayúsculas, minúsculas y números.'
+                )
+        return password
 
 class ProfileForm(forms.ModelForm):
     class Meta:

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -2,11 +2,11 @@
 # apps/users/views/auth.py
 
 from django.shortcuts import render, redirect
-from django.contrib.auth import login
+from django.contrib.auth import login, authenticate
 from django.contrib.auth.views import LoginView as DjangoLoginView
 from django.conf import settings
 from ..forms import RegistroUsuarioForm, LoginForm
-from apps.core.services.email_service import send_welcome_email
+from apps.core.services.email_service import send_welcome_email, send_confirmation_email
 
 
 def register(request):
@@ -16,7 +16,15 @@ def register(request):
         if form.is_valid():
             user = form.save()
             send_welcome_email(user.email)
-            login(request, user)
+            send_confirmation_email(user.email)
+            # authenticate to attach backend info before login
+            auth_user = authenticate(
+                request,
+                username=form.cleaned_data["username"],
+                password=form.cleaned_data["password1"],
+            )
+            if auth_user is not None:
+                login(request, auth_user)
             return redirect('home')
     else:
         form = RegistroUsuarioForm()

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -35,7 +35,6 @@
 
             <form method="post">
                 {% csrf_token %}
-                {{ form.non_field_errors }}
 
                 <div class="mb-3">
                     <label for="{{ form.username.id_for_label }}">Nombre de usuario o correo electrónico</label>
@@ -44,7 +43,8 @@
                            name="{{ form.username.name }}"
                            value="{{ form.username.value|default_if_none:'' }}"
                            class="form-control"
-                           id="{{ form.username.id_for_label }}">
+                           id="{{ form.username.id_for_label }}"
+                           required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
                     {% if form.username.errors %}
                       <div class="invalid-feedback d-block">
                         {{ form.username.errors.as_text|striptags }}
@@ -58,7 +58,8 @@
                         <input type="password"
                                name="{{ form.password.name }}"
                                class="form-control"
-                               id="{{ form.password.id_for_label }}">
+                               id="{{ form.password.id_for_label }}"
+                               required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
                         <button type="button" class="btn btn-outline-secondary" id="toggle-password">
 
 
@@ -73,10 +74,15 @@
                         {{ form.password.errors.as_text|striptags }}
                       </div>
                     {% endif %}
+                    {% if form.non_field_errors %}
+                      <div class="invalid-feedback d-block">
+                        {{ form.non_field_errors }}
+                      </div>
+                    {% endif %}
                 </div>
 
                 <div class="form-check mb-3">
-                    <input type="checkbox" name="{{ form.remember_me.name }}" class="form-check-input" id="{{ form.remember_me.id_for_label }}">
+                    <input type="checkbox" name="{{ form.remember_me.name }}" class="form-check-input" id="{{ form.remember_me.id_for_label }}" {% if form.remember_me.value or form.remember_me.initial %}checked{% endif %}>
                     <label class="form-check-label" for="{{ form.remember_me.id_for_label }}">Recordar contraseña</label>
                 </div>
 

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -61,7 +61,7 @@
           <!-- Username -->
 <div class="mb-3">
     {{ form.username.label_tag }}
-    <input type="text" name="{{ form.username.name }}" value="{{ form.username.value|default_if_none:'' }}" class="form-control" id="{{ form.username.id_for_label }}">
+    <input type="text" name="{{ form.username.name }}" value="{{ form.username.value|default_if_none:'' }}" class="form-control" id="{{ form.username.id_for_label }}" required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
     {% if form.username.errors %}
       <div class="invalid-feedback d-block">
         {{ form.username.errors.as_text|striptags }}
@@ -72,7 +72,7 @@
 <!-- Email -->
 <div class="mb-3">
     {{ form.email.label_tag }}
-    <input type="email" name="{{ form.email.name }}" value="{{ form.email.value|default_if_none:'' }}" class="form-control" id="{{ form.email.id_for_label }}">
+    <input type="email" name="{{ form.email.name }}" value="{{ form.email.value|default_if_none:'' }}" class="form-control" id="{{ form.email.id_for_label }}" required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
     {% if form.email.errors %}
       <div class="invalid-feedback d-block">
         {{ form.email.errors.as_text|striptags }}
@@ -83,7 +83,8 @@
 <!-- Password1 -->
 <div class="mb-3">
     {{ form.password1.label_tag }}
-    <input type="password" name="{{ form.password1.name }}" class="form-control" id="{{ form.password1.id_for_label }}">
+    <input type="password" name="{{ form.password1.name }}" class="form-control" id="{{ form.password1.id_for_label }}" required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
+    <small class="form-text text-muted">La contraseña debe tener al menos 6 caracteres e incluir mayúsculas, minúsculas y números.</small>
     {% if form.password1.errors %}
       <div class="invalid-feedback d-block">
         {{ form.password1.errors.as_text|striptags }}
@@ -94,14 +95,14 @@
 <!-- Password2 -->
 <div class="mb-3">
     {{ form.password2.label_tag }}
-    <input type="password" name="{{ form.password2.name }}" class="form-control" id="{{ form.password2.id_for_label }}">
+    <input type="password" name="{{ form.password2.name }}" class="form-control" id="{{ form.password2.id_for_label }}" required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
     {% if form.password2.errors %}
       <div class="invalid-feedback d-block">
         {{ form.password2.errors.as_text|striptags }}
       </div>
     {% endif %}
 </div>
-            <button type="submit" class="btn btn-primary w-100">Iniciar Sesión</button>
+            <button type="submit" class="btn btn-dark w-100">Crear cuenta</button>
         </form>
 
         <div class="text-center my-3">


### PR DESCRIPTION
## Summary
- show required field messages in LoginForm and RegistroUsuarioForm
- customize invalid login message
- add required attributes and custom browser messages on login/register templates
- display login error below password field
- allow registration to continue even if welcome email can't be sent
- default remember-me checked and verify email uniqueness during signup
- fix registration view to authenticate before login
- update signup button text/color
- enforce password complexity and Spanish mismatch message
- send welcome and confirmation emails after registration
- show password requirements hint on signup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL' and 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848ca1fc644832186ec55c7da7a8b9d