### PR TITLE
Show avatars in reviews

### DIFF
--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 
 def club_profile(request, slug):
     club = get_object_or_404(Club, slug=slug)
-    reseñas = club.reseñas.select_related('usuario').all()
+    reseñas = club.reseñas.select_related('usuario__profile', 'usuario').all()
     detallado = club.get_detailed_ratings()
     competidores = club.competidores.all()
     posts = club.posts.all()
@@ -71,7 +71,7 @@ def club_profile(request, slug):
 def ajax_reviews(request, slug):
     """Devolver la lista de reseñas ordenada sin recargar la página."""
     club = get_object_or_404(Club, slug=slug)
-    reseñas = club.reseñas.select_related('usuario').all()
+    reseñas = club.reseñas.select_related('usuario__profile', 'usuario').all()
     orden = request.GET.get('orden', 'relevantes')
 
     if orden == 'recientes':

--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -191,6 +191,12 @@ textarea.form-control {
   color: rgb(255, 255, 255);
 }
 
+.review-avatar-img {
+  width: 32px;
+  height: 32px;
+  object-fit: cover;
+}
+
 .review-user .fw-medium {
   font-size: 0.8rem;
   color: #555;

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -382,10 +382,14 @@
               <div class="review-slide{% if forloop.first %} active{% endif %}">
       <p class="review-text">“{{ reseña.comentario }}”</p>
 
-      <div class="review-user-container d-flex align-items-center">
-        <div class="review-avatar">{{ reseña.usuario.username|first|upper }}</div>
-        <div class="fw-medium ms-2">{{ reseña.usuario.username }}</div>
-      </div>
+        <div class="review-user-container d-flex align-items-center">
+          {% if reseña.usuario.profile.avatar %}
+          <img src="{{ reseña.usuario.profile.avatar.url }}" alt="{{ reseña.usuario.username }}" class="review-avatar-img rounded-circle">
+          {% else %}
+          <div class="review-avatar">{{ reseña.usuario.username|first|upper }}</div>
+          {% endif %}
+          <div class="fw-medium ms-2">{{ reseña.usuario.username }}</div>
+        </div>
     </div>
 
 

--- a/templates/clubs/reviews_list.html
+++ b/templates/clubs/reviews_list.html
@@ -1,10 +1,14 @@
 {% for reseña in reseñas %}
   <div class="mb-3 rounded p-4 border position-relative" style="min-height: 120px;">
     <div class="d-flex justify-content-between align-items-center mb-2">
-      <div class="d-flex align-items-center">
-        <div class="review-avatar">{{ reseña.usuario.username|first|upper }}</div>
-        <div class="fw-medium ms-2">{{ reseña.usuario.username }}</div>
-      </div>
+        <div class="d-flex align-items-center">
+          {% if reseña.usuario.profile.avatar %}
+          <img src="{{ reseña.usuario.profile.avatar.url }}" alt="{{ reseña.usuario.username }}" class="review-avatar-img rounded-circle">
+          {% else %}
+          <div class="review-avatar">{{ reseña.usuario.username|first|upper }}</div>
+          {% endif %}
+          <div class="fw-medium ms-2">{{ reseña.usuario.username }}</div>
+        </div>
       <div class=" fw-bold text-warning">⭐ {{ reseña.promedio }}</div>
     </div>
     <p class="mb-3 review-text">{{ reseña.comentario }}</p>


### PR DESCRIPTION
## Summary
- display user profile photos in club review list and carousel
- add CSS for review avatars
- prefetch `usuario__profile` when loading reviews

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684c0e49ccc883218e755067e9475ebf