### PR TITLE
Add placeholders in account form

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -128,6 +128,9 @@ class AccountForm(forms.ModelForm):
             self.fields['username'].initial = user.username
             self.fields['email'].initial = user.email
             self.user = user
+        placeholder_fields = ['username', 'email', 'new_password1', 'new_password2']
+        for f in placeholder_fields:
+            self.fields[f].widget.attrs.setdefault('placeholder', ' ')
 
     def clean(self):
         cleaned = super().clean()

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -31,19 +31,19 @@
                     {% endif %}
                 </div>
                 <div class="form-field">
-                    {{ form.username.as_widget(attrs={'placeholder': ' '}) }}
+                    {{ form.username }}
                     <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
                 </div>
                 <div class="form-field">
-                    {{ form.email.as_widget(attrs={'placeholder': ' '}) }}
+                    {{ form.email }}
                     <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
                 </div>
                 <div class="form-field">
-                    {{ form.new_password1.as_widget(attrs={'placeholder': ' '}) }}
+                    {{ form.new_password1 }}
                     <label for="{{ form.new_password1.id_for_label }}">{{ form.new_password1.label }}</label>
                 </div>
                 <div class="form-field">
-                    {{ form.new_password2.as_widget(attrs={'placeholder': ' '}) }}
+                    {{ form.new_password2 }}
                     <label for="{{ form.new_password2.id_for_label }}">{{ form.new_password2.label }}</label>
                 </div>
                 <div class="form-field checkbox-field">


### PR DESCRIPTION
## Summary
- add placeholder defaults to `AccountForm`
- simplify form field markup in profile template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684cc031df5883218a9df4840fdb3d8e