### PR TITLE
Add follow button transition

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -298,9 +298,13 @@ textarea.form-control {
   fill: none;
 }
 
+.gallery-actions svg path {
+  transition: fill 0.3s ease, stroke 0.3s ease;
+}
+
 #club-heart.liked path {
-  fill: #fff !important;
-  stroke: #fff !important;
+  fill: #e63946 !important;
+  stroke: #e63946 !important;
 }
 
 #club-share path,

--- a/static/js/share-like.js
+++ b/static/js/share-like.js
@@ -4,15 +4,23 @@ document.addEventListener('DOMContentLoaded', () => {
     heart.addEventListener('click', async () => {
       const url = heart.dataset.url;
       const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+
+      // Optimistic UI update
+      heart.classList.toggle('liked');
+
       try {
         const res = await fetch(url, {
           method: 'POST',
-          headers: { 'X-CSRFToken': csrftoken },
+          headers: {
+            'X-CSRFToken': csrftoken,
+            'X-Requested-With': 'XMLHttpRequest'
+          },
           credentials: 'same-origin'
         });
         if (res.redirected) {
           const modal = new bootstrap.Modal(document.getElementById('loginModal'));
           modal.show();
+          heart.classList.toggle('liked'); // revert optimistic update
           return;
         }
         if (res.ok) {
@@ -21,9 +29,12 @@ document.addEventListener('DOMContentLoaded', () => {
           if (data.message) {
             showToast(data.message);
           }
+        } else {
+          heart.classList.toggle('liked'); // revert on error
         }
       } catch (err) {
         console.error(err);
+        heart.classList.toggle('liked'); // revert on error
       }
     });
   }


### PR DESCRIPTION
## Summary
- animate heart color on the club profile page
- toggle follow state immediately for a smoother experience
- make the follow request via AJAX to avoid redirects

## Testing
- `python manage.py test apps.users.tests.test_follow.FollowTests.test_follow_and_unfollow_user` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684d696156cc832182a2e45a74bce51a