### PR TITLE
Add gallery like and share controls

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -274,3 +274,30 @@ textarea.form-control {
   border-bottom: 1px solid #000;
   font-weight: 600;
 }
+
+/* Acciones en la galería */
+.gallery-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.gallery-actions button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.gallery-actions svg {
+  width: 24px;
+  height: 24px;
+  stroke: #000;
+  stroke-width: 1;
+  fill: none;
+}
+
+#club-heart.liked path {
+  fill: #000;
+}

--- a/static/js/share-like.js
+++ b/static/js/share-like.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const heart = document.getElementById('club-heart');
+  if (heart) {
+    heart.addEventListener('click', () => {
+      heart.classList.toggle('liked');
+    });
+  }
+
+  const shareBtn = document.getElementById('club-share');
+  if (shareBtn) {
+    shareBtn.addEventListener('click', async () => {
+      const url = window.location.href;
+      if (navigator.share) {
+        try {
+          await navigator.share({ url });
+        } catch (err) {
+          console.error(err);
+        }
+      } else if (navigator.clipboard) {
+        try {
+          await navigator.clipboard.writeText(url);
+          alert('Enlace copiado al portapapeles');
+        } catch (err) {
+          prompt('Copia este enlace:', url);
+        }
+      } else {
+        prompt('Copia este enlace:', url);
+      }
+    });
+  }
+});

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -106,6 +106,18 @@
     <div class="col-lg-8">
       <div class="mb-4   rounded">
         {% if club.photos.all %}
+  <div class="gallery-actions">
+    <button id="club-heart" aria-label="Me gusta">
+      <svg viewBox="0 0 24 24">
+        <path d="M12 21s-8.5-6.1-10-10.5C1 6 4 3 7.5 3c2.5 0 4.5 1.8 4.5 1.8S14 3 16.5 3C20 3 23 6 22 10.5 20.5 14.9 12 21 12 21z"/>
+      </svg>
+    </button>
+    <button id="club-share" aria-label="Compartir">
+      <svg data-name="Livello 1" id="Livello_1" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+        <path d="M105,82a23,23,0,0,0-22.49,18.17L41.74,77.29a23,23,0,0,0,0-26.57L82.51,27.83a23,23,0,1,0-.44-6.63l-44.53,25a23,23,0,1,0,0,35.62l44.53,25A23,23,0,1,0,105,82Zm0-76A17,17,0,1,1,88,23,17,17,0,0,1,105,6ZM11,76A17,17,0,0,1,35,52h0A17,17,0,0,1,11,76Zm94,46a17,17,0,1,1,17-17A17,17,0,0,1,105,122Z"/>
+      </svg>
+    </button>
+  </div>
   <div class="mb-4 gallery-slideshow">
     {% for photo in club.photos.all %}
       <div class="gallery-slide{% if forloop.first %} active{% endif %}">
@@ -432,6 +444,8 @@
 <script src="{% static 'js/review-filter.js' %}"></script>
 <script src="{% static 'js/slides.js' %}"></script>
 <script src="{% static 'js/rating.js' %}"></script>
+
+<script src="{% static 'js/share-like.js' %}"></script>
 
 <script src="{% static 'js/gallery-slideshow.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add favorite heart and share buttons above club gallery
- style the new gallery action buttons
- implement JS to toggle the heart and share club URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL', 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684ce0c666888321afd4f3b40dff8992