### PR TITLE
Add clear input buttons in profile form

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -81,11 +81,27 @@
   align-items: center;
 }
 
-.profile-form .form-field input:not(:placeholder-shown) + label,
-.profile-form .form-field input:focus + label,
-.profile-form .form-field textarea:not(:placeholder-shown) + label,
-.profile-form .form-field textarea:focus + label {
+.profile-form .form-field input:not(:placeholder-shown) ~ label,
+.profile-form .form-field input:focus ~ label,
+.profile-form .form-field textarea:not(:placeholder-shown) ~ label,
+.profile-form .form-field textarea:focus ~ label {
   top: -0.6rem;
   font-size: 0.75rem;
   color: #000;
+}
+
+.profile-form .clear-btn {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1rem;
+  display: none;
+}
+
+.profile-form input:not(:placeholder-shown) + .clear-btn {
+  display: block;
 }

--- a/static/js/clear-input.js
+++ b/static/js/clear-input.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.form-field').forEach(field => {
+    const input = field.querySelector('input');
+    const btn = field.querySelector('.clear-btn');
+    if (!input || !btn) return;
+
+    const toggle = () => {
+      if (input.value) {
+        btn.style.display = 'block';
+      } else {
+        btn.style.display = 'none';
+      }
+    };
+
+    btn.addEventListener('click', () => {
+      input.value = '';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      toggle();
+      input.focus();
+    });
+
+    input.addEventListener('input', toggle);
+    toggle();
+  });
+});

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -32,18 +32,22 @@
                 </div>
                 <div class="form-field">
                     {{ form.username }}
+                    <button type="button" class="clear-btn">×</button>
                     <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
                 </div>
                 <div class="form-field">
                     {{ form.email }}
+                    <button type="button" class="clear-btn">×</button>
                     <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
                 </div>
                 <div class="form-field">
                     {{ form.new_password1 }}
+                    <button type="button" class="clear-btn">×</button>
                     <label for="{{ form.new_password1.id_for_label }}">{{ form.new_password1.label }}</label>
                 </div>
                 <div class="form-field">
                     {{ form.new_password2 }}
+                    <button type="button" class="clear-btn">×</button>
                     <label for="{{ form.new_password2.id_for_label }}">{{ form.new_password2.label }}</label>
                 </div>
                 <div class="form-field checkbox-field">
@@ -142,4 +146,5 @@
 
 {% block extra_js %}
 <script src="{% static 'js/profile-tabs.js' %}"></script>
+<script src="{% static 'js/clear-input.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add clear buttons to username/email/password fields in profile.html
- update floating label CSS and new clear button styling
- add clear-input.js to toggle button visibility and clear values
- include script in profile page

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cc28688708321864e94c24d7e8329