### PR TITLE
Use avatar in header dropdown

### DIFF
--- a/static/css/_header.css
+++ b/static/css/_header.css
@@ -1,1 +1,21 @@
  
+
+/* Avatar in navigation dropdown */
+.nav-avatar-img {
+    width: 30px;
+    height: 30px;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
+.nav-avatar {
+    width: 30px;
+    height: 30px;
+    background-color: #000;
+    color: #fff;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+}

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -34,9 +34,12 @@
                 {% if user.is_authenticated %}
                     <li class="nav-item">
                         <div class="custom-dropdown small" id="user-dropdown">
-                            <div class="selected">
-                                <span class="selected-text">{{ user.username }}</span>
-                                <span class="select-arrow"></span>
+                            <div class="selected d-flex align-items-center">
+                                {% if user.profile.avatar %}
+                                    <img src="{{ user.profile.avatar.url }}" alt="{{ user.username }}" class="nav-avatar-img">
+                                {% else %}
+                                    <div class="nav-avatar">{{ user.username|first|upper }}</div>
+                                {% endif %}
                             </div>
                             <div class="dropdown-menu " id="user-menu" >
                                 <a href="{% url 'profile' %}" class="dropdown-item text-light">Mi perfil</a> 


### PR DESCRIPTION
## Summary
- show user avatar or initials in the header dropdown
- add styles for navigation avatars
- remove dropdown arrow from user avatar

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cd9abe8548321a0b6b62b924156ed