### PR TITLE
Improve feature selection in club admin dashboard

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -106,3 +106,11 @@
 .profile-form input:not(:placeholder-shown) + .clear-btn {
   display: block;
 }
+
+.feature-option {
+  cursor: pointer;
+}
+.feature-option.selected {
+  background-color: #d1e7dd;
+  border-color: #badbcc;
+}

--- a/static/js/feature-select.js
+++ b/static/js/feature-select.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.feature-option').forEach(option => {
+    const checkbox = option.querySelector('input[type="checkbox"]');
+    if (checkbox.checked) {
+      option.classList.add('selected');
+    }
+    option.addEventListener('click', () => {
+      checkbox.checked = !checkbox.checked;
+      option.classList.toggle('selected', checkbox.checked);
+    });
+  });
+});

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -104,8 +104,23 @@
           {% endif %}
         </div>
         <div class="form-field">
-          {{ form.features }}
-          <label for="{{ form.features.id_for_label }}">{{ form.features.label }}</label>
+          <label class="d-block mb-2">{{ form.features.label }}</label>
+          <div class="d-flex flex-wrap gap-3" id="features-container">
+            {% for feature in form.features.field.queryset %}
+            <div class="feature-option border rounded p-3 d-flex align-items-center {% if feature in club.features.all %}selected{% endif %}">
+              <input type="checkbox" name="features" value="{{ feature.id }}" class="d-none"{% if feature in club.features.all %} checked{% endif %}>
+              {% if feature.icon %}
+              <img src="{{ feature.icon.url }}"
+                   alt="{{ feature.name }}"
+                   style="width: 45px; height: 45px; object-fit: contain; user-select:none;"
+                   class="me-2">
+              {% endif %}
+              <div class="text-wrap" style="font-size: 14px; user-select:none;">
+                {{ feature.name }}
+              </div>
+            </div>
+            {% endfor %}
+          </div>
           {% if form.features.errors %}
           <div class="invalid-feedback d-block">
             {{ form.features.errors.as_text|striptags }}
@@ -223,4 +238,5 @@
 
 {% block extra_js %}
 <script src="{% static 'js/profile-tabs.js' %}"></script>
+<script src="{% static 'js/feature-select.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- render club features as selectable tags in dashboard
- add JS to toggle feature selection
- highlight selected feature tags with CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL' and 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685216af11188321b171d82356a7a96d