### PR TITLE
Add dependency installation section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,19 @@ python manage.py runserver
 El sitio quedará disponible en http://127.0.0.1:8000/.
 
 
+## Instalación de dependencias
+
+Para instalar las dependencias en un entorno virtual:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Las pruebas requieren Django y Pillow, ya incluidos en `requirements.txt`.
+
+
 
 
 directorio_boxeo/


### PR DESCRIPTION
## Summary
- add section in README for installing dependencies in a virtual env
- note Django and Pillow are needed for tests

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6849d3dca5608321bd058fcc8180b256