### PR TITLE
Revamp profile form

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -27,3 +27,65 @@
   display: block;
   opacity: 1;
 }
+/* Form styles inspired by Zellwk CodePen */
+.profile-form .form-field {
+  position: relative;
+  margin-bottom: 1.5rem;
+}
+
+.profile-form .form-field input[type="text"],
+.profile-form .form-field input[type="email"],
+.profile-form .form-field input[type="password"],
+.profile-form .form-field input[type="file"],
+.profile-form .form-field textarea {
+  width: 100%;
+  padding: 0.75rem 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: none;
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.profile-form .form-field input[type="checkbox"] {
+  width: auto;
+  margin-right: 0.5rem;
+}
+
+.profile-form .form-field input:focus,
+.profile-form .form-field textarea:focus {
+  outline: none;
+  border-color: #000;
+  box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
+}
+
+.profile-form .form-field label {
+  position: absolute;
+  left: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: #fff;
+  padding: 0 0.25rem;
+  color: #666;
+  pointer-events: none;
+  transition: transform 0.2s, font-size 0.2s, color 0.2s;
+}
+
+.profile-form .checkbox-field label {
+  position: static;
+  transform: none;
+  padding: 0;
+}
+
+.profile-form .checkbox-field {
+  display: flex;
+  align-items: center;
+}
+
+.profile-form .form-field input:not(:placeholder-shown) + label,
+.profile-form .form-field input:focus + label,
+.profile-form .form-field textarea:not(:placeholder-shown) + label,
+.profile-form .form-field textarea:focus + label {
+  top: -0.6rem;
+  font-size: 0.75rem;
+  color: #000;
+}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -19,36 +19,36 @@
             {% if profile.avatar %}
                 <img src="{{ profile.avatar.url }}" class="rounded-circle mb-3" style="width:100px;height:100px;object-fit:cover;">
             {% endif %}
-            <form method="post" enctype="multipart/form-data" class="mb-5">
+            <form method="post" enctype="multipart/form-data" class="profile-form mb-5">
                 {% csrf_token %}
-                <div class="mb-3">
-                    {{ form.avatar.label_tag }}
-                    {{ form.avatar }}
+                <div class="form-field">
+                    {{ form.avatar.as_widget }}
+                    <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
                     {% if form.avatar.errors %}
                     <div class="invalid-feedback d-block">
                         {{ form.avatar.errors.as_text|striptags }}
                     </div>
                     {% endif %}
                 </div>
-                <div class="mb-3">
-                    {{ form.username.label_tag }}
-                    {{ form.username }}
+                <div class="form-field">
+                    {{ form.username.as_widget(attrs={'placeholder': ' '}) }}
+                    <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
                 </div>
-                <div class="mb-3">
-                    {{ form.email.label_tag }}
-                    {{ form.email }}
+                <div class="form-field">
+                    {{ form.email.as_widget(attrs={'placeholder': ' '}) }}
+                    <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
                 </div>
-                <div class="mb-3">
-                    {{ form.new_password1.label_tag }}
-                    {{ form.new_password1 }}
+                <div class="form-field">
+                    {{ form.new_password1.as_widget(attrs={'placeholder': ' '}) }}
+                    <label for="{{ form.new_password1.id_for_label }}">{{ form.new_password1.label }}</label>
                 </div>
-                <div class="mb-3">
-                    {{ form.new_password2.label_tag }}
-                    {{ form.new_password2 }}
+                <div class="form-field">
+                    {{ form.new_password2.as_widget(attrs={'placeholder': ' '}) }}
+                    <label for="{{ form.new_password2.id_for_label }}">{{ form.new_password2.label }}</label>
                 </div>
-                <div class="form-check mb-3">
+                <div class="form-field checkbox-field">
                     {{ form.notifications }}
-                    {{ form.notifications.label_tag }}
+                    <label for="{{ form.notifications.id_for_label }}">{{ form.notifications.label }}</label>
                 </div>
                 <button type="submit" class="btn btn-primary">Guardar cambios</button>
             </form>


### PR DESCRIPTION
## Summary
- restyle the profile form with floating labels
- adjust profile.html markup to match new CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL' and 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cbe3697708321a44e50b913f93c50