### PR TITLE
Implement competitor profile updates

### DIFF
--- a/apps/clubs/admin.py
+++ b/apps/clubs/admin.py
@@ -76,7 +76,7 @@ class ClaseAdmin(admin.ModelAdmin):
 
 @admin.register(Competidor)
 class CompetidorAdmin(admin.ModelAdmin):
-    list_display = ('nombre', 'club', 'victorias', 'derrotas', 'empates')
+    list_display = ('nombre', 'club', 'record', 'modalidad', 'peso', 'sexo')
 
 @admin.register(Reseña)
 class ReseñaAdmin(admin.ModelAdmin):

--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -156,7 +156,15 @@ class HorarioForm(forms.ModelForm):
 class CompetidorForm(forms.ModelForm):
     class Meta:
         model = models.Competidor
-        fields = ['nombre', 'victorias', 'derrotas', 'empates', 'titulos']
+        fields = [
+            'avatar',
+            'nombre',
+            'record',
+            'modalidad',
+            'peso',
+            'sexo',
+            'palmares',
+        ]
 
 
 class EntrenadorForm(forms.ModelForm):

--- a/apps/clubs/management/commands/seed_clubs.py
+++ b/apps/clubs/management/commands/seed_clubs.py
@@ -72,13 +72,17 @@ class Command(BaseCommand):
                 )
 
             for _ in range(random.randint(1, 3)):
+                wins = random.randint(0, 10)
+                losses = random.randint(0, 5)
+                draws = random.randint(0, 3)
                 Competidor.objects.create(
                     club=club,
                     nombre=fake.name(),
-                    victorias=random.randint(0, 10),
-                    derrotas=random.randint(0, 5),
-                    empates=random.randint(0, 3),
-                    titulos=fake.text(max_nb_chars=50),
+                    record=f"{wins}-{losses}-{draws}",
+                    modalidad=random.choice([c[0] for c in Competidor.MODALIDAD_CHOICES]),
+                    peso=random.choice([c[0] for c in Competidor.PESO_CHOICES]),
+                    sexo=random.choice([c[0] for c in Competidor.SEXO_CHOICES]),
+                    palmares=fake.text(max_nb_chars=50),
                 )
 
             for _ in range(random.randint(1, 3)):

--- a/apps/clubs/migrations/0014_competidor_new_fields.py
+++ b/apps/clubs/migrations/0014_competidor_new_fields.py
@@ -1,0 +1,57 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0013_entrenador_fields'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='competidor',
+            name='victorias',
+        ),
+        migrations.RemoveField(
+            model_name='competidor',
+            name='derrotas',
+        ),
+        migrations.RemoveField(
+            model_name='competidor',
+            name='empates',
+        ),
+        migrations.RemoveField(
+            model_name='competidor',
+            name='titulos',
+        ),
+        migrations.AddField(
+            model_name='competidor',
+            name='avatar',
+            field=models.ImageField(blank=True, null=True, upload_to='competidores/'),
+        ),
+        migrations.AddField(
+            model_name='competidor',
+            name='record',
+            field=models.CharField(blank=True, max_length=20),
+        ),
+        migrations.AddField(
+            model_name='competidor',
+            name='modalidad',
+            field=models.CharField(blank=True, choices=[('elite', 'Elite'), ('joven', 'Joven'), ('junior', 'Junior'), ('schoolboy', 'Schoolboy'), ('profesional', 'Profesional')], max_length=15),
+        ),
+        migrations.AddField(
+            model_name='competidor',
+            name='peso',
+            field=models.CharField(blank=True, choices=[('minimosca', 'Minimosca'), ('mosca', 'Mosca'), ('gallo', 'Gallo'), ('pluma', 'Pluma'), ('ligero', 'Ligero'), ('welter', 'W\u00e9lter'), ('superwelter', 'Superw\u00e9lter'), ('medio', 'Medio'), ('semipesado', 'Semipesado'), ('crucero', 'Crucero'), ('pesado', 'Pesado'), ('superpesado', 'Superpesado')], max_length=15),
+        ),
+        migrations.AddField(
+            model_name='competidor',
+            name='sexo',
+            field=models.CharField(blank=True, choices=[('M', 'Masculino'), ('F', 'Femenino')], max_length=1),
+        ),
+        migrations.AddField(
+            model_name='competidor',
+            name='palmares',
+            field=models.TextField(blank=True, verbose_name='Palmar\u00e9s'),
+        ),
+    ]

--- a/apps/clubs/models/competidor.py
+++ b/apps/clubs/models/competidor.py
@@ -1,14 +1,61 @@
 from django.db import models
-from .club import Club    
+from .club import Club
+from apps.core.utils.image_utils import resize_image
 
 
 class Competidor(models.Model):
-    club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='competidores')
+    MODALIDAD_CHOICES = [
+        ("elite", "Elite"),
+        ("joven", "Joven"),
+        ("junior", "Junior"),
+        ("schoolboy", "Schoolboy"),
+        ("profesional", "Profesional"),
+    ]
+
+    PESO_CHOICES = [
+        ("minimosca", "Minimosca"),
+        ("mosca", "Mosca"),
+        ("gallo", "Gallo"),
+        ("pluma", "Pluma"),
+        ("ligero", "Ligero"),
+        ("welter", "Wélter"),
+        ("superwelter", "Superwélter"),
+        ("medio", "Medio"),
+        ("semipesado", "Semipesado"),
+        ("crucero", "Crucero"),
+        ("pesado", "Pesado"),
+        ("superpesado", "Superpesado"),
+    ]
+
+    SEXO_CHOICES = [
+        ("M", "Masculino"),
+        ("F", "Femenino"),
+    ]
+
+    club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name="competidores")
+    avatar = models.ImageField(upload_to="competidores/", blank=True, null=True)
     nombre = models.CharField(max_length=100)
-    victorias = models.IntegerField(default=0)
-    derrotas = models.IntegerField(default=0)
-    empates = models.IntegerField(default=0)
-    titulos = models.TextField(blank=True)
+    record = models.CharField(max_length=20, blank=True)
+    modalidad = models.CharField(max_length=15, choices=MODALIDAD_CHOICES, blank=True)
+    peso = models.CharField(max_length=15, choices=PESO_CHOICES, blank=True)
+    sexo = models.CharField(max_length=1, choices=SEXO_CHOICES, blank=True)
+    palmares = models.TextField(blank=True, verbose_name="Palmarés")
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        if self.avatar and hasattr(self.avatar, "path"):
+            resize_image(self.avatar.path)
+
+    @property
+    def categoria(self):
+        parts = []
+        if self.modalidad:
+            parts.append(self.get_modalidad_display())
+        if self.peso:
+            parts.append(self.get_peso_display())
+        if self.sexo:
+            parts.append(self.get_sexo_display())
+        return " ".join(parts)
 
     def __str__(self):
         return self.nombre

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -205,7 +205,7 @@ def competidor_create(request, slug):
     if not has_club_permission(request.user, club):
         return HttpResponseForbidden()
     if request.method == 'POST':
-        form = CompetidorForm(request.POST)
+        form = CompetidorForm(request.POST, request.FILES)
         if form.is_valid():
             competidor = form.save(commit=False)
             competidor.club = club
@@ -223,7 +223,7 @@ def competidor_update(request, pk):
     if not has_club_permission(request.user, competidor.club):
         return HttpResponseForbidden()
     if request.method == 'POST':
-        form = CompetidorForm(request.POST, instance=competidor)
+        form = CompetidorForm(request.POST, request.FILES, instance=competidor)
         if form.is_valid():
             form.save()
             messages.success(request, 'Competidor actualizado correctamente.')

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -356,21 +356,25 @@
                                 <table class="table table-sm table-striped table-bordered text-center">
                                     <thead class="table-dark">
                                         <tr>
+                                            <th>Avatar</th>
                                             <th>Nombre</th>
-                                            <th>Victorias</th>
-                                            <th>Derrotas</th>
-                                            <th>Empates</th>
-                                            <th>Títulos</th>
+                                            <th>Record</th>
+                                            <th>Categoria</th>
+                                            <th>Palmarés</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         {% for competidor in competidores %}
                                             <tr>
+                                                <td>
+                                                    {% if competidor.avatar %}
+                                                        <img src="{{ competidor.avatar.url }}" class="img-fluid" style="max-height:40px;">
+                                                    {% endif %}
+                                                </td>
                                                 <td>{{ competidor.nombre }}</td>
-                                                <td style="color:#008800;">{{ competidor.victorias }}</td>
-                                                <td style="color:#c60300;">{{ competidor.derrotas }}</td>
-                                                <td style="color:#7faefc;">{{ competidor.empates }}</td>
-                                                <td>{{ competidor.titulos|default:"—" }}</td>
+                                                <td>{{ competidor.record }}</td>
+                                                <td>{{ competidor.categoria }}</td>
+                                                <td>{{ competidor.palmares|default:"—" }}</td>
                                             </tr>
                                         {% endfor %}
                                     </tbody>

--- a/templates/clubs/competidor_form.html
+++ b/templates/clubs/competidor_form.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container py-4">
   <h1 class="h5">{% if competidor %}Editar{% else %}Nuevo{% endif %} competidor</h1>
-  <form method="post">
+  <form method="post" enctype="multipart/form-data">
     {% csrf_token %}
     {{ form.as_p }}
     <button type="submit" class="btn btn-primary">Guardar</button>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -215,7 +215,7 @@
       <ul>
         {% for comp in club.competidores.all %}
         <li>
-          {{ comp.nombre }} ({{ comp.victorias }}-{{ comp.derrotas }}-{{ comp.empates }})
+          {{ comp.nombre }} - {{ comp.record }} - {{ comp.categoria }}
           <a href="{% url 'competidor_update' comp.id %}">Editar</a>
           <form method="post" action="{% url 'competidor_delete' comp.id %}" class="d-inline">
             {% csrf_token %}


### PR DESCRIPTION
## Summary
- extend `Competidor` model with avatar, category, and record fields
- update competitor forms, admin and dashboard
- show new columns on club profile
- adapt seed command
- provide migration for schema changes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68523bc8afbc8321b473579d0acc39e9