### PR TITLE
Add black styling to share modal icons

### DIFF
--- a/templates/partials/_share_profile_modal.html
+++ b/templates/partials/_share_profile_modal.html
@@ -8,58 +8,58 @@
       <div class="modal-body">
         <ul class="list-unstyled row row-cols-2 mb-0">
           <li class="col d-flex align-items-center mb-2">
-            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+            <svg width="16" height="16" fill="currentColor" class="bi text-black" style="margin-right:10px;">
               <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#link-45deg"/>
             </svg>
-            <button type="button" class="btn btn-link share-copy p-0">Copiar enlace</button>
+            <button type="button" class="btn btn-link text-black share-copy p-0">Copiar enlace</button>
           </li>
           <li class="col d-flex align-items-center mb-2">
-            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+            <svg width="16" height="16" fill="currentColor" class="bi text-black" style="margin-right:10px;">
               <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#envelope-fill"/>
             </svg>
-            <a id="share-email" class="btn btn-link p-0" target="_blank">Correo electrónico</a>
+            <a id="share-email" class="btn btn-link text-black p-0" target="_blank">Correo electrónico</a>
           </li>
           <li class="col d-flex align-items-center mb-2">
-            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+            <svg width="16" height="16" fill="currentColor" class="bi text-black" style="margin-right:10px;">
               <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#whatsapp"/>
             </svg>
-            <a id="share-whatsapp" class="btn btn-link p-0" target="_blank">WhatsApp</a>
+            <a id="share-whatsapp" class="btn btn-link text-black p-0" target="_blank">WhatsApp</a>
           </li>
           <li class="col d-flex align-items-center mb-2">
-            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+            <svg width="16" height="16" fill="currentColor" class="bi text-black" style="margin-right:10px;">
               <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#messenger"/>
             </svg>
-            <a id="share-messenger" class="btn btn-link p-0" target="_blank">Messenger</a>
+            <a id="share-messenger" class="btn btn-link text-black p-0" target="_blank">Messenger</a>
           </li>
           <li class="col d-flex align-items-center mb-2">
-            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+            <svg width="16" height="16" fill="currentColor" class="bi text-black" style="margin-right:10px;">
               <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#facebook"/>
             </svg>
-            <a id="share-facebook" class="btn btn-link p-0" target="_blank">Facebook</a>
+            <a id="share-facebook" class="btn btn-link text-black p-0" target="_blank">Facebook</a>
           </li>
           <li class="col d-flex align-items-center mb-2">
-            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+            <svg width="16" height="16" fill="currentColor" class="bi text-black" style="margin-right:10px;">
               <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#instagram"/>
             </svg>
-            <a id="share-instagram" class="btn btn-link p-0" target="_blank">Instagram</a>
+            <a id="share-instagram" class="btn btn-link text-black p-0" target="_blank">Instagram</a>
           </li>
           <li class="col d-flex align-items-center mb-2">
-            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+            <svg width="16" height="16" fill="currentColor" class="bi text-black" style="margin-right:10px;">
               <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#telegram"/>
             </svg>
-            <a id="share-telegram" class="btn btn-link p-0" target="_blank">Telegram</a>
+            <a id="share-telegram" class="btn btn-link text-black p-0" target="_blank">Telegram</a>
           </li>
           <li class="col d-flex align-items-center mb-2">
-            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+            <svg width="16" height="16" fill="currentColor" class="bi text-black" style="margin-right:10px;">
               <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#twitter-x"/>
             </svg>
-            <a id="share-x" class="btn btn-link p-0" target="_blank">X</a>
+            <a id="share-x" class="btn btn-link text-black p-0" target="_blank">X</a>
           </li>
           <li class="col d-flex align-items-center mb-2">
-            <svg width="16" height="16" fill="currentColor" class="bi" style="margin-right:10px;">
+            <svg width="16" height="16" fill="currentColor" class="bi text-black" style="margin-right:10px;">
               <use xlink:href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/bootstrap-icons.svg#code-slash"/>
             </svg>
-            <button type="button" class="btn btn-link share-embed p-0">Insertar</button>
+            <button type="button" class="btn btn-link text-black share-embed p-0">Insertar</button>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- ensure every share option uses black text and icons in the share modal

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684d85df2254832193412361814b5b07