### PR TITLE
Improve avatar upload UX with drag and drop

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -103,6 +103,9 @@ class ClubForm(forms.ModelForm):
     class Meta:
         model = models.Club
         exclude = ('slug', 'created_at', 'updated_at', 'verified')
+        widgets = {
+            'logo': forms.ClearableFileInput(attrs={'class': 'd-none'}),
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -83,6 +83,9 @@ class ProfileForm(forms.ModelForm):
     class Meta:
         model = Profile
         fields = ['avatar', 'bio', 'location']
+        widgets = {
+            'avatar': forms.ClearableFileInput(attrs={'class': 'd-none'}),
+        }
 
     def clean_avatar(self):
         avatar = self.cleaned_data.get('avatar')
@@ -120,6 +123,9 @@ class AccountForm(forms.ModelForm):
     class Meta:
         model = Profile
         fields = ['avatar', 'notifications']
+        widgets = {
+            'avatar': forms.ClearableFileInput(attrs={'class': 'd-none'}),
+        }
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -114,3 +114,33 @@
   background-color: #d1e7dd;
   border: 2px solid #198754 !important;
 }
+/* Avatar dropzone styles */
+.avatar-dropzone {
+  width: 100px;
+  height: 100px;
+  position: relative;
+}
+.avatar-dropzone input[type="file"] {
+  display: none;
+}
+.avatar-dropzone .avatar-preview {
+  width: 100%;
+  height: 100%;
+  border: 2px dashed #666;
+  border-radius: 50%;
+  background-size: cover;
+  background-position: center;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  color: #666;
+}
+.avatar-dropzone.dragover .avatar-preview {
+  border-color: #000;
+}
+.avatar-dropzone .avatar-preview.has-image {
+  border-style: solid;
+  color: transparent;
+}

--- a/static/js/avatar-dropzone.js
+++ b/static/js/avatar-dropzone.js
@@ -1,0 +1,45 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.avatar-dropzone').forEach(zone => {
+    const input = zone.querySelector('input[type="file"]');
+    const preview = zone.querySelector('.avatar-preview');
+    if (!input || !preview) return;
+
+    const showFile = file => {
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = e => {
+        preview.style.backgroundImage = `url('${e.target.result}')`;
+        preview.classList.add('has-image');
+        preview.textContent = '';
+      };
+      reader.readAsDataURL(file);
+    };
+
+    zone.addEventListener('click', () => input.click());
+
+    zone.addEventListener('dragover', e => {
+      e.preventDefault();
+      zone.classList.add('dragover');
+    });
+
+    zone.addEventListener('dragleave', () => {
+      zone.classList.remove('dragover');
+    });
+
+    zone.addEventListener('drop', e => {
+      e.preventDefault();
+      zone.classList.remove('dragover');
+      const file = e.dataTransfer.files[0];
+      if (file) {
+        input.files = e.dataTransfer.files;
+        showFile(file);
+      }
+    });
+
+    input.addEventListener('change', () => {
+      if (input.files.length) {
+        showFile(input.files[0]);
+      }
+    });
+  });
+});

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -17,7 +17,10 @@
       <form method="post" action="{% url 'club_edit' club.slug %}" enctype="multipart/form-data" class="profile-form">
         {% csrf_token %}
         <div class="form-field">
-          {{ form.logo }}
+          <div class="avatar-dropzone">
+            {{ form.logo }}
+            <div class="avatar-preview{% if club.logo %} has-image{% endif %}"{% if club.logo %} style="background-image:url('{{ club.logo.url }}')"{% endif %}>{% if not club.logo %}+{% endif %}</div>
+          </div>
           <label for="{{ form.logo.id_for_label }}">{{ form.logo.label }}</label>
           {% if form.logo.errors %}
           <div class="invalid-feedback d-block">
@@ -239,4 +242,5 @@
 {% block extra_js %}
 <script src="{% static 'js/profile-tabs.js' %}"></script>
 <script src="{% static 'js/feature-select.js' %}"></script>
+<script src="{% static 'js/avatar-dropzone.js' %}"></script>
 {% endblock %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -16,13 +16,13 @@
     <div class="profile-content  ">
         <div id="tab-account" class="profile-section active col-6">
             <h1 class="mb-4">Mi Cuenta</h1>
-            {% if profile.avatar %}
-                <img src="{{ profile.avatar.url }}" class="rounded-circle mb-3" style="width:100px;height:100px;object-fit:cover;">
-            {% endif %}
             <form method="post" enctype="multipart/form-data" class="profile-form mb-5">
                 {% csrf_token %}
                 <div class="form-field">
-                    {{ form.avatar.as_widget }}
+                    <div class="avatar-dropzone">
+                        {{ form.avatar }}
+                        <div class="avatar-preview{% if profile.avatar %} has-image{% endif %}"{% if profile.avatar %} style="background-image:url('{{ profile.avatar.url }}')"{% endif %}>{% if not profile.avatar %}+{% endif %}</div>
+                    </div>
                     <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
                     {% if form.avatar.errors %}
                     <div class="invalid-feedback d-block">
@@ -148,4 +148,5 @@
 {% block extra_js %}
 <script src="{% static 'js/profile-tabs.js' %}"></script>
 <script src="{% static 'js/clear-input.js' %}"></script>
+<script src="{% static 'js/avatar-dropzone.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement drag-and-drop component for avatar/logo uploads
- style new dropzone in profile.css
- use dropzone in profile and dashboard pages
- load new avatar-dropzone JS on relevant pages
- fix callable restriction by hiding file inputs via widgets

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68521d73d6808321bd5c9dd2a04bd3d2