### PR TITLE
Implement follow button fill transition and share menu

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -299,10 +299,37 @@ textarea.form-control {
 }
 
 #club-heart.liked path {
-  fill: #fff;
-  stroke: #fff;
-
+  fill: #fff !important;
+  stroke: #fff !important;
 }
-#club-share  path, #club-heart path { 
-  stroke: #fff;
+
+#club-share path,
+#club-heart path {
+  stroke: #fff !important;
+}
+
+.share-menu {
+  position: absolute;
+  right: 0;
+  top: 35px;
+  display: none;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: rgba(0, 0, 0, 0.8);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.share-menu.show {
+  display: flex;
+}
+
+.share-menu a,
+.share-menu button {
+  color: #fff;
+  background: none;
+  border: none;
+  text-decoration: none;
+  font-size: 0.875rem;
+  text-align: left;
 }

--- a/static/js/share-like.js
+++ b/static/js/share-like.js
@@ -27,6 +27,50 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+
+  const shareBtn = document.getElementById('club-share');
+  if (shareBtn) {
+    let menu = null;
+    shareBtn.addEventListener('click', async () => {
+      if (navigator.share) {
+        try {
+          await navigator.share({
+            title: document.title,
+            url: window.location.href
+          });
+        } catch (err) {
+          console.error('Share failed:', err);
+        }
+        return;
+      }
+
+      if (!menu) {
+        menu = document.createElement('div');
+        menu.className = 'share-menu';
+        const url = encodeURIComponent(window.location.href);
+        const title = encodeURIComponent(document.title);
+        menu.innerHTML = `
+          <a href="https://www.facebook.com/sharer/sharer.php?u=${url}" target="_blank">Facebook</a>
+          <a href="https://twitter.com/intent/tweet?url=${url}&text=${title}" target="_blank">Twitter</a>
+          <a href="https://wa.me/?text=${url}" target="_blank">WhatsApp</a>
+          <button type="button" class="copy-link">Copiar enlace</button>
+          <a href="mailto:?subject=${title}&body=${url}">Email</a>
+        `;
+        shareBtn.parentElement.appendChild(menu);
+        menu.querySelector('.copy-link').addEventListener('click', () => {
+          navigator.clipboard.writeText(window.location.href);
+          showToast('Enlace copiado');
+        });
+      }
+      menu.classList.toggle('show');
+    });
+
+    document.addEventListener('click', (e) => {
+      if (menu && !shareBtn.contains(e.target) && !menu.contains(e.target)) {
+        menu.classList.remove('show');
+      }
+    });
+  }
 });
 
 function showToast(message) {


### PR DESCRIPTION
## Summary
- add Web Share API/links handling to `#club-share`
- toggle heart fill via CSS with `!important`
- add styles for share menu dropdown

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cfd08ee8483218f6b85075a80dd6d