### PR TITLE
Add login modal and follow notifications

### DIFF
--- a/apps/users/context_processors.py
+++ b/apps/users/context_processors.py
@@ -1,0 +1,6 @@
+from .forms import LoginForm
+
+
+def login_form(request):
+    """Provide a login form instance for use in templates."""
+    return {'login_form': LoginForm()}

--- a/apps/users/views/follow.py
+++ b/apps/users/views/follow.py
@@ -2,6 +2,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404, redirect, render
 from django.http import JsonResponse
+from django.contrib import messages
 from django.contrib.auth.models import User
 
 from apps.clubs.models import Club, Reseña, ClubPost
@@ -21,11 +22,15 @@ def toggle_follow(request, model, object_id):
     if not created:
         follow.delete()
         following = False
+        msg = 'Has dejado de seguir este club.'
     else:
         following = True
+        msg = 'Ahora sigues este club.'
 
     if request.headers.get('x-requested-with') == 'XMLHttpRequest':
-        return JsonResponse({'following': following})
+        return JsonResponse({'following': following, 'message': msg})
+
+    messages.success(request, msg)
 
     return redirect(request.META.get('HTTP_REFERER', '/'))
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -100,6 +100,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'django.template.context_processors.static',
+                'apps.users.context_processors.login_form',
             ],
         },
     },

--- a/static/js/share-like.js
+++ b/static/js/share-like.js
@@ -10,8 +10,17 @@ document.addEventListener('DOMContentLoaded', () => {
           headers: { 'X-CSRFToken': csrftoken },
           credentials: 'same-origin'
         });
+        if (res.redirected) {
+          const modal = new bootstrap.Modal(document.getElementById('loginModal'));
+          modal.show();
+          return;
+        }
         if (res.ok) {
-          heart.classList.toggle('liked');
+          const data = await res.json();
+          heart.classList.toggle('liked', data.following);
+          if (data.message) {
+            showToast(data.message);
+          }
         }
       } catch (err) {
         console.error(err);
@@ -19,3 +28,19 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 });
+
+function showToast(message) {
+  let container = document.querySelector('.toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'toast-container position-fixed top-0 end-0 p-3';
+    document.body.appendChild(container);
+  }
+  const toast = document.createElement('div');
+  toast.className = 'toast bg-black text-bg-success border-0 mb-2';
+  toast.role = 'alert';
+  toast.innerHTML = `<div class="d-flex"><div class="toast-body">${message}</div>` +
+                    `<button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button></div>`;
+  container.appendChild(toast);
+  new bootstrap.Toast(toast).show();
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,7 @@
 
     {% include 'partials/_header.html' %}
     {% include 'partials/_messages.html' %}
+    {% include 'partials/_login_modal.html' %}
       {% if request.path != '/' %}
         {% include 'partials/_search_modal.html' %}
     {% endif %}

--- a/templates/partials/_login_modal.html
+++ b/templates/partials/_login_modal.html
@@ -1,0 +1,17 @@
+<div class="modal fade" id="loginModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Iniciar Sesión</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form method="post" action="{% url 'login' %}">
+          {% csrf_token %}
+          {{ login_form.as_p }}
+          <button type="submit" class="btn btn-dark w-100">Iniciar Sesión</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add a context processor to provide a login form everywhere
- include login modal in base template
- show toast messages when following/unfollowing
- open login modal on follow when not logged in

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684cf0b1e69c8321a5f280b0aa618fd7