### PR TITLE
Improve review validation and editing

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -41,7 +41,7 @@ class RegistroUsuarioForm(UserCreationForm):
 
 class ReseñaForm(forms.ModelForm):
     comentario = forms.CharField(
-        widget=forms.Textarea(attrs={'rows': 4}),
+        widget=forms.Textarea(attrs={'rows': 4, 'minlength': 200}),
         min_length=200,
         required=True,
         error_messages={
@@ -49,6 +49,12 @@ class ReseñaForm(forms.ModelForm):
             'min_length': 'El comentario debe tener al menos 200 caracteres.'
         },
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        required_msg = 'Debes puntuar esta categoría.'
+        for field in ['instalaciones', 'entrenadores', 'ambiente', 'calidad_precio', 'variedad_clases']:
+            self.fields[field].error_messages['required'] = required_msg
 
     class Meta:
         model = Reseña

--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -162,7 +162,8 @@ textarea.form-control {
 .review-text {
   font-size: 1rem;
   font-style: italic;
-  color: #333;  
+  color: #333;
+  word-break: break-word;
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;

--- a/static/js/rating.js
+++ b/static/js/rating.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
             input.type = 'hidden';
             input.name = name;
             input.id = id;
+            input.required = true;
             container.appendChild(input);
         }
 

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -306,28 +306,36 @@
         {% if not reseña_existente %}
           <form method="POST" id="reseña-form">
             {% csrf_token %}
+            {% if form.errors %}
+            <div class="alert alert-danger">Por favor completa todos los campos obligatorios.</div>
+            {% endif %}
             <div class="mb-3">
               <label class="form-label">Instalaciones:</label>
               <div class="star-rating" data-name="instalaciones"></div>
+              <input type="hidden" name="instalaciones" required id="input-instalaciones">
             </div>
             <div class="mb-3">
               <label class="form-label">Entrenadores:</label>
               <div class="star-rating" data-name="entrenadores"></div>
+              <input type="hidden" name="entrenadores" required id="input-entrenadores">
             </div>
             <div class="mb-3">
               <label class="form-label">Ambiente:</label>
               <div class="star-rating" data-name="ambiente"></div>
+              <input type="hidden" name="ambiente" required id="input-ambiente">
             </div>
             <div class="mb-3">
               <label class="form-label">Calidad-precio:</label>
               <div class="star-rating" data-name="calidad_precio"></div>
+              <input type="hidden" name="calidad_precio" required id="input-calidad_precio">
             </div>
             <div class="mb-3">
               <label class="form-label">Variedad de clases:</label>
               <div class="star-rating" data-name="variedad_clases"></div>
+              <input type="hidden" name="variedad_clases" required id="input-variedad_clases">
             </div>
             <div class="mb-3">
-              <textarea name="comentario" class="form-control" rows="4" placeholder="¿Qué te ha gustado o qué mejorarías del club?"></textarea>
+              <textarea name="comentario" class="form-control" rows="4" minlength="200" placeholder="¿Qué te ha gustado o qué mejorarías del club?"></textarea>
             </div>
             <button type="submit" class="btn btn-dark">Enviar Reseña</button>
           </form>

--- a/templates/clubs/reviews_list.html
+++ b/templates/clubs/reviews_list.html
@@ -7,10 +7,19 @@
       </div>
       <div class=" fw-bold text-warning">⭐ {{ reseña.promedio }}</div>
     </div>
-    <p class="mb-3">{{ reseña.comentario }}</p>
+    <p class="mb-3 review-text">{{ reseña.comentario }}</p>
     <div class="position-absolute text-muted small " style="bottom: 1rem; right: 1rem;">
       {{ reseña.creado|date:"SHORT_DATE_FORMAT" }}
     </div>
+    {% if user.is_authenticated and user == reseña.usuario %}
+      <div class="mt-2">
+        <a href="{% url 'editar_reseña' reseña.id %}" class="btn btn-sm btn-link">Editar</a>
+        <form action="{% url 'eliminar_reseña' reseña.id %}" method="post" class="d-inline">
+          {% csrf_token %}
+          <button type="submit" class="btn btn-sm btn-link text-danger">Eliminar</button>
+        </form>
+      </div>
+    {% endif %}
   </div>
 {% empty %}
   <p class="text-muted">Este club todavía no tiene comentarios escritos.</p>


### PR DESCRIPTION
## Summary
- enforce minimum length on review text in form
- provide star rating required messages
- ensure review text stays within container
- show error alert on review form
- allow editing or deleting own reviews
- ensure rating inputs are required

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684befa826188321b5bca3976a7405b4