### PR TITLE
Fix newline in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Pillow>=10.0
 django-allauth
 cryptography
 PyJWT
+


### PR DESCRIPTION
## Summary
- add a trailing newline to `requirements.txt`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==5.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_6848dae646008321b59bdd52972240a4