### PR TITLE
Add coach profile model and page

### DIFF
--- a/apps/clubs/admin.py
+++ b/apps/clubs/admin.py
@@ -1,5 +1,17 @@
 from django.contrib import admin
-from .models import Club, Feature, ClubPhoto, Clase, Competidor, Reseña, Horario, ClubPost, Entrenador
+from .models import (
+    Club,
+    Feature,
+    ClubPhoto,
+    Clase,
+    Competidor,
+    Reseña,
+    Horario,
+    ClubPost,
+    Entrenador,
+    EntrenadorPhoto,
+    TrainingLevel,
+)
 from django import forms 
 
 class ClubPhotoInline(admin.TabularInline):
@@ -16,6 +28,10 @@ class CompetidorInline(admin.TabularInline):
 
 class EntrenadorInline(admin.TabularInline):
     model = Entrenador
+    extra = 1
+
+class EntrenadorPhotoInline(admin.TabularInline):
+    model = EntrenadorPhoto
     extra = 1
 
 class ReseñaInline(admin.TabularInline):
@@ -75,5 +91,25 @@ class ClubPostAdmin(admin.ModelAdmin):
 
 @admin.register(Entrenador)
 class EntrenadorAdmin(admin.ModelAdmin):
-    list_display = ('nombre', 'apellidos', 'club')
+    list_display = ('nombre', 'apellidos', 'club', 'verificado')
+    prepopulated_fields = {'slug': ('nombre', 'apellidos')}
+    inlines = [EntrenadorPhotoInline]
+    fields = (
+        'club',
+        'avatar',
+        'nombre',
+        'apellidos',
+        'slug',
+        'verificado',
+        'ciudad',
+        'telefono',
+        'whatsapp',
+        'email',
+        'precio_hora',
+        'promociones',
+        'clase_prueba',
+        'experiencia_anos',
+        'bio',
+        'niveles',
+    )
 

--- a/apps/clubs/migrations/0013_entrenador_fields.py
+++ b/apps/clubs/migrations/0013_entrenador_fields.py
@@ -1,0 +1,92 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0012_club_owner'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TrainingLevel',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=50, unique=True)),
+            ],
+            options={
+                'verbose_name': 'Nivel',
+                'verbose_name_plural': 'Niveles',
+            },
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='slug',
+            field=models.SlugField(blank=True, unique=True),
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='ciudad',
+            field=models.CharField(blank=True, choices=[('Madrid', 'Madrid'), ('Barcelona', 'Barcelona'), ('Valencia', 'Valencia'), ('Sevilla', 'Sevilla'), ('Zaragoza', 'Zaragoza')], max_length=50),
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='telefono',
+            field=models.CharField(blank=True, max_length=20),
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='whatsapp',
+            field=models.CharField(blank=True, max_length=20),
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='email',
+            field=models.EmailField(blank=True, max_length=254),
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='verificado',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='precio_hora',
+            field=models.DecimalField(blank=True, null=True, decimal_places=2, max_digits=6),
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='promociones',
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='clase_prueba',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='experiencia_anos',
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='bio',
+            field=models.TextField(blank=True),
+        ),
+        migrations.CreateModel(
+            name='EntrenadorPhoto',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('image', models.ImageField(upload_to='coach_photos/')),
+                ('uploaded_at', models.DateTimeField(auto_now_add=True)),
+                ('entrenador', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='photos', to='clubs.entrenador')),
+            ],
+        ),
+        migrations.AddField(
+            model_name='entrenador',
+            name='niveles',
+            field=models.ManyToManyField(blank=True, to='clubs.traininglevel'),
+        ),
+    ]

--- a/apps/clubs/models/__init__.py
+++ b/apps/clubs/models/__init__.py
@@ -6,6 +6,6 @@ from .horario import Horario
 from .resena import Reseña
 from .clase import Clase
 from .competidor import Competidor
-from .entrenador import Entrenador
+from .entrenador import Entrenador, EntrenadorPhoto, TrainingLevel
 from .post import ClubPost
 from .booking import Booking

--- a/apps/clubs/models/entrenador.py
+++ b/apps/clubs/models/entrenador.py
@@ -1,11 +1,68 @@
 from django.db import models
+from django.utils.text import slugify
+
 from .club import Club
+from apps.core.utils.image_utils import resize_image
+
+
+class TrainingLevel(models.Model):
+    """Modelo simple para los niveles que puede impartir un entrenador."""
+    name = models.CharField(max_length=50, unique=True)
+
+    class Meta:
+        verbose_name = "Nivel"
+        verbose_name_plural = "Niveles"
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return self.name
 
 class Entrenador(models.Model):
+    CITY_CHOICES = [
+        ("Madrid", "Madrid"),
+        ("Barcelona", "Barcelona"),
+        ("Valencia", "Valencia"),
+        ("Sevilla", "Sevilla"),
+        ("Zaragoza", "Zaragoza"),
+    ]
+
     club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='entrenadores')
     avatar = models.ImageField(upload_to='entrenadores/', blank=True, null=True)
     nombre = models.CharField(max_length=100)
     apellidos = models.CharField(max_length=150)
+    slug = models.SlugField(unique=True, blank=True)
+    ciudad = models.CharField(max_length=50, choices=CITY_CHOICES, blank=True)
+    telefono = models.CharField(max_length=20, blank=True)
+    whatsapp = models.CharField(max_length=20, blank=True)
+    email = models.EmailField(blank=True)
+    verificado = models.BooleanField(default=False)
+    niveles = models.ManyToManyField(TrainingLevel, blank=True)
+    precio_hora = models.DecimalField(max_digits=6, decimal_places=2, null=True, blank=True)
+    promociones = models.TextField(blank=True)
+    clase_prueba = models.BooleanField(default=False)
+    experiencia_anos = models.PositiveIntegerField(null=True, blank=True)
+    bio = models.TextField(blank=True)
+
+    def save(self, *args, **kwargs):
+        if not self.slug:
+            self.slug = slugify(f"{self.nombre}-{self.apellidos}")
+        super().save(*args, **kwargs)
+        if self.avatar and hasattr(self.avatar, "path"):
+            resize_image(self.avatar.path)
 
     def __str__(self):
         return f"{self.nombre} {self.apellidos}"
+
+
+class EntrenadorPhoto(models.Model):
+    """Fotos adicionales asociadas a un entrenador."""
+    entrenador = models.ForeignKey(Entrenador, related_name="photos", on_delete=models.CASCADE)
+    image = models.ImageField(upload_to="coach_photos/")
+    uploaded_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"Foto de {self.entrenador}"
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        if self.image and hasattr(self.image, "path"):
+            resize_image(self.image.path)

--- a/apps/clubs/views/__init__.py
+++ b/apps/clubs/views/__init__.py
@@ -1,5 +1,5 @@
 from .search import search_results
-from .public import club_profile, ajax_reviews
+from .public import club_profile, coach_profile, ajax_reviews
 from .post import post_create, post_update, post_delete
 from .booking import book_clase, cancel_booking
 from .dashboard import (

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render, get_object_or_404, redirect 
-from ..models import Club
+from ..models import Club, Entrenador
 from django.contrib import messages
 from apps.clubs.forms import ReseñaForm
 from apps.users.forms import RegistroUsuarioForm
@@ -65,6 +65,14 @@ def club_profile(request, slug):
         'club_followed': club_followed,
         'register_form': register_form,
 
+    })
+
+
+def coach_profile(request, slug):
+    """Vista pública del perfil del entrenador."""
+    coach = get_object_or_404(Entrenador, slug=slug)
+    return render(request, 'clubs/coach_profile.html', {
+        'coach': coach,
     })
 
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     # Perfil público de clubs
     path('@<slug:slug>/admin/', dashboard, name='club_dashboard'),
     path('@<slug:slug>/', club_public.club_profile, name='club_profile'),
+    path('coach/@<slug:slug>/', club_public.coach_profile, name='coach_profile'),
 
     # Perfil público de usuarios
     path('profile/<str:username>/', user_profile.profile_detail, name='user_profile'),

--- a/templates/clubs/coach_profile.html
+++ b/templates/clubs/coach_profile.html
@@ -1,0 +1,123 @@
+{% extends 'base.html' %}
+{% block body_class %}club-profile-page{% endblock %}
+{% load static %}
+{% block content %}
+<div class="container-fluid col-12 px-3 my-3" id="profile-container">
+    {% include 'partials/_back-btn.html' %}
+    <div class="row">
+        <div class="col-lg-2">
+            {% if coach.avatar %}
+                <img src="{{ coach.avatar.url }}" alt="{{ coach.nombre }}" class="img-fluid rounded">
+            {% endif %}
+            <div class="d-flex align-items-start mt-4 mb-4 gap-3">
+                <div>
+                    <h1 class="h3 mb-2" style="font-weight:900;">{{ coach.nombre }} {{ coach.apellidos }}</h1>
+                    <div class="d-flex align-items-center mb-3">
+                        <span class="badge">Entrenador</span>
+                        {% if coach.verificado %}
+                            <span class="ms-2" title="Verificado">
+                                <svg fill="none" height="24" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                                    <path clip-rule="evenodd" d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM11.2071 16.2071L18.2071 9.20711L16.7929 7.79289L10.5 14.0858L7.20711 10.7929L5.79289 12.2071L9.79289 16.2071C9.98043 16.3946 10.2348 16.5 10.5 16.5C10.7652 16.5 11.0196 16.3946 11.2071 16.2071Z" fill="black" fill-rule="evenodd" />
+                                </svg>
+                            </span>
+                        {% endif %}
+                    </div>
+                    {% if coach.ciudad %}
+                    <p class="mb-2 d-flex">
+                        <svg class="w-6 h-6 text-gray-800 dark:text-white me-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="none" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 13a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" />
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.8 13.938h-.011a7 7 0 1 0-11.464.144h-.016l.14.171c.1.127.2.251.3.371L12 21l5.13-6.248c.194-.209.374-.429.54-.659l.13-.155Z" />
+                        </svg>
+                        {{ coach.ciudad }}
+                    </p>
+                    {% endif %}
+                    {% if coach.telefono %}
+                    <p class="mb-2 d-flex align-items-center">
+                        <svg class="w-6 h-6 text-gray-800 dark:text-white me-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.427 14.768 17.2 13.542a1.733 1.733 0 0 0-2.45 0l-.613.613a1.732 1.732 0 0 1-2.45 0l-1.838-1.84a1.735 1.735 0 0 1 0-2.452l.612-.613a1.735 1.735 0 0 0 0-2.452L9.237 5.572a1.6 1.6 0 0 0-2.45 0c-3.223 3.2-1.702 6.896 1.519 10.117 3.22 3.221 6.914 4.745 10.12 1.535a1.601 1.601 0 0 0 0-2.456Z" />
+                        </svg>
+                        <a href="tel:{{ coach.telefono }}" class="text-decoration-none text-reset">{{ coach.telefono }}</a>
+                    </p>
+                    {% endif %}
+                    {% if coach.whatsapp %}
+                    <p class="mb-2 d-flex align-items-center">
+                        <svg class="w-6 h-6 text-gray-800 dark:text-white me-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24">
+                            <path fill="currentColor" fill-rule="evenodd" d="M12 4a8 8 0 0 0-6.895 12.06l.569.718-.697 2.359 2.32-.648.379.243A8 8 0 1 0 12 4ZM2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10a9.96 9.96 0 0 1-5.016-1.347l-4.948 1.382 1.426-4.829-.006-.007-.033-.055A9.958 9.958 0 0 1 2 12Z" clip-rule="evenodd" />
+                            <path fill="currentColor" d="M16.735 13.492c-.038-.018-1.497-.736-1.756-.83a1.008 1.008 0 0 0-.34-.075c-.196 0-.362.098-.49.291-.146.217-.587.732-.723.886-.018.02-.042.045-.057.045-.013 0-.239-.093-.307-.123-1.564-.68-2.751-2.313-2.914-2.589-.023-.04-.024-.057-.024-.057.005-.021.058-.074.085-.101.08-.079.166-.182.249-.283l.117-.14c.121-.14.175-.25.237-.375l.033-.066a.68.68 0 0 0-.02-.64c-.034-.069-.65-1.555-.715-1.711-.158-.377-.366-.552-.655-.552-.027 0 0 0-.112.005-.137.005-.883.104-1.213.311-.35.22-.94.924-.94 2.160 1.112.705 2.162 1.008 2.561l.041.06c1.161 1.695 2.608 2.951 4.074 3.537 1.412.564 2.081.63 2.461.63.16 0 .288-.013.4-.024l.072-.007c.488-.043 1.56-.599 1.804-1.276.192-.534.243-1.117.115-1.329-.088-.144-.239-.216-.43-.308Z" />
+                        </svg>
+                        <a href="https://wa.me/{{ coach.whatsapp }}" target="_blank" class="text-decoration-none text-reset">WhatsApp</a>
+                    </p>
+                    {% endif %}
+                    {% if coach.email %}
+                    <p class="mb-2 d-flex align-items-center">
+                        <svg class="w-6 h-6 text-gray-800 dark:text-white me-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 8v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8m18 0-8.029-4.46a2 2 0 0 0-1.942 0L3 8m18 0-9 6.5L3 8" />
+                        </svg>
+                        <a href="mailto:{{ coach.email }}" class="text-decoration-none text-reset">{{ coach.email }}</a>
+                    </p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-8">
+            <div class="mb-4 rounded">
+                {% if coach.photos.all %}
+                    <div class="mb-4 gallery-slideshow position-relative">
+                        {% for photo in coach.photos.all %}
+                            <div class="gallery-slide{% if forloop.first %} active{% endif %}">
+                                <img src="{{ photo.image.url }}" alt="Foto" class="img-fluid rounded shadow-sm" style="width:100%;max-height:500px;min-height:500px;object-fit:cover;background:rgb(85,85,85);">
+                            </div>
+                        {% endfor %}
+                        <button id="galleryPrev" class="slide-arrow left ms-3">
+                            <svg viewBox="0 0 48 48">
+                                <path d="M30.83 32.67l-9.17-9.17 9.17-9.17-2.83-2.83-12 12 12 12z" />
+                                <path d="M0-.5h48v48h-48z" fill="none" />
+                            </svg>
+                        </button>
+                        <button id="galleryNext" class="slide-arrow right me-3">
+                            <svg viewBox="0 0 48 48" style="transform:rotate(180deg);">
+                                <path d="M30.83 32.67l-9.17-9.17 9.17-9.17-2.83-2.83-12 12 12 12z" />
+                                <path d="M0-.5h48v48h-48z" fill="none" />
+                            </svg>
+                        </button>
+                        <div class="gallery-dots-container" style="position:absolute;bottom:15px;width:100%;display:flex;justify-content:center;">
+                            <div class="gallery-dots d-flex gap-1">
+                                {% for photo in coach.photos.all %}
+                                    <span class="gallery-dot{% if forloop.first %} active{% endif %}"></span>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                {% else %}
+                    <p>No hay fotos todavía.</p>
+                {% endif %}
+            </div>
+            <div class="mb-4">
+                {% if coach.bio %}
+                    <p>{{ coach.bio|linebreaks }}</p>
+                {% endif %}
+                {% if coach.niveles.all %}
+                    <h5 class="mb-2">Niveles</h5>
+                    <div class="d-flex flex-wrap gap-2 mb-2">
+                        {% for n in coach.niveles.all %}
+                            <span class="badge">{{ n.name }}</span>
+                        {% endfor %}
+                    </div>
+                {% endif %}
+                {% if coach.precio_hora %}
+                    <p><strong>Precio/hora:</strong> {{ coach.precio_hora }} €</p>
+                {% endif %}
+                {% if coach.promociones %}
+                    <p><strong>Promociones:</strong> {{ coach.promociones }}</p>
+                {% endif %}
+                <p><strong>Clase de prueba:</strong> {{ coach.clase_prueba|yesno:"Sí,No" }}</p>
+                {% if coach.experiencia_anos %}
+                    <p><strong>Experiencia:</strong> {{ coach.experiencia_anos }} años</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+{% include 'partials/_share_profile_modal.html' %}
+<script src="{% static 'js/gallery-slideshow.js' %}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- expand `Entrenador` model with new contact fields, biography and pricing data
- create `TrainingLevel` and `EntrenadorPhoto` models for levels and gallery
- expose coach profile via `/coach/@<slug>` route
- add admin support for new models and fields
- implement coach profile template with slideshow
- add initial migration for the new fields and models

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68522c1a007883218b60f3297fcc5996