### PR TITLE
Fix dashboard module import

### DIFF
--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -2,7 +2,6 @@
 
 from django.urls import path
 from .views import (
-    dashboard,
     search,
     public,
     post_create,
@@ -11,7 +10,7 @@ from .views import (
     book_clase,
     cancel_booking,
 )
-from .views import dashboard as dash_views
+import apps.clubs.views.dashboard as dash_views
 
 urlpatterns = [
     path('resultados/', search.search_results, name='search_results'),


### PR DESCRIPTION
## Summary
- fix import for dashboard module in clubs urls

## Testing
- `python -m py_compile apps/clubs/urls.py`
- `pytest -q` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_685191379aec8321abe2a4980c3dffef