### PR TITLE
Add clear button support to search form

### DIFF
--- a/static/css/_search-form.css
+++ b/static/css/_search-form.css
@@ -10,7 +10,15 @@
 
 }
 
-#main-search-form > input {
+#main-search-form .form-field {
+    position: relative;
+    flex: 1;
+    height: 100%;
+    display: flex;
+    align-items: center;
+}
+
+#main-search-form .form-field input {
     height: 100%;
     outline: none;
     background: none;
@@ -20,8 +28,24 @@
     font-size: 1rem;
 }
 
-#main-search-form > input:focus {
+#main-search-form .form-field input:focus {
     box-shadow: none;
+}
+
+#main-search-form .clear-btn {
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 1rem;
+    display: none;
+}
+
+#main-search-form .form-field input:not(:placeholder-shown) + .clear-btn {
+    display: block;
 }
 
 .custom-dropdown {

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,6 +38,7 @@
 <script src="{% static 'js/user-dropdown.js' %}"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{% static 'js/page-loader.js' %}"></script>
+<script src="{% static 'js/clear-input.js' %}"></script>
 {% block extra_js %}{% endblock %}
 
 </body>

--- a/templates/partials/_search_form.html
+++ b/templates/partials/_search_form.html
@@ -4,15 +4,18 @@
       style="max-width:  600px;  margin: 0 auto; z-index:10;"
       > 
  
- 
-    <input 
-    type="text"
-    name="q"
-    id="search-input"
-    class="form-control border-0"
-    placeholder="Buscar por ciudad o nombre del club"
-    autocomplete="off"
->
+
+    <div class="form-field flex-grow-1">
+        <input
+        type="text"
+        name="q"
+        id="search-input"
+        class="form-control border-0"
+        placeholder="Buscar por ciudad o nombre del club"
+        autocomplete="off"
+        >
+        <button type="button" class="clear-btn">&times;</button>
+    </div>
 
  
 


### PR DESCRIPTION
## Summary
- enable clear input button in the search form
- style the new clear button
- load `clear-input.js` globally so it works on the search form

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684df0f564108321842cbc816834bc7d