### PR TITLE
Add login modal for unauthenticated users

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -26,7 +26,11 @@
 
     {% block content %}{% endblock %}
 
-    {% include 'partials/_footer.html' %} 
+      {% include 'partials/_footer.html' %}
+
+      {% if not user.is_authenticated %}
+        {% include 'partials/_login_modal.html' %}
+      {% endif %}
 
 <script src="{% static 'js/search-results.js' %}"></script>
 <script src="{% static 'js/geolocator.js' %}"></script>


### PR DESCRIPTION
## Summary
- include the login modal partial in `base.html`
- load the modal only when the visitor isn't authenticated

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cf7d9b0648321a32d6090723ffebe