### PR TITLE
Fix profile label position

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -85,8 +85,9 @@
 .profile-form .form-field input:focus ~ label,
 .profile-form .form-field textarea:not(:placeholder-shown) ~ label,
 .profile-form .form-field textarea:focus ~ label {
-  top: -0.6rem;
-  font-size: 0.75rem;
+  top: 0;
+  transform: translateY(-50%);
+  font-size: 0.5rem;
   color: #000;
 }
 


### PR DESCRIPTION
## Summary
- ensure profile labels move to the top border when the input has focus or content

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cc6a0f7508321a32660d0e46fa859