### PR TITLE
Fix slug migration for Entrenador

### DIFF
--- a/apps/clubs/migrations/0013_entrenador_fields.py
+++ b/apps/clubs/migrations/0013_entrenador_fields.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='entrenador',
             name='slug',
-            field=models.SlugField(blank=True, unique=True),
+            field=models.SlugField(blank=True, unique=True, null=True),
         ),
         migrations.AddField(
             model_name='entrenador',

--- a/apps/clubs/models/entrenador.py
+++ b/apps/clubs/models/entrenador.py
@@ -29,7 +29,7 @@ class Entrenador(models.Model):
     avatar = models.ImageField(upload_to='entrenadores/', blank=True, null=True)
     nombre = models.CharField(max_length=100)
     apellidos = models.CharField(max_length=150)
-    slug = models.SlugField(unique=True, blank=True)
+    slug = models.SlugField(unique=True, blank=True, null=True)
     ciudad = models.CharField(max_length=50, choices=CITY_CHOICES, blank=True)
     telefono = models.CharField(max_length=20, blank=True)
     whatsapp = models.CharField(max_length=20, blank=True)


### PR DESCRIPTION
## Summary
- allow `slug` field on `Entrenador` model to be nullable
- update corresponding migration to avoid unique constraint errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68522ea8ba688321a9df3f125ec64a35