### PR TITLE
Add avatar display in feed reviews

### DIFF
--- a/apps/users/views/follow.py
+++ b/apps/users/views/follow.py
@@ -34,9 +34,21 @@ def feed(request):
     ct_club = ContentType.objects.get_for_model(Club)
     for f in follows:
         if f.followed_content_type == ct_club:
-            posts.extend(Reseña.objects.filter(club_id=f.followed_object_id))
-            posts.extend(ClubPost.objects.filter(club_id=f.followed_object_id))
+            posts.extend(
+                Reseña.objects
+                .select_related("usuario__profile", "club")
+                .filter(club_id=f.followed_object_id)
+            )
+            posts.extend(
+                ClubPost.objects.select_related("club").filter(
+                    club_id=f.followed_object_id
+                )
+            )
         elif f.followed_content_type == ct_user:
-            posts.extend(Reseña.objects.filter(usuario_id=f.followed_object_id))
+            posts.extend(
+                Reseña.objects
+                .select_related("usuario__profile", "club")
+                .filter(usuario_id=f.followed_object_id)
+            )
     posts = sorted(posts, key=lambda r: getattr(r, 'creado', r.created_at), reverse=True)[:20]
     return render(request, 'users/feed.html', {'posts': posts})

--- a/templates/users/feed.html
+++ b/templates/users/feed.html
@@ -6,10 +6,15 @@
     {% for post in posts %}
         <div class="mb-3">
             {% if post.__class__.__name__ == 'Reseña' %}
-                <p class="mb-1">
+                <div class="d-flex align-items-center mb-1">
+                    {% if post.usuario.profile.avatar %}
+                        <img src="{{ post.usuario.profile.avatar.url }}" alt="{{ post.usuario.username }}" class="review-avatar-img rounded-circle me-2">
+                    {% else %}
+                        <div class="review-avatar me-2">{{ post.usuario.username|first|upper }}</div>
+                    {% endif %}
                     <strong>{{ post.usuario.username }}</strong> en
                     <a href="{% url 'club_profile' slug=post.club.slug %}">{{ post.club.name }}</a>
-                </p>
+                </div>
                 <p class="mb-0">{{ post.comentario }}</p>
                 <small class="text-muted">{{ post.creado }}</small>
             {% else %}


### PR DESCRIPTION
## Summary
- show user avatar in feed page when listing reviews
- use `select_related` to prefetch profile and club for feed posts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cacf67590832190cd04451850e7f2