### PR TITLE
Fix share modal behavior

### DIFF
--- a/static/js/share-like.js
+++ b/static/js/share-like.js
@@ -41,44 +41,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const shareBtn = document.getElementById('club-share');
   if (shareBtn) {
-    let menu = null;
-    shareBtn.addEventListener('click', async () => {
-      if (navigator.share) {
-        try {
-          await navigator.share({
-            title: document.title,
-            url: window.location.href
-          });
-        } catch (err) {
-          console.error('Share failed:', err);
-        }
-        return;
-      }
-
-      if (!menu) {
-        menu = document.createElement('div');
-        menu.className = 'share-menu';
+    shareBtn.addEventListener('click', () => {
+      const modalEl = document.getElementById('shareProfileModal');
+      if (modalEl) {
         const url = encodeURIComponent(window.location.href);
         const title = encodeURIComponent(document.title);
-        menu.innerHTML = `
-          <a href="https://www.facebook.com/sharer/sharer.php?u=${url}" target="_blank">Facebook</a>
-          <a href="https://twitter.com/intent/tweet?url=${url}&text=${title}" target="_blank">Twitter</a>
-          <a href="https://wa.me/?text=${url}" target="_blank">WhatsApp</a>
-          <button type="button" class="copy-link">Copiar enlace</button>
-          <a href="mailto:?subject=${title}&body=${url}">Email</a>
-        `;
-        shareBtn.parentElement.appendChild(menu);
-        menu.querySelector('.copy-link').addEventListener('click', () => {
-          navigator.clipboard.writeText(window.location.href);
-          showToast('Enlace copiado');
-        });
-      }
-      menu.classList.toggle('show');
-    });
-
-    document.addEventListener('click', (e) => {
-      if (menu && !shareBtn.contains(e.target) && !menu.contains(e.target)) {
-        menu.classList.remove('show');
+        modalEl.querySelector('#share-email').href = `mailto:?subject=${title}&body=${url}`;
+        modalEl.querySelector('#share-whatsapp').href = `https://wa.me/?text=${title}%20${url}`;
+        modalEl.querySelector('#share-messenger').href = `fb-messenger://share/?link=${url}`;
+        modalEl.querySelector('#share-facebook').href = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
+        modalEl.querySelector('#share-instagram').href = `https://www.instagram.com/?url=${url}`;
+        modalEl.querySelector('#share-telegram').href = `https://t.me/share/url?url=${url}&text=${title}`;
+        modalEl.querySelector('#share-x').href = `https://twitter.com/intent/tweet?url=${url}&text=${title}`;
+        new bootstrap.Modal(modalEl).show();
       }
     });
   }

--- a/static/js/share-modal.js
+++ b/static/js/share-modal.js
@@ -1,30 +1,31 @@
+// Generic share modal functionality for profile and club pages
+
 document.addEventListener('DOMContentLoaded', () => {
-  const shareBtn = document.getElementById('profile-share');
   const modalEl = document.getElementById('shareProfileModal');
-  const copyBtn = modalEl ? modalEl.querySelector('.share-copy') : null;
-  const embedBtn = modalEl ? modalEl.querySelector('.share-embed') : null;
+  if (!modalEl) return;
+
+  const triggers = document.querySelectorAll('#profile-share, #club-share');
+  const copyBtn = modalEl.querySelector('.share-copy');
+  const embedBtn = modalEl.querySelector('.share-embed');
 
   function setLinks() {
     const url = encodeURIComponent(window.location.href);
     const title = encodeURIComponent(document.title);
-    if (modalEl) {
-      modalEl.querySelector('#share-email').href = `mailto:?subject=${title}&body=${url}`;
-      modalEl.querySelector('#share-whatsapp').href = `https://wa.me/?text=${title}%20${url}`;
-      modalEl.querySelector('#share-messenger').href = `fb-messenger://share/?link=${url}`;
-      modalEl.querySelector('#share-facebook').href = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
-      modalEl.querySelector('#share-instagram').href = `https://www.instagram.com/?url=${url}`;
-      modalEl.querySelector('#share-telegram').href = `https://t.me/share/url?url=${url}&text=${title}`;
-      modalEl.querySelector('#share-x').href = `https://twitter.com/intent/tweet?url=${url}&text=${title}`;
-    }
+    modalEl.querySelector('#share-email').href = `mailto:?subject=${title}&body=${url}`;
+    modalEl.querySelector('#share-whatsapp').href = `https://wa.me/?text=${title}%20${url}`;
+    modalEl.querySelector('#share-messenger').href = `fb-messenger://share/?link=${url}`;
+    modalEl.querySelector('#share-facebook').href = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
+    modalEl.querySelector('#share-instagram').href = `https://www.instagram.com/?url=${url}`;
+    modalEl.querySelector('#share-telegram').href = `https://t.me/share/url?url=${url}&text=${title}`;
+    modalEl.querySelector('#share-x').href = `https://twitter.com/intent/tweet?url=${url}&text=${title}`;
   }
 
-  if (shareBtn) {
-    shareBtn.addEventListener('click', () => {
+  triggers.forEach(btn => {
+    btn.addEventListener('click', () => {
       setLinks();
-      const modal = new bootstrap.Modal(modalEl);
-      modal.show();
+      new bootstrap.Modal(modalEl).show();
     });
-  }
+  });
 
   if (copyBtn) {
     copyBtn.addEventListener('click', () => {

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -437,12 +437,14 @@
     </div>
   </div>
 </div>
+{% include 'partials/_share_profile_modal.html' %}
 {% include 'partials/_register_modal.html' %}
 <script src="{% static 'js/review-filter.js' %}"></script>
 <script src="{% static 'js/slides.js' %}"></script>
 <script src="{% static 'js/rating.js' %}"></script>
 
 <script src="{% static 'js/share-like.js' %}"></script>
+<script src="{% static 'js/share-modal.js' %}"></script>
 
 <script src="{% static 'js/gallery-slideshow.js' %}"></script>
 {% endblock %}

--- a/templates/users/profile_detail.html
+++ b/templates/users/profile_detail.html
@@ -37,5 +37,5 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="{% static 'js/share-profile.js' %}"></script>
+<script src="{% static 'js/share-modal.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add new shared modal script for profiles and clubs
- switch to new modal script in templates
- update club share JS to open the modal
- remove old modal script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684d801779848321b9601c5ae892ddc8