### PR TITLE
Fix template as_widget syntax

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -18,7 +18,7 @@
         {% csrf_token %}
         <div class="form-field">
           <div class="avatar-dropzone">
-            {{ form.logo.as_widget(attrs={'class':'d-none'}) }}
+          {{ form.logo.as_widget(attrs={"class": "d-none"}) }}
             <div class="avatar-preview{% if club.logo %} has-image{% endif %}"{% if club.logo %} style="background-image:url('{{ club.logo.url }}')"{% endif %}>{% if not club.logo %}+{% endif %}</div>
           </div>
           <label for="{{ form.logo.id_for_label }}">{{ form.logo.label }}</label>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -20,7 +20,7 @@
                 {% csrf_token %}
                 <div class="form-field">
                     <div class="avatar-dropzone">
-                        {{ form.avatar.as_widget(attrs={'class':'d-none'}) }}
+                        {{ form.avatar.as_widget(attrs={"class": "d-none"}) }}
                         <div class="avatar-preview{% if profile.avatar %} has-image{% endif %}"{% if profile.avatar %} style="background-image:url('{{ profile.avatar.url }}')"{% endif %}>{% if not profile.avatar %}+{% endif %}</div>
                     </div>
                     <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>


### PR DESCRIPTION
## Summary
- use double quotes in `as_widget` calls to avoid template syntax errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852222e0e84832198297b8233bbe391