### PR TITLE
Add profile creation signal

### DIFF
--- a/apps/users/apps.py
+++ b/apps/users/apps.py
@@ -3,3 +3,7 @@ from django.apps import AppConfig
 class UsersConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'apps.users'
+
+    def ready(self):
+        # Import signal handlers to ensure profiles are created when users are added
+        from . import signals  # noqa: F401

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -1,0 +1,10 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.contrib.auth.models import User
+
+from .models import Profile
+
+@receiver(post_save, sender=User)
+def create_profile(sender, instance, created, **kwargs):
+    if created:
+        Profile.objects.create(user=instance)

--- a/apps/users/tests/test_user.py
+++ b/apps/users/tests/test_user.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
+from apps.users.models import Profile
 from unittest.mock import patch
 
 
@@ -67,4 +68,10 @@ class LoginPageTests(TestCase):
         self.assertContains(response, 'Contraseña')
         self.assertContains(response, 'Recordar contraseña')
         self.assertContains(response, 'toggle-password')
+
+
+class ProfileCreationTests(TestCase):
+    def test_profile_created_on_user_creation(self):
+        user = User.objects.create_user(username="signaluser", password="pass")
+        self.assertTrue(Profile.objects.filter(user=user).exists())
 


### PR DESCRIPTION
## Summary
- create a `post_save` signal in users app so every new `User` gets a `Profile`
- import the signals from `UsersConfig`
- test that creating a user automatically creates a profile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684c20e140b48321a050932d3a817d83