### PR TITLE
Change club admin path and enforce owner check

### DIFF
--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -30,7 +30,6 @@ urlpatterns = [
     path('resultados/', search.search_results, name='search_results'),
     path('valoraciones/<slug:slug>/', public.ajax_reviews, name='ajax_reviews'),
 
-    path('<slug:slug>/dashboard/', dashboard, name='club_dashboard'),
     path('<slug:slug>/editar/', club_edit, name='club_edit'),
     path('<slug:slug>/clase/nueva/', clase_create, name='clase_create'),
     path('clase/<int:pk>/editar/', clase_update, name='clase_update'),

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -27,8 +27,8 @@ from ..permissions import has_club_permission
 @login_required
 def dashboard(request, slug):
     club = get_object_or_404(Club, slug=slug)
-    if not has_club_permission(request.user, club):
-        return HttpResponseForbidden()
+    if club.owner != request.user:
+        return redirect('home')
     classes = club.clases.all()
     posts = club.posts.all()
     bookings = Booking.objects.filter(

--- a/config/urls.py
+++ b/config/urls.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
 from apps.clubs.views import public as club_public
+from apps.clubs.views.dashboard import dashboard
 from apps.users.views import profile as user_profile
   
 from apps.users.forms import LoginForm   
@@ -17,6 +18,7 @@ urlpatterns = [
     path('', include('apps.core.urls')),
 
     # Perfil público de clubs
+    path('@<slug:slug>/admin/', dashboard, name='club_dashboard'),
     path('@<slug:slug>/', club_public.club_profile, name='club_profile'),
 
     # Perfil público de usuarios


### PR DESCRIPTION
## Summary
- remove old dashboard route from `apps/clubs/urls.py`
- define `/@<slug>/admin/` route in `config/urls.py`
- redirect non‑owners to home when accessing dashboard

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68520a8551dc83219bda4dba64d7457b