### PR TITLE
Fix modal overlay persisting

### DIFF
--- a/static/js/modal-fix.js
+++ b/static/js/modal-fix.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', function() {
+  document.querySelectorAll('.modal').forEach(function(modalEl) {
+    modalEl.addEventListener('hidden.bs.modal', function () {
+      document.querySelectorAll('.modal-backdrop').forEach(b => b.remove());
+      document.body.classList.remove('modal-open');
+      document.body.style.removeProperty('padding-right');
+    });
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,6 +38,7 @@
 <script src="{% static 'js/user-dropdown.js' %}"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{% static 'js/page-loader.js' %}"></script>
+<script src="{% static 'js/modal-fix.js' %}"></script>
 {% block extra_js %}{% endblock %}
 
 </body>


### PR DESCRIPTION
## Summary
- add `modal-fix.js` to clean up leftover modal backdrops
- include new script in `base.html`

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684dee9a3ed48321bdbf8dac1a077c06