### PR TITLE
Show toast messages for review actions

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,7 @@
     </div>
 
     {% include 'partials/_header.html' %}
+    {% include 'partials/_messages.html' %}
       {% if request.path != '/' %}
         {% include 'partials/_search_modal.html' %}
     {% endif %}

--- a/templates/partials/_messages.html
+++ b/templates/partials/_messages.html
@@ -1,0 +1,18 @@
+{% if messages %}
+<div class="toast-container position-fixed top-0 end-0 p-3">
+    {% for message in messages %}
+    <div class="toast text-bg-{{ message.tags|default:'success' }} border-0 mb-2" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="4000">
+        <div class="d-flex">
+            <div class="toast-body">{{ message }}</div>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const toastElList = document.querySelectorAll('.toast');
+  toastElList.forEach((toastEl) => new bootstrap.Toast(toastEl).show());
+});
+</script>
+{% endif %}


### PR DESCRIPTION
## Summary
- add Bootstrap toast container to base layout
- render success messages as toast notifications

## Testing
- `python manage.py test` *(fails: Could not import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684c0410df248321b417aa35520ff4a7