### PR TITLE
Add trainer management tab and links

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -158,3 +158,9 @@ class CompetidorForm(forms.ModelForm):
         model = models.Competidor
         fields = ['nombre', 'victorias', 'derrotas', 'empates', 'titulos']
 
+
+class EntrenadorForm(forms.ModelForm):
+    class Meta:
+        model = models.Entrenador
+        exclude = ['slug', 'club']
+

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -24,6 +24,9 @@ from apps.clubs.views.dashboard import (
     competidor_create,
     competidor_update,
     competidor_delete,
+    entrenador_create,
+    entrenador_update,
+    entrenador_delete,
 )
 
 urlpatterns = [
@@ -45,6 +48,10 @@ urlpatterns = [
     path('<slug:slug>/competidor/nuevo/', competidor_create, name='competidor_create'),
     path('competidor/<int:pk>/editar/', competidor_update, name='competidor_update'),
     path('competidor/<int:pk>/eliminar/', competidor_delete, name='competidor_delete'),
+
+    path('<slug:slug>/entrenador/nuevo/', entrenador_create, name='entrenador_create'),
+    path('entrenador/<int:pk>/editar/', entrenador_update, name='entrenador_update'),
+    path('entrenador/<int:pk>/eliminar/', entrenador_delete, name='entrenador_delete'),
 
     path('<slug:slug>/posts/nuevo/', post_create, name='clubpost_create'),
     path('posts/<int:pk>/editar/', post_update, name='clubpost_update'),

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -233,7 +233,11 @@
                                         {{ e.nombre|first|upper }}
                                         </div>
                                     {% endif %}
-                                    <span>{{ e.nombre }} {{ e.apellidos }}</span>
+                                    {% if e.slug %}
+                                        <a href="{% url 'coach_profile' e.slug %}" class="text-decoration-none text-reset">{{ e.nombre }} {{ e.apellidos }}</a>
+                                    {% else %}
+                                        <span>{{ e.nombre }} {{ e.apellidos }}</span>
+                                    {% endif %}
                                     </div>
                                 {% endfor %}
                                 </div>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -7,6 +7,7 @@
     <div class="profile-tab active" data-target="tab-profile">Mi perfil</div>
     <div class="profile-tab" data-target="tab-gallery">Galería</div>
     <div class="profile-tab" data-target="tab-schedule">Horarios</div>
+    <div class="profile-tab" data-target="tab-coaches">Entrenadores</div>
     <div class="profile-tab" data-target="tab-competitors">Competidores</div>
     <div class="profile-tab" data-target="tab-posts">Publicaciones</div>
     <div class="profile-tab" data-target="tab-bookings">Reservas</div>
@@ -189,6 +190,23 @@
         </li>
         {% empty %}
         <li>No hay horarios.</li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div id="tab-coaches" class="profile-section">
+      <a href="{% url 'entrenador_create' club.slug %}" class="btn btn-secondary btn-sm mb-3">Añadir entrenador</a>
+      <ul>
+        {% for coach in club.entrenadores.all %}
+        <li>
+          {{ coach.nombre }} {{ coach.apellidos }}
+          <a href="{% url 'entrenador_update' coach.id %}">Editar</a>
+          <form method="post" action="{% url 'entrenador_delete' coach.id %}" class="d-inline">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-link p-0">Eliminar</button>
+          </form>
+        </li>
+        {% empty %}
+        <li>No hay entrenadores.</li>
         {% endfor %}
       </ul>
     </div>

--- a/templates/clubs/entrenador_confirm_delete.html
+++ b/templates/clubs/entrenador_confirm_delete.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">Eliminar entrenador</h1>
+  <p>¿Seguro que deseas eliminar este entrenador?</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Eliminar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/clubs/entrenador_form.html
+++ b/templates/clubs/entrenador_form.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">{% if entrenador %}Editar{% else %}Nuevo{% endif %} entrenador</h1>
+  <form method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Guardar</button>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- link coaches to profile page from club profile
- create `EntrenadorForm`
- add trainer CRUD views and URL routes
- add trainer management tab in dashboard
- include coach templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685233f2db9c8321affd80777ed7da95