### PR TITLE
Add rating validation

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -40,6 +40,16 @@ class RegistroUsuarioForm(UserCreationForm):
  
 
 class ReseñaForm(forms.ModelForm):
+    comentario = forms.CharField(
+        widget=forms.Textarea(attrs={'rows': 4}),
+        min_length=200,
+        required=True,
+        error_messages={
+            'required': 'Este campo es obligatorio.',
+            'min_length': 'El comentario debe tener al menos 200 caracteres.'
+        },
+    )
+
     class Meta:
         model = Reseña
         exclude = ('usuario', 'club', 'creado')
@@ -62,12 +72,11 @@ class ReseñaForm(forms.ModelForm):
         }
         
         widgets = {
-            'instalaciones': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input'}),
-            'entrenadores': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input'}),
-            'ambiente': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input'}),
-            'calidad_precio': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input'}),
-            'variedad_clases': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input'}),
-            'comentario': forms.Textarea(attrs={'rows': 4}),
+            'instalaciones': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input', 'required': 'required'}),
+            'entrenadores': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input', 'required': 'required'}),
+            'ambiente': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input', 'required': 'required'}),
+            'calidad_precio': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input', 'required': 'required'}),
+            'variedad_clases': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input', 'required': 'required'}),
         }
 class ClubPostForm(forms.ModelForm):
     class Meta:

--- a/static/js/rating.js
+++ b/static/js/rating.js
@@ -71,3 +71,33 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('reseña-form');
+    if (!form) return;
+
+    form.addEventListener('submit', e => {
+        const fields = [
+            'instalaciones',
+            'entrenadores',
+            'ambiente',
+            'calidad_precio',
+            'variedad_clases'
+        ];
+
+        for (const name of fields) {
+            const input = form.querySelector(`input[name="${name}"]`);
+            if (!input || parseInt(input.value, 10) < 1) {
+                alert('Debes completar la valoración en todas las categorías.');
+                e.preventDefault();
+                return;
+            }
+        }
+
+        const comment = form.querySelector('textarea[name="comentario"]');
+        if (!comment || comment.value.trim().length < 200) {
+            alert('El comentario debe tener al menos 200 caracteres.');
+            e.preventDefault();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- enforce minimum comment length and required ratings in `ReseñaForm`
- add client-side validation for star rating and comment length

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684bedeb91908321986ecc314a9156ba