### PR TITLE
Add CSRF trusted origins

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -49,6 +49,12 @@ if _hosts:
 else:
     ALLOWED_HOSTS = []
 
+_origins = os.environ.get("CSRF_TRUSTED_ORIGINS")
+if _origins:
+    CSRF_TRUSTED_ORIGINS = [o.strip() for o in _origins.split(",") if o.strip()]
+else:
+    CSRF_TRUSTED_ORIGINS = []
+
 
 INSTALLED_APPS = [
     'django.contrib.admin',

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,12 @@ python manage.py migrate
 ```bash
 python manage.py runserver
 ```
+   Si ejecutas el servidor desde un dominio distinto (por ejemplo, en
+   servicios en la nube o IDEs remotos), asegúrate de incluir esa URL en la
+   variable de entorno `CSRF_TRUSTED_ORIGINS`:
+```bash
+export CSRF_TRUSTED_ORIGINS="https://tu-dominio.example.com"
+```
 4. Configura los proveedores sociales (Google o Facebook) en el panel de
    administración dentro de "Social applications". Guarda las credenciales
    correspondientes y ejecuta `python manage.py migrate` para aplicar las


### PR DESCRIPTION
## Summary
- allow configuration of `CSRF_TRUSTED_ORIGINS` via env var
- document the new environment variable in the README

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6851939135f083218d0c9172904e589d