### PR TITLE
Fix share modal behavior

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -311,29 +311,3 @@ textarea.form-control {
 #club-heart path {
   stroke: #fff !important;
 }
-
-.share-menu {
-  position: absolute;
-  right: 0;
-  top: 35px;
-  display: none;
-  flex-direction: column;
-  gap: 0.25rem;
-  background: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
-  border-radius: 0.25rem;
-}
-
-.share-menu.show {
-  display: flex;
-}
-
-.share-menu a,
-.share-menu button {
-  color: #fff;
-  background: none;
-  border: none;
-  text-decoration: none;
-  font-size: 0.875rem;
-  text-align: left;
-}

--- a/static/js/share-like.js
+++ b/static/js/share-like.js
@@ -41,44 +41,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const shareBtn = document.getElementById('club-share');
   if (shareBtn) {
-    let menu = null;
-    shareBtn.addEventListener('click', async () => {
-      if (navigator.share) {
-        try {
-          await navigator.share({
-            title: document.title,
-            url: window.location.href
-          });
-        } catch (err) {
-          console.error('Share failed:', err);
-        }
-        return;
-      }
-
-      if (!menu) {
-        menu = document.createElement('div');
-        menu.className = 'share-menu';
+    shareBtn.addEventListener('click', () => {
+      const modalEl = document.getElementById('shareProfileModal');
+      if (modalEl) {
         const url = encodeURIComponent(window.location.href);
         const title = encodeURIComponent(document.title);
-        menu.innerHTML = `
-          <a href="https://www.facebook.com/sharer/sharer.php?u=${url}" target="_blank">Facebook</a>
-          <a href="https://twitter.com/intent/tweet?url=${url}&text=${title}" target="_blank">Twitter</a>
-          <a href="https://wa.me/?text=${url}" target="_blank">WhatsApp</a>
-          <button type="button" class="copy-link">Copiar enlace</button>
-          <a href="mailto:?subject=${title}&body=${url}">Email</a>
-        `;
-        shareBtn.parentElement.appendChild(menu);
-        menu.querySelector('.copy-link').addEventListener('click', () => {
-          navigator.clipboard.writeText(window.location.href);
-          showToast('Enlace copiado');
-        });
-      }
-      menu.classList.toggle('show');
-    });
-
-    document.addEventListener('click', (e) => {
-      if (menu && !shareBtn.contains(e.target) && !menu.contains(e.target)) {
-        menu.classList.remove('show');
+        modalEl.querySelector('#share-email').href = `mailto:?subject=${title}&body=${url}`;
+        modalEl.querySelector('#share-whatsapp').href = `https://wa.me/?text=${title}%20${url}`;
+        modalEl.querySelector('#share-messenger').href = `fb-messenger://share/?link=${url}`;
+        modalEl.querySelector('#share-facebook').href = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
+        modalEl.querySelector('#share-instagram').href = `https://www.instagram.com/?url=${url}`;
+        modalEl.querySelector('#share-telegram').href = `https://t.me/share/url?url=${url}&text=${title}`;
+        modalEl.querySelector('#share-x').href = `https://twitter.com/intent/tweet?url=${url}&text=${title}`;
+        new bootstrap.Modal(modalEl).show();
       }
     });
   }

--- a/static/js/share-modal.js
+++ b/static/js/share-modal.js
@@ -1,30 +1,31 @@
+// Generic share modal functionality for profile and club pages
+
 document.addEventListener('DOMContentLoaded', () => {
-  const shareBtn = document.getElementById('profile-share');
   const modalEl = document.getElementById('shareProfileModal');
-  const copyBtn = modalEl ? modalEl.querySelector('.share-copy') : null;
-  const embedBtn = modalEl ? modalEl.querySelector('.share-embed') : null;
+  if (!modalEl) return;
+
+  const triggers = document.querySelectorAll('#profile-share, #club-share');
+  const copyBtn = modalEl.querySelector('.share-copy');
+  const embedBtn = modalEl.querySelector('.share-embed');
 
   function setLinks() {
     const url = encodeURIComponent(window.location.href);
     const title = encodeURIComponent(document.title);
-    if (modalEl) {
-      modalEl.querySelector('#share-email').href = `mailto:?subject=${title}&body=${url}`;
-      modalEl.querySelector('#share-whatsapp').href = `https://wa.me/?text=${title}%20${url}`;
-      modalEl.querySelector('#share-messenger').href = `fb-messenger://share/?link=${url}`;
-      modalEl.querySelector('#share-facebook').href = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
-      modalEl.querySelector('#share-instagram').href = `https://www.instagram.com/?url=${url}`;
-      modalEl.querySelector('#share-telegram').href = `https://t.me/share/url?url=${url}&text=${title}`;
-      modalEl.querySelector('#share-x').href = `https://twitter.com/intent/tweet?url=${url}&text=${title}`;
-    }
+    modalEl.querySelector('#share-email').href = `mailto:?subject=${title}&body=${url}`;
+    modalEl.querySelector('#share-whatsapp').href = `https://wa.me/?text=${title}%20${url}`;
+    modalEl.querySelector('#share-messenger').href = `fb-messenger://share/?link=${url}`;
+    modalEl.querySelector('#share-facebook').href = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
+    modalEl.querySelector('#share-instagram').href = `https://www.instagram.com/?url=${url}`;
+    modalEl.querySelector('#share-telegram').href = `https://t.me/share/url?url=${url}&text=${title}`;
+    modalEl.querySelector('#share-x').href = `https://twitter.com/intent/tweet?url=${url}&text=${title}`;
   }
 
-  if (shareBtn) {
-    shareBtn.addEventListener('click', () => {
+  triggers.forEach(btn => {
+    btn.addEventListener('click', () => {
       setLinks();
-      const modal = new bootstrap.Modal(modalEl);
-      modal.show();
+      new bootstrap.Modal(modalEl).show();
     });
-  }
+  });
 
   if (copyBtn) {
     copyBtn.addEventListener('click', () => {

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -437,12 +437,14 @@
     </div>
   </div>
 </div>
+{% include 'partials/_share_profile_modal.html' %}
 {% include 'partials/_register_modal.html' %}
 <script src="{% static 'js/review-filter.js' %}"></script>
 <script src="{% static 'js/slides.js' %}"></script>
 <script src="{% static 'js/rating.js' %}"></script>
 
 <script src="{% static 'js/share-like.js' %}"></script>
+<script src="{% static 'js/share-modal.js' %}"></script>
 
 <script src="{% static 'js/gallery-slideshow.js' %}"></script>
 {% endblock %}

--- a/templates/partials/_share_profile_modal.html
+++ b/templates/partials/_share_profile_modal.html
@@ -6,16 +6,61 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <ul class="list-unstyled mb-0">
-          <li><button type="button" class="btn btn-link share-copy p-0">Copiar enlace</button></li>
-          <li><a id="share-email" class="btn btn-link p-0" target="_blank">Correo electrónico</a></li>
-          <li><a id="share-whatsapp" class="btn btn-link p-0" target="_blank">WhatsApp</a></li>
-          <li><a id="share-messenger" class="btn btn-link p-0" target="_blank">Messenger</a></li>
-          <li><a id="share-facebook" class="btn btn-link p-0" target="_blank">Facebook</a></li>
-          <li><a id="share-instagram" class="btn btn-link p-0" target="_blank">Instagram</a></li>
-          <li><a id="share-telegram" class="btn btn-link p-0" target="_blank">Telegram</a></li>
-          <li><a id="share-x" class="btn btn-link p-0" target="_blank">X</a></li>
-          <li><button type="button" class="btn btn-link share-embed p-0">Insertar</button></li>
+        <ul class="list-unstyled row row-cols-2 mb-0">
+          <li class="col d-flex align-items-center mb-2">
+            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+              <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#link-45deg"/>
+            </svg>
+            <button type="button" class="btn btn-link share-copy p-0">Copiar enlace</button>
+          </li>
+          <li class="col d-flex align-items-center mb-2">
+            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+              <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#envelope-fill"/>
+            </svg>
+            <a id="share-email" class="btn btn-link p-0" target="_blank">Correo electrónico</a>
+          </li>
+          <li class="col d-flex align-items-center mb-2">
+            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+              <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#whatsapp"/>
+            </svg>
+            <a id="share-whatsapp" class="btn btn-link p-0" target="_blank">WhatsApp</a>
+          </li>
+          <li class="col d-flex align-items-center mb-2">
+            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+              <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#messenger"/>
+            </svg>
+            <a id="share-messenger" class="btn btn-link p-0" target="_blank">Messenger</a>
+          </li>
+          <li class="col d-flex align-items-center mb-2">
+            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+              <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#facebook"/>
+            </svg>
+            <a id="share-facebook" class="btn btn-link p-0" target="_blank">Facebook</a>
+          </li>
+          <li class="col d-flex align-items-center mb-2">
+            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+              <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#instagram"/>
+            </svg>
+            <a id="share-instagram" class="btn btn-link p-0" target="_blank">Instagram</a>
+          </li>
+          <li class="col d-flex align-items-center mb-2">
+            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+              <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#telegram"/>
+            </svg>
+            <a id="share-telegram" class="btn btn-link p-0" target="_blank">Telegram</a>
+          </li>
+          <li class="col d-flex align-items-center mb-2">
+            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+              <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#twitter-x"/>
+            </svg>
+            <a id="share-x" class="btn btn-link p-0" target="_blank">X</a>
+          </li>
+          <li class="col d-flex align-items-center mb-2">
+            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+              <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#code-slash"/>
+            </svg>
+            <button type="button" class="btn btn-link share-embed p-0">Insertar</button>
+          </li>
         </ul>
       </div>
     </div>

--- a/templates/users/profile_detail.html
+++ b/templates/users/profile_detail.html
@@ -37,5 +37,5 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="{% static 'js/share-profile.js' %}"></script>
+<script src="{% static 'js/share-modal.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add new shared modal script for profiles and clubs
- switch to new modal script in templates
- update club share JS to open the modal
- remove old modal script
- layout share modal in two columns with icons
- drop unused CSS for the old popover menu

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684d801779848321b9601c5ae892ddc8