### PR TITLE
Implement profile tabs layout

### DIFF
--- a/apps/users/migrations/0003_notifications.py
+++ b/apps/users/migrations/0003_notifications.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0002_follow'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='notifications',
+            field=models.BooleanField(default=True),
+        ),
+    ]

--- a/apps/users/models/profile.py
+++ b/apps/users/models/profile.py
@@ -9,6 +9,7 @@ class Profile(models.Model):
     avatar = models.ImageField(upload_to="avatars/", blank=True, null=True)
     bio = models.TextField(blank=True)
     location = models.CharField(max_length=100, blank=True)
+    notifications = models.BooleanField(default=True)
 
     def __str__(self):
         return f"Perfil de {self.user.username}"

--- a/apps/users/views/profile.py
+++ b/apps/users/views/profile.py
@@ -3,9 +3,10 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.models import User
 from django.contrib import messages
 
-from ..forms import ProfileForm
+from ..forms import ProfileForm, AccountForm
 from ..models import Profile, Follow
-from apps.clubs.models import Booking, Club
+from apps.clubs.models import Booking, Club, Reseña
+
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import F, FloatField, Avg, Count, ExpressionWrapper
 from django.db.models.functions import Round
@@ -16,7 +17,7 @@ from django.core.paginator import Paginator
 def profile(request):
     profile_obj, _ = Profile.objects.get_or_create(user=request.user)
     if request.method == 'POST':
-        form = ProfileForm(request.POST, request.FILES, instance=profile_obj)
+        form = AccountForm(request.POST, request.FILES, instance=profile_obj, user=request.user)
         if form.is_valid():
             form.save()
             messages.success(request, 'Perfil actualizado exitosamente.')
@@ -25,12 +26,42 @@ def profile(request):
             for error in form.errors.get('avatar', []):
                 messages.error(request, error)
     else:
-        form = ProfileForm(instance=profile_obj)
+        form = AccountForm(instance=profile_obj, user=request.user)
     bookings = Booking.objects.filter(user=request.user).select_related('clase', 'evento')
+
+    follower_ct = ContentType.objects.get_for_model(request.user)
+    club_ct = ContentType.objects.get_for_model(Club)
+
+    follow_qs = Follow.objects.filter(
+        follower_content_type=follower_ct,
+        follower_object_id=request.user.id,
+        followed_content_type=club_ct,
+    )
+    club_ids = follow_qs.values_list('followed_object_id', flat=True)
+
+    clubs = Club.objects.filter(id__in=club_ids)
+
+    average_expr = ExpressionWrapper(
+        (F('reseñas__instalaciones') + F('reseñas__entrenadores') +
+         F('reseñas__ambiente') + F('reseñas__calidad_precio') +
+         F('reseñas__variedad_clases')) / 5.0,
+        output_field=FloatField(),
+    )
+
+    clubs = clubs.annotate(
+        average_rating=Round(Avg(average_expr), precision=1),
+        reviews_count=Count('reseñas')
+    )
+
+    favoritos_page = clubs
+
+    user_reviews = Reseña.objects.filter(usuario=request.user)
     return render(request, 'users/profile.html', {
         'form': form,
         'profile': profile_obj,
         'bookings': bookings,
+        'favoritos': favoritos_page,
+        'reviews': user_reviews,
     })
 
 def profile_detail(request, username):

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -1,0 +1,29 @@
+.profile-wrapper {
+  display: flex;
+  gap: 2rem;
+}
+.profile-tabs {
+  min-width: 200px;
+}
+.profile-tab {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+  transition: all 0.3s;
+}
+.profile-tab.active {
+  border-left-color: #000;
+  font-weight: 600;
+}
+.profile-content {
+  flex: 1;
+}
+.profile-section {
+  display: none;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+.profile-section.active {
+  display: block;
+  opacity: 1;
+}

--- a/static/js/profile-tabs.js
+++ b/static/js/profile-tabs.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const tabs = document.querySelectorAll('.profile-tab');
+  const sections = document.querySelectorAll('.profile-section');
+
+  function activate(tab) {
+    tabs.forEach(t => t.classList.remove('active'));
+    sections.forEach(s => s.classList.remove('active'));
+    tab.classList.add('active');
+    const target = tab.dataset.target;
+    const sec = document.getElementById(target);
+    if (sec) sec.classList.add('active');
+  }
+
+  tabs.forEach(t => {
+    t.addEventListener('click', () => activate(t));
+  });
+
+  const activeTab = document.querySelector('.profile-tab.active') || tabs[0];
+  if (activeTab) activate(activeTab);
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,6 +33,7 @@
 <script src="{% static 'js/user-dropdown.js' %}"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{% static 'js/page-loader.js' %}"></script>
+{% block extra_js %}{% endblock %}
 
 </body>
 </html>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -2,58 +2,144 @@
 {% load static %}
 
 {% block content %}
-<div class="container py-4">
-    <h1 class="mb-4">Mi Perfil</h1>
-    {% if profile.avatar %}
-        <img src="{{ profile.avatar.url }}" class="rounded-circle mb-3" style="width:100px;height:100px;object-fit:cover;">
-    {% endif %}
-    <form method="post" enctype="multipart/form-data" class="mb-5">
-        {% csrf_token %}
-        <div class="mb-3">
-            {{ form.avatar.label_tag }}
-            {{ form.avatar }}
-            {% if form.avatar.errors %}
-            <div class="invalid-feedback d-block">
-                {{ form.avatar.errors.as_text|striptags }}
-            </div>
+<div class="container py-4 profile-wrapper">
+    <div class="profile-tabs">
+        <div class="profile-tab active" data-target="tab-account">Mi cuenta</div>
+        <div class="profile-tab" data-target="tab-bookings">Reservas</div>
+        <div class="profile-tab" data-target="tab-favorites">Favoritos</div>
+        <div class="profile-tab" data-target="tab-reviews">Reseñas</div>
+        <form method="POST" action="{% url 'logout' %}">
+            {% csrf_token %}
+            <button type="submit" class="profile-tab text-start w-100">Cerrar sesión</button>
+        </form>
+    </div>
+    <div class="profile-content">
+        <div id="tab-account" class="profile-section active">
+            <h1 class="mb-4">Mi Cuenta</h1>
+            {% if profile.avatar %}
+                <img src="{{ profile.avatar.url }}" class="rounded-circle mb-3" style="width:100px;height:100px;object-fit:cover;">
             {% endif %}
-        </div>
-        <div class="mb-3">
-            {{ form.bio.label_tag }}
-            {{ form.bio }}
-        </div>
-        <div class="mb-3">
-            {{ form.location.label_tag }}
-            {{ form.location }}
-        </div>
-        <button type="submit" class="btn btn-primary">Guardar cambios</button>
-    </form>
-
-    {% if bookings %}
-    <h2 class="h5">Mis Reservas</h2>
-    <ul class="list-group">
-        {% for b in bookings %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-            <span>
-                {% if b.clase %}
-                    Clase: {{ b.clase.nombre }} ({{ b.clase.hora_inicio|time:"H:i" }})
-                {% elif b.evento %}
-                    Evento: {{ b.evento.titulo }}
-                {% endif %}
-            </span>
-            {% if b.status != 'cancelled' %}
-            <form action="{% url 'cancel_booking' b.id %}" method="post" class="ms-2">
+            <form method="post" enctype="multipart/form-data" class="mb-5">
                 {% csrf_token %}
-                <button type="submit" class="btn btn-sm btn-danger">Cancelar</button>
+                <div class="mb-3">
+                    {{ form.avatar.label_tag }}
+                    {{ form.avatar }}
+                    {% if form.avatar.errors %}
+                    <div class="invalid-feedback d-block">
+                        {{ form.avatar.errors.as_text|striptags }}
+                    </div>
+                    {% endif %}
+                </div>
+                <div class="mb-3">
+                    {{ form.username.label_tag }}
+                    {{ form.username }}
+                </div>
+                <div class="mb-3">
+                    {{ form.email.label_tag }}
+                    {{ form.email }}
+                </div>
+                <div class="mb-3">
+                    {{ form.new_password1.label_tag }}
+                    {{ form.new_password1 }}
+                </div>
+                <div class="mb-3">
+                    {{ form.new_password2.label_tag }}
+                    {{ form.new_password2 }}
+                </div>
+                <div class="form-check mb-3">
+                    {{ form.notifications }}
+                    {{ form.notifications.label_tag }}
+                </div>
+                <button type="submit" class="btn btn-primary">Guardar cambios</button>
             </form>
+        </div>
+        <div id="tab-bookings" class="profile-section">
+            <h2 class="h5">Mis Reservas</h2>
+            {% if bookings %}
+            <ul class="list-group">
+                {% for b in bookings %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>
+                        {% if b.clase %}
+                            Clase: {{ b.clase.nombre }} ({{ b.clase.hora_inicio|time:"H:i" }})
+                        {% elif b.evento %}
+                            Evento: {{ b.evento.titulo }}
+                        {% endif %}
+                    </span>
+                    {% if b.status != 'cancelled' %}
+                    <form action="{% url 'cancel_booking' b.id %}" method="post" class="ms-2">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-sm btn-danger">Cancelar</button>
+                    </form>
+                    {% else %}
+                    <span class="badge bg-secondary">Cancelada</span>
+                    {% endif %}
+                </li>
+                {% empty %}
+                <li class="list-group-item">No tienes reservas.</li>
+                {% endfor %}
+            </ul>
             {% else %}
-            <span class="badge bg-secondary">Cancelada</span>
+            <p>No tienes reservas.</p>
             {% endif %}
-        </li>
-        {% empty %}
-        <li class="list-group-item">No tienes reservas.</li>
-        {% endfor %}
-    </ul>
-    {% endif %}
+        </div>
+        <div id="tab-favorites" class="profile-section">
+            <h2 class="h5 mb-3">Favoritos</h2>
+            {% if favoritos %}
+            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-4">
+                {% for club in favoritos %}
+                <div class="col">
+                    <div class="card h-100 border-0 shadow-sm">
+                        <a href="{% url 'club_profile' club.slug %}" class="text-decoration-none text-dark">
+                            {% if club.logo %}
+                                <img src="{{ club.logo.url }}" class="card-img-top object-fit-cover" style="height:200px" alt="{{ club.name }}">
+                            {% else %}
+                                <div class="card-img-top d-flex align-items-center justify-content-center bg-light" style="height:200px;">
+                                    <span class="text-muted">Sin logo</span>
+                                </div>
+                            {% endif %}
+                            <div class="card-body">
+                                <h5 class="card-title fw-bold mb-1">{{ club.name }}</h5>
+                                <div class="d-flex align-items-center gap-1">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="gold" viewBox="0 0 24 24" stroke="gold">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
+                                    </svg>
+                                    {% if club.average_rating %}
+                                    <span class="small">{{ club.average_rating }} ({{ club.reviews_count }})</span>
+                                    {% else %}
+                                    <span class="text-muted small">Sin reseñas</span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </a>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+            {% else %}
+            <p>No sigues a ningún club todavía.</p>
+            {% endif %}
+        </div>
+        <div id="tab-reviews" class="profile-section">
+            <h2 class="h5 mb-3">Mis Reseñas</h2>
+            {% if reviews %}
+            <ul class="reseña-list">
+                {% for r in reviews %}
+                <li class="reseña-item mb-3">
+                    <h4><a href="{% url 'club_profile' r.club.slug %}">{{ r.club.name }}</a></h4>
+                    <p>⭐ {{ r.promedio }} | "{{ r.comentario }}"</p>
+                    <small>{{ r.creado|date:"d/m/Y H:i" }}</small>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p>No has escrito ninguna reseña todavía.</p>
+            {% endif %}
+        </div>
+    </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script src="{% static 'js/profile-tabs.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add notifications field to user profile model
- provide account edit form including username, email, password and notifications
- compute favorites and reviews in profile view
- rebuild profile template with vertical tabs
- style and JS for new tabs
- support extra javascript block in base template

## Testing
- `python3 -m py_compile apps/users/forms.py apps/users/views/profile.py apps/users/models/profile.py`
- `pytest -q` *(fails: ModuleNotFoundError for Django/Pillow)*

------
https://chatgpt.com/codex/tasks/task_e_684cbaab34bc8321bf6fa64617a5b20f