### PR TITLE
Add gallery like and share controls

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -274,3 +274,32 @@ textarea.form-control {
   border-bottom: 1px solid #000;
   font-weight: 600;
 }
+
+/* Acciones en la galería */
+.gallery-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.gallery-actions button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.gallery-actions svg {
+  width: 24px;
+  height: 24px;
+  stroke: #fff;
+  stroke-width: 1;
+  fill: none;
+}
+
+#club-heart.liked path {
+  fill: #fff;
+  stroke: #fff;
+}

--- a/static/js/share-like.js
+++ b/static/js/share-like.js
@@ -1,0 +1,76 @@
+document.addEventListener('DOMContentLoaded', () => {
+  function getCookie(name) {
+    let cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+      const cookies = document.cookie.split(';');
+      for (let i = 0; i < cookies.length; i++) {
+        const cookie = cookies[i].trim();
+        if (cookie.substring(0, name.length + 1) === (name + '=')) {
+          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+          break;
+        }
+      }
+    }
+    return cookieValue;
+  }
+
+  function showToast(message) {
+    let container = document.querySelector('.toast-container');
+    if (!container) {
+      container = document.createElement('div');
+      container.className = 'toast-container position-fixed top-0 end-0 p-3';
+      document.body.appendChild(container);
+    }
+    const toast = document.createElement('div');
+    toast.className = 'toast bg-black text-bg-success border-0 mb-2';
+    toast.role = 'alert';
+    toast.dataset.bsDelay = '4000';
+    toast.innerHTML = `<div class="d-flex"><div class="toast-body">${message}</div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button></div>`;
+    container.appendChild(toast);
+    new bootstrap.Toast(toast).show();
+  }
+
+  const heart = document.getElementById('club-heart');
+  if (heart) {
+    heart.addEventListener('click', async () => {
+      const url = heart.dataset.url;
+      const csrf = getCookie('csrftoken');
+      try {
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'X-CSRFToken': csrf }
+        });
+        if (res.ok) {
+          heart.classList.toggle('liked');
+          const followed = heart.classList.contains('liked');
+          showToast(followed ? 'Ahora sigues al club' : 'Has dejado de seguir al club');
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  }
+
+  const shareBtn = document.getElementById('club-share');
+  if (shareBtn) {
+    shareBtn.addEventListener('click', async () => {
+      const url = window.location.href;
+      if (navigator.share) {
+        try {
+          await navigator.share({ url });
+        } catch (err) {
+          console.error(err);
+        }
+      } else if (navigator.clipboard) {
+        try {
+          await navigator.clipboard.writeText(url);
+          alert('Enlace copiado al portapapeles');
+        } catch (err) {
+          prompt('Copia este enlace:', url);
+        }
+      } else {
+        prompt('Copia este enlace:', url);
+      }
+    });
+  }
+});

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -31,16 +31,7 @@
         </span>
         {% endif %}
     </div>
-    {% if user.is_authenticated %}
-    <form action="{% url 'toggle_follow' 'club' club.id %}" method="post" class="mb-3">
-        {% csrf_token %}
-        {% if club_followed %}
-        <button type="submit" class="btn btn-sm btn-outline-danger">Dejar de seguir</button>
-        {% else %}
-        <button type="submit" class="btn btn-sm btn-primary">Seguir</button>
-        {% endif %}
-    </form>
-    {% endif %}
+    {# Botón de seguir sustituido por el corazón de la galería #}
     <p class="mb-1 small d-flex align-items-center">
   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"
        stroke-linecap="round" stroke-linejoin="round" class="me-2" viewBox="0 0 24 24">
@@ -107,6 +98,20 @@
       <div class="mb-4   rounded">
         {% if club.photos.all %}
   <div class="mb-4 gallery-slideshow">
+    <div class="gallery-actions">
+      {% if user.is_authenticated %}
+      <button id="club-heart" aria-label="Seguir" data-url="{% url 'toggle_follow' 'club' club.id %}" class="{% if club_followed %}liked{% endif %}">
+        <svg viewBox="0 0 24 24">
+          <path d="M12 21s-8.5-6.1-10-10.5C1 6 4 3 7.5 3c2.5 0 4.5 1.8 4.5 1.8S14 3 16.5 3C20 3 23 6 22 10.5 20.5 14.9 12 21 12 21z"/>
+        </svg>
+      </button>
+      {% endif %}
+      <button id="club-share" aria-label="Compartir">
+        <svg data-name="Livello 1" id="Livello_1" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+          <path d="M105,82a23,23,0,0,0-22.49,18.17L41.74,77.29a23,23,0,0,0,0-26.57L82.51,27.83a23,23,0,1,0-.44-6.63l-44.53,25a23,23,0,1,0,0,35.62l44.53,25A23,23,0,1,0,105,82Zm0-76A17,17,0,1,1,88,23,17,17,0,0,1,105,6ZM11,76A17,17,0,0,1,35,52h0A17,17,0,0,1,11,76Zm94,46a17,17,0,1,1,17-17A17,17,0,0,1,105,122Z"/>
+        </svg>
+      </button>
+    </div>
     {% for photo in club.photos.all %}
       <div class="gallery-slide{% if forloop.first %} active{% endif %}">
         <img src="{{ photo.image.url }}" alt="Foto" class="img-fluid rounded shadow-sm" style="width:100%; max-height:450px; object-fit:contain; background:rgb(85, 85, 85);">
@@ -432,6 +437,8 @@
 <script src="{% static 'js/review-filter.js' %}"></script>
 <script src="{% static 'js/slides.js' %}"></script>
 <script src="{% static 'js/rating.js' %}"></script>
+
+<script src="{% static 'js/share-like.js' %}"></script>
 
 <script src="{% static 'js/gallery-slideshow.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add favorite heart and share buttons above club gallery
- style the new gallery action buttons
- implement JS to toggle the heart and share club URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL', 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684ce0c666888321afd4f3b40dff8992