### PR TITLE
Fix duplicate redirect assertion in tests

### DIFF
--- a/apps/users/tests/test_user.py
+++ b/apps/users/tests/test_user.py
@@ -19,7 +19,6 @@ class RegistrationTests(TestCase):
         self.assertTrue(User.objects.filter(username="newuser").exists())
         # And the view should redirect to home
         self.assertRedirects(response, reverse("home"))
-        self.assertRedirects(response, reverse("home"))
 
     def test_welcome_email_sent(self):
         data = {


### PR DESCRIPTION
## Summary
- remove redundant `assertRedirects` from registration test

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684c20dcc4808321b6a9950809e6c1a8