### PR TITLE
Implement avatar upload validations

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.forms import AuthenticationForm
 from django.utils.translation import gettext_lazy as _
 from .models import Profile
+import os
 
 
 class LoginForm(AuthenticationForm):
@@ -82,4 +83,23 @@ class ProfileForm(forms.ModelForm):
     class Meta:
         model = Profile
         fields = ['avatar', 'bio', 'location']
+
+    def clean_avatar(self):
+        avatar = self.cleaned_data.get('avatar')
+        if not avatar:
+            return avatar
+
+        max_size = 2 * 1024 * 1024  # 2MB
+        if avatar.size > max_size:
+            raise forms.ValidationError(
+                'El archivo excede el tamaño máximo de 2MB.'
+            )
+
+        ext = os.path.splitext(avatar.name)[1].lower()
+        if ext not in ['.jpg', '.jpeg', '.png']:
+            raise forms.ValidationError(
+                'Formato de imagen no soportado. Usa JPG o PNG.'
+            )
+
+        return avatar
 

--- a/apps/users/tests/test_avatar_validation.py
+++ b/apps/users/tests/test_avatar_validation.py
@@ -1,0 +1,29 @@
+import io
+import tempfile
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+
+from apps.users.forms import ProfileForm
+
+class AvatarValidationTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="u", password="pass")
+        self.profile = self.user.profile
+
+    def test_avatar_size_limit(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(MEDIA_ROOT=tmpdir):
+                big_content = b"a" * (2 * 1024 * 1024 + 1)
+                upload = SimpleUploadedFile("big.jpg", big_content, content_type="image/jpeg")
+                form = ProfileForm(data={}, files={"avatar": upload}, instance=self.profile)
+                self.assertFalse(form.is_valid())
+                self.assertIn("2MB", form.errors["avatar"][0])
+
+    def test_avatar_format_validation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(MEDIA_ROOT=tmpdir):
+                upload = SimpleUploadedFile("test.gif", b"GIF89a", content_type="image/gif")
+                form = ProfileForm(data={}, files={"avatar": upload}, instance=self.profile)
+                self.assertFalse(form.is_valid())
+                self.assertIn("JPG", form.errors["avatar"][0])

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     path('signup/', auth.register, name='signup'),
     path('login/', LoginView.as_view(), name='login'),
     path('logout/', auth_views.LogoutView.as_view(next_page='/'), name='logout'),
-    path('profile/', profile_views.profile, name='profile'),
+    path('perfil/', profile_views.profile, name='profile'),
     path('favoritos/', profile_views.favorites, name='favoritos'),
     path('mis-reseñas/', review.mis_reseñas, name='mis-reseñas'),
     path('reseña/<slug:slug>/', review.dejar_reseña, name='dejar-reseña'),

--- a/apps/users/views/profile.py
+++ b/apps/users/views/profile.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.models import User
+from django.contrib import messages
 
 from ..forms import ProfileForm
 from ..models import Profile, Follow
@@ -18,7 +19,11 @@ def profile(request):
         form = ProfileForm(request.POST, request.FILES, instance=profile_obj)
         if form.is_valid():
             form.save()
+            messages.success(request, 'Perfil actualizado exitosamente.')
             return redirect('profile')
+        else:
+            for error in form.errors.get('avatar', []):
+                messages.error(request, error)
     else:
         form = ProfileForm(instance=profile_obj)
     bookings = Booking.objects.filter(user=request.user).select_related('clase', 'evento')

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -4,11 +4,19 @@
 {% block content %}
 <div class="container py-4">
     <h1 class="mb-4">Mi Perfil</h1>
+    {% if profile.avatar %}
+        <img src="{{ profile.avatar.url }}" class="rounded-circle mb-3" style="width:100px;height:100px;object-fit:cover;">
+    {% endif %}
     <form method="post" enctype="multipart/form-data" class="mb-5">
         {% csrf_token %}
         <div class="mb-3">
             {{ form.avatar.label_tag }}
             {{ form.avatar }}
+            {% if form.avatar.errors %}
+            <div class="invalid-feedback d-block">
+                {{ form.avatar.errors.as_text|striptags }}
+            </div>
+            {% endif %}
         </div>
         <div class="mb-3">
             {{ form.bio.label_tag }}


### PR DESCRIPTION
## Summary
- enforce 2 MB and JPG/PNG validation when uploading avatar
- display error messages and show current avatar on profile
- update route for profile to `/perfil/`
- test avatar size and format rules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cb52e39088321ad074ee2cfc1ab41