### PR TITLE
Enable club management updates with notifications

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -119,3 +119,25 @@ class CancelBookingForm(forms.Form):
     """Simple form used to confirm cancellation."""
     pass
 
+
+class ClubPhotoForm(forms.ModelForm):
+    class Meta:
+        model = models.ClubPhoto
+        fields = ['image']
+
+
+class HorarioForm(forms.ModelForm):
+    class Meta:
+        model = models.Horario
+        fields = ['dia', 'hora_inicio', 'hora_fin']
+        widgets = {
+            'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
+            'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
+        }
+
+
+class CompetidorForm(forms.ModelForm):
+    class Meta:
+        model = models.Competidor
+        fields = ['nombre', 'victorias', 'derrotas', 'empates', 'titulos']
+

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -16,6 +16,14 @@ from apps.clubs.views.dashboard import (
     clase_create,
     clase_update,
     clase_delete,
+    photo_upload,
+    photo_delete,
+    horario_create,
+    horario_update,
+    horario_delete,
+    competidor_create,
+    competidor_update,
+    competidor_delete,
 )
 
 urlpatterns = [
@@ -27,6 +35,17 @@ urlpatterns = [
     path('<slug:slug>/clase/nueva/', clase_create, name='clase_create'),
     path('clase/<int:pk>/editar/', clase_update, name='clase_update'),
     path('clase/<int:pk>/eliminar/', clase_delete, name='clase_delete'),
+
+    path('<slug:slug>/foto/nueva/', photo_upload, name='clubphoto_upload'),
+    path('foto/<int:pk>/eliminar/', photo_delete, name='clubphoto_delete'),
+
+    path('<slug:slug>/horario/nuevo/', horario_create, name='horario_create'),
+    path('horario/<int:pk>/editar/', horario_update, name='horario_update'),
+    path('horario/<int:pk>/eliminar/', horario_delete, name='horario_delete'),
+
+    path('<slug:slug>/competidor/nuevo/', competidor_create, name='competidor_create'),
+    path('competidor/<int:pk>/editar/', competidor_update, name='competidor_update'),
+    path('competidor/<int:pk>/eliminar/', competidor_delete, name='competidor_delete'),
 
     path('<slug:slug>/posts/nuevo/', post_create, name='clubpost_create'),
     path('posts/<int:pk>/editar/', post_update, name='clubpost_update'),

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -1,10 +1,26 @@
 from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 from django.http import HttpResponseForbidden
 from django.db.models import Q
 
-from ..models import Club, Clase, ClubPost, Booking
-from ..forms import ClubForm, ClaseForm, ClubPostForm
+from ..models import (
+    Club,
+    Clase,
+    ClubPost,
+    Booking,
+    ClubPhoto,
+    Horario,
+    Competidor,
+)
+from ..forms import (
+    ClubForm,
+    ClaseForm,
+    ClubPostForm,
+    ClubPhotoForm,
+    HorarioForm,
+    CompetidorForm,
+)
 from ..permissions import has_club_permission
 
 
@@ -35,6 +51,7 @@ def club_edit(request, slug):
         form = ClubForm(request.POST, request.FILES, instance=club)
         if form.is_valid():
             form.save()
+            messages.success(request, 'Club actualizado correctamente.')
             return redirect('club_dashboard', slug=club.slug)
     else:
         form = ClubForm(instance=club)
@@ -52,6 +69,7 @@ def clase_create(request, slug):
             clase = form.save(commit=False)
             clase.club = club
             clase.save()
+            messages.success(request, 'Clase creada correctamente.')
             return redirect('club_dashboard', slug=club.slug)
     else:
         form = ClaseForm()
@@ -67,6 +85,7 @@ def clase_update(request, pk):
         form = ClaseForm(request.POST, instance=clase)
         if form.is_valid():
             form.save()
+            messages.success(request, 'Clase actualizada correctamente.')
             return redirect('club_dashboard', slug=clase.club.slug)
     else:
         form = ClaseForm(instance=clase)
@@ -81,5 +100,141 @@ def clase_delete(request, pk):
     if request.method == 'POST':
         slug = clase.club.slug
         clase.delete()
+        messages.success(request, 'Clase eliminada correctamente.')
         return redirect('club_dashboard', slug=slug)
     return render(request, 'clubs/clase_confirm_delete.html', {'clase': clase})
+
+
+@login_required
+def photo_upload(request, slug):
+    club = get_object_or_404(Club, slug=slug)
+    if not has_club_permission(request.user, club):
+        return HttpResponseForbidden()
+    if request.method == 'POST':
+        form = ClubPhotoForm(request.POST, request.FILES)
+        if form.is_valid():
+            photo = form.save(commit=False)
+            photo.club = club
+            photo.save()
+            messages.success(request, 'Foto añadida correctamente.')
+            return redirect('club_dashboard', slug=club.slug)
+    else:
+        form = ClubPhotoForm()
+    return render(request, 'clubs/photo_form.html', {'form': form, 'club': club})
+
+
+@login_required
+def photo_delete(request, pk):
+    photo = get_object_or_404(ClubPhoto, pk=pk)
+    if not has_club_permission(request.user, photo.club):
+        return HttpResponseForbidden()
+    if request.method == 'POST':
+        slug = photo.club.slug
+        photo.delete()
+        messages.success(request, 'Foto eliminada correctamente.')
+        return redirect('club_dashboard', slug=slug)
+    return render(request, 'clubs/photo_confirm_delete.html', {'photo': photo})
+
+
+@login_required
+def horario_create(request, slug):
+    club = get_object_or_404(Club, slug=slug)
+    if not has_club_permission(request.user, club):
+        return HttpResponseForbidden()
+    if request.method == 'POST':
+        form = HorarioForm(request.POST)
+        if form.is_valid():
+            horario = form.save(commit=False)
+            horario.club = club
+            horario.save()
+            messages.success(request, 'Horario añadido correctamente.')
+            return redirect('club_dashboard', slug=club.slug)
+    else:
+        form = HorarioForm()
+    return render(request, 'clubs/horario_form.html', {'form': form, 'club': club})
+
+
+@login_required
+def horario_update(request, pk):
+    horario = get_object_or_404(Horario, pk=pk)
+    if not has_club_permission(request.user, horario.club):
+        return HttpResponseForbidden()
+    if request.method == 'POST':
+        form = HorarioForm(request.POST, instance=horario)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Horario actualizado correctamente.')
+            return redirect('club_dashboard', slug=horario.club.slug)
+    else:
+        form = HorarioForm(instance=horario)
+    return render(request, 'clubs/horario_form.html', {
+        'form': form,
+        'club': horario.club,
+        'horario': horario,
+    })
+
+
+@login_required
+def horario_delete(request, pk):
+    horario = get_object_or_404(Horario, pk=pk)
+    if not has_club_permission(request.user, horario.club):
+        return HttpResponseForbidden()
+    if request.method == 'POST':
+        slug = horario.club.slug
+        horario.delete()
+        messages.success(request, 'Horario eliminado correctamente.')
+        return redirect('club_dashboard', slug=slug)
+    return render(request, 'clubs/horario_confirm_delete.html', {'horario': horario})
+
+
+@login_required
+def competidor_create(request, slug):
+    club = get_object_or_404(Club, slug=slug)
+    if not has_club_permission(request.user, club):
+        return HttpResponseForbidden()
+    if request.method == 'POST':
+        form = CompetidorForm(request.POST)
+        if form.is_valid():
+            competidor = form.save(commit=False)
+            competidor.club = club
+            competidor.save()
+            messages.success(request, 'Competidor añadido correctamente.')
+            return redirect('club_dashboard', slug=club.slug)
+    else:
+        form = CompetidorForm()
+    return render(request, 'clubs/competidor_form.html', {'form': form, 'club': club})
+
+
+@login_required
+def competidor_update(request, pk):
+    competidor = get_object_or_404(Competidor, pk=pk)
+    if not has_club_permission(request.user, competidor.club):
+        return HttpResponseForbidden()
+    if request.method == 'POST':
+        form = CompetidorForm(request.POST, instance=competidor)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Competidor actualizado correctamente.')
+            return redirect('club_dashboard', slug=competidor.club.slug)
+    else:
+        form = CompetidorForm(instance=competidor)
+    return render(request, 'clubs/competidor_form.html', {
+        'form': form,
+        'club': competidor.club,
+        'competidor': competidor,
+    })
+
+
+@login_required
+def competidor_delete(request, pk):
+    competidor = get_object_or_404(Competidor, pk=pk)
+    if not has_club_permission(request.user, competidor.club):
+        return HttpResponseForbidden()
+    if request.method == 'POST':
+        slug = competidor.club.slug
+        competidor.delete()
+        messages.success(request, 'Competidor eliminado correctamente.')
+        return redirect('club_dashboard', slug=slug)
+    return render(request, 'clubs/competidor_confirm_delete.html', {
+        'competidor': competidor,
+    })

--- a/apps/clubs/views/post.py
+++ b/apps/clubs/views/post.py
@@ -1,5 +1,6 @@
 from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 from django.http import HttpResponseForbidden
 
 from ..models import Club, ClubPost
@@ -18,6 +19,7 @@ def post_create(request, slug):
             post = form.save(commit=False)
             post.club = club
             post.save()
+            messages.success(request, 'Publicación creada correctamente.')
             return redirect('club_profile', slug=slug)
     else:
         form = ClubPostForm()
@@ -33,6 +35,7 @@ def post_update(request, pk):
         form = ClubPostForm(request.POST, instance=post)
         if form.is_valid():
             form.save()
+            messages.success(request, 'Publicación actualizada correctamente.')
             return redirect('club_profile', slug=post.club.slug)
     else:
         form = ClubPostForm(instance=post)
@@ -47,5 +50,6 @@ def post_delete(request, pk):
     if request.method == 'POST':
         slug = post.club.slug
         post.delete()
+        messages.success(request, 'Publicación eliminada correctamente.')
         return redirect('club_profile', slug=slug)
     return render(request, 'clubs/post_confirm_delete.html', {'post': post})

--- a/templates/clubs/competidor_confirm_delete.html
+++ b/templates/clubs/competidor_confirm_delete.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">Eliminar competidor</h1>
+  <p>¿Seguro que deseas eliminar este competidor?</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Eliminar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/clubs/competidor_form.html
+++ b/templates/clubs/competidor_form.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">{% if competidor %}Editar{% else %}Nuevo{% endif %} competidor</h1>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Guardar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -6,6 +6,9 @@
     <a href="{% url 'club_edit' club.slug %}" class="btn btn-primary btn-sm">Editar club</a>
     <a href="{% url 'clase_create' club.slug %}" class="btn btn-secondary btn-sm">Añadir clase</a>
     <a href="{% url 'clubpost_create' club.slug %}" class="btn btn-secondary btn-sm">Nueva publicación</a>
+    <a href="{% url 'clubphoto_upload' club.slug %}" class="btn btn-secondary btn-sm">Añadir foto</a>
+    <a href="{% url 'horario_create' club.slug %}" class="btn btn-secondary btn-sm">Añadir horario</a>
+    <a href="{% url 'competidor_create' club.slug %}" class="btn btn-secondary btn-sm">Añadir competidor</a>
   </p>
   <h2 class="h5 mt-4">Clases</h2>
   <ul>
@@ -35,6 +38,53 @@
     </li>
     {% empty %}
     <li>No hay posts.</li>
+    {% endfor %}
+  </ul>
+
+  <h2 class="h5 mt-4">Galería</h2>
+  <ul>
+    {% for photo in club.photos.all %}
+    <li>
+      <img src="{{ photo.image.url }}" style="width: 100px; height: 80px; object-fit: cover;">
+      <form method="post" action="{% url 'clubphoto_delete' photo.id %}" style="display:inline">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-link p-0">Eliminar</button>
+      </form>
+    </li>
+    {% empty %}
+    <li>No hay fotos.</li>
+    {% endfor %}
+  </ul>
+
+  <h2 class="h5 mt-4">Horarios</h2>
+  <ul>
+    {% for h in club.horarios.all %}
+    <li>
+      {{ h.get_dia_display }} {{ h.hora_inicio|time:'H:i' }} - {{ h.hora_fin|time:'H:i' }}
+      <a href="{% url 'horario_update' h.id %}">Editar</a>
+      <form method="post" action="{% url 'horario_delete' h.id %}" style="display:inline">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-link p-0">Eliminar</button>
+      </form>
+    </li>
+    {% empty %}
+    <li>No hay horarios.</li>
+    {% endfor %}
+  </ul>
+
+  <h2 class="h5 mt-4">Competidores</h2>
+  <ul>
+    {% for comp in club.competidores.all %}
+    <li>
+      {{ comp.nombre }} ({{ comp.victorias }}-{{ comp.derrotas }}-{{ comp.empates }})
+      <a href="{% url 'competidor_update' comp.id %}">Editar</a>
+      <form method="post" action="{% url 'competidor_delete' comp.id %}" style="display:inline">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-link p-0">Eliminar</button>
+      </form>
+    </li>
+    {% empty %}
+    <li>No hay competidores.</li>
     {% endfor %}
   </ul>
   <h2 class="h5 mt-4">Reservas</h2>

--- a/templates/clubs/horario_confirm_delete.html
+++ b/templates/clubs/horario_confirm_delete.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">Eliminar horario</h1>
+  <p>¿Seguro que deseas eliminar este horario?</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Eliminar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/clubs/horario_form.html
+++ b/templates/clubs/horario_form.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">{% if horario %}Editar{% else %}Nuevo{% endif %} horario</h1>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Guardar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/clubs/photo_confirm_delete.html
+++ b/templates/clubs/photo_confirm_delete.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">Eliminar foto</h1>
+  <p>¿Seguro que deseas eliminar esta foto?</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Eliminar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/clubs/photo_form.html
+++ b/templates/clubs/photo_form.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">Añadir foto</h1>
+  <form method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Guardar</button>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add forms for gallery photos, horarios and competitors
- notify users about club edits, class edits, schedule and competitor changes
- allow uploading/deleting photos and managing horarios and competidores
- display new sections in the dashboard template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_685202ef19948321a565c242779cb916