### PR TITLE
Update image resize to convert RGBA/P modes

### DIFF
--- a/apps/core/utils/image_utils.py
+++ b/apps/core/utils/image_utils.py
@@ -6,5 +6,10 @@ def resize_image(image_path, max_size=(800, 800)):
     img = Image.open(image_path)
     img = ImageOps.exif_transpose(img)
     img.thumbnail(max_size, Image.LANCZOS)
-    img.save(image_path, format=img.format)
+
+    if img.mode in ("RGBA", "P"):
+        img = img.convert("RGB")
+
+    fmt = img.format or "JPEG"
+    img.save(image_path, format=fmt)
 


### PR DESCRIPTION
## Summary
- ensure RGBA and P images are converted to RGB before saving
- default to JPEG when saving if format unknown

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6849d249b6fc83219b462ea8125cd667