### PR TITLE
Show followed clubs in favorites

### DIFF
--- a/apps/users/tests/test_favorites.py
+++ b/apps/users/tests/test_favorites.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+
+from apps.clubs.models import Club
+from apps.users.models import Follow
+
+
+class FavoritesViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='u', password='pass')
+        self.club = Club.objects.create(
+            name='Club Favorito',
+            city='City',
+            address='Address',
+            phone='123',
+            email='c@example.com'
+        )
+        follower_ct = ContentType.objects.get_for_model(self.user)
+        club_ct = ContentType.objects.get_for_model(Club)
+        Follow.objects.create(
+            follower_content_type=follower_ct,
+            follower_object_id=self.user.id,
+            followed_content_type=club_ct,
+            followed_object_id=self.club.id,
+        )
+
+    def test_clubs_followed_are_listed(self):
+        self.client.login(username='u', password='pass')
+        url = reverse('favoritos')
+        response = self.client.get(url)
+        self.assertContains(response, 'Club Favorito')
+

--- a/apps/users/views/profile.py
+++ b/apps/users/views/profile.py
@@ -2,12 +2,13 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.models import User
 
-from django.shortcuts import render, redirect
-
 from ..forms import ProfileForm
 from ..models import Profile, Follow
-from apps.clubs.models import Booking
+from apps.clubs.models import Booking, Club
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import F, FloatField, Avg, Count, ExpressionWrapper
+from django.db.models.functions import Round
+from django.core.paginator import Paginator
 
 
 @login_required
@@ -49,7 +50,37 @@ def profile_detail(request, username):
 
 @login_required
 def favorites(request):
-    """Placeholder view for user favorites."""
-    return render(request, 'users/favorites.html')
+    follower_ct = ContentType.objects.get_for_model(request.user)
+    club_ct = ContentType.objects.get_for_model(Club)
+
+    follow_qs = Follow.objects.filter(
+        follower_content_type=follower_ct,
+        follower_object_id=request.user.id,
+        followed_content_type=club_ct,
+    )
+    club_ids = follow_qs.values_list('followed_object_id', flat=True)
+
+    clubs = Club.objects.filter(id__in=club_ids)
+
+    average_expr = ExpressionWrapper(
+        (F('reseñas__instalaciones') + F('reseñas__entrenadores') +
+         F('reseñas__ambiente') + F('reseñas__calidad_precio') +
+         F('reseñas__variedad_clases')) / 5.0,
+        output_field=FloatField(),
+    )
+
+    clubs = clubs.annotate(
+        average_rating=Round(Avg(average_expr), precision=1),
+        reviews_count=Count('reseñas')
+    )
+
+    paginator = Paginator(clubs, 12)
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
+    return render(request, 'users/favorites.html', {
+        'clubs': page_obj,
+        'page_obj': page_obj,
+    })
 
 

--- a/templates/users/favorites.html
+++ b/templates/users/favorites.html
@@ -1,8 +1,89 @@
 {% extends 'base.html' %}
+{% load static %}
+
+{% block body_class %}search-result-page{% endblock %}
 
 {% block content %}
-<div class="container py-4">
-    <h1 class="mb-4">Favoritos</h1>
-    <p>Tus clubes favoritos aparecerán aquí.</p>
+<div class="container-fluid px-3 my-5 col-10">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        {% include 'partials/_back-btn.html' %}
+    </div>
+
+    {% if clubs %}
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
+        {% for club in clubs %}
+        <div class="col">
+            <div class="card h-100 border-0 shadow-sm">
+                <a href="{% url 'club_profile' club.slug %}" class="text-decoration-none text-dark">
+                    {% if club.logo %}
+                        <img src="{{ club.logo.url }}" class="card-img-top object-fit-cover" style="height: 200px;" alt="{{ club.name }}">
+                    {% else %}
+                        <div class="card-img-top d-flex align-items-center justify-content-center bg-light" style="height: 200px;">
+                            <span class="text-muted">Sin logo</span>
+                        </div>
+                    {% endif %}
+
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start mb-1">
+                            <h5 class="card-title fw-bold mb-0">{{ club.name }}</h5>
+                            <div class="d-flex align-items-center gap-1 text-end">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="gold" viewBox="0 0 24 24" stroke="gold">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
+                                </svg>
+                                {% if club.average_rating %}
+                                    <span class="small">{{ club.average_rating }} ({{ club.reviews_count }})</span>
+                                {% else %}
+                                    <span class="text-muted small">Sin reseñas</span>
+                                {% endif %}
+                            </div>
+                        </div>
+
+                        <div class="d-flex align-items-center mb-3">
+                            <span class="badge bg-secondary">{{ club.get_category_display }}</span>
+                            {% if club.verified %}
+                            <span class="ms-2" title="Verificado">
+                                <svg fill="none" height="24" viewBox="0 0 24 24" width="15" xmlns="http://www.w3.org/2000/svg">
+                                    <path clip-rule="evenodd" d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM11.2071 16.2071L18.2071 9.20711L16.7929 7.79289L10.5 14.0858L7.20711 10.7929L5.79289 12.2071L9.79289 16.2071C9.98043 16.3946 10.2348 16.5 10.5 16.5C10.7652 16.5 11.0196 16.3946 11.2071 16.2071Z" fill="black" fill-rule="evenodd"/>
+                                </svg>
+                            </span>
+                            {% endif %}
+                        </div>
+                    </div>
+                </a>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+
+    {% if page_obj.has_other_pages %}
+    <nav class="mt-4" aria-label="Favoritos">
+        <ul class="pagination justify-content-center">
+            {% if page_obj.has_previous %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page_obj.previous_page_number }}" aria-label="Anterior">&laquo;</a>
+            </li>
+            {% else %}
+            <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+            {% endif %}
+            {% for num in page_obj.paginator.page_range %}
+            {% if page_obj.number == num %}
+            <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+            {% else %}
+            <li class="page-item"><a class="page-link" href="?page={{ num }}">{{ num }}</a></li>
+            {% endif %}
+            {% endfor %}
+            {% if page_obj.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page_obj.next_page_number }}" aria-label="Siguiente">&raquo;</a>
+            </li>
+            {% else %}
+            <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+            {% endif %}
+        </ul>
+    </nav>
+    {% endif %}
+    {% else %}
+    <p>No sigues a ningún club todavía.</p>
+    {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- list followed clubs in `favorites` view with pagination
- style favorites page same as search results
- test that followed clubs appear

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684c057a181483218c8805ad5fc91c1f