### PR TITLE
Enhance boxer table layout

### DIFF
--- a/apps/clubs/models/competidor.py
+++ b/apps/clubs/models/competidor.py
@@ -59,3 +59,12 @@ class Competidor(models.Model):
 
     def __str__(self):
         return self.nombre
+
+    @property
+    def record_tuple(self):
+        """Return wins, losses and draws as integers."""
+        try:
+            wins, losses, draws = [int(p) for p in self.record.split("-")]
+            return wins, losses, draws
+        except Exception:
+            return 0, 0, 0

--- a/apps/core/templatetags/utils_filters.py
+++ b/apps/core/templatetags/utils_filters.py
@@ -1,0 +1,14 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def initials(value):
+    """Return initials from a full name string."""
+    if not value:
+        return ""
+    parts = [p for p in str(value).split() if p]
+    if not parts:
+        return ""
+    initials = "".join(p[0] for p in parts[:2])
+    return initials.upper()

--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -320,3 +320,24 @@ textarea.form-control {
 #club-heart path {
   stroke: #fff !important;
 }
+
+/* Avatar para competidores en tablas */
+.competitor-avatar {
+  width: 30px;
+  height: 30px;
+  background-color: #000;
+  color: #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 0.75rem;
+}
+
+.competitor-avatar-img {
+  width: 30px;
+  height: 30px;
+  object-fit: cover;
+  border-radius: 50%;
+}

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block body_class %}club-profile-page{% endblock %}
-{% load static star_rating %}
+{% load static star_rating utils_filters %}
 {% block content %}
     <div class="container-fluid col-12 px-3 my-3" id="profile-container">
         <!-- Flecha volver arriba -->
@@ -356,8 +356,7 @@
                                 <table class="table table-sm table-striped table-bordered text-center">
                                     <thead class="table-dark">
                                         <tr>
-                                            <th>Avatar</th>
-                                            <th>Nombre</th>
+                                            <th>Boxeador</th>
                                             <th>Record</th>
                                             <th>Categoria</th>
                                             <th>Palmarés</th>
@@ -366,13 +365,21 @@
                                     <tbody>
                                         {% for competidor in competidores %}
                                             <tr>
-                                                <td>
-                                                    {% if competidor.avatar %}
-                                                        <img src="{{ competidor.avatar.url }}" class="img-fluid" style="max-height:40px;">
-                                                    {% endif %}
+                                                <td class="text-start">
+                                                    <div class="d-flex align-items-center">
+                                                        {% if competidor.avatar %}
+                                                            <img src="{{ competidor.avatar.url }}" alt="{{ competidor.nombre }}" class="competitor-avatar-img me-2">
+                                                        {% else %}
+                                                            <div class="competitor-avatar me-2">{{ competidor.nombre|initials }}</div>
+                                                        {% endif %}
+                                                        <span>{{ competidor.nombre }}</span>
+                                                    </div>
                                                 </td>
-                                                <td>{{ competidor.nombre }}</td>
-                                                <td>{{ competidor.record }}</td>
+                                                <td>
+                                                    {% with rec=competidor.record_tuple %}
+                                                        <span class="text-success">{{ rec.0 }}</span>-<span class="text-danger">{{ rec.1 }}</span>-<span class="text-primary">{{ rec.2 }}</span>
+                                                    {% endwith %}
+                                                </td>
                                                 <td>{{ competidor.categoria }}</td>
                                                 <td>{{ competidor.palmares|default:"—" }}</td>
                                             </tr>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static %}
+{% load static utils_filters %}
 
 {% block content %}
 <div class="d-flex mt-5 container-fluid col-12">
@@ -215,7 +215,9 @@
       <ul>
         {% for comp in club.competidores.all %}
         <li>
-          {{ comp.nombre }} - {{ comp.record }} - {{ comp.categoria }}
+          {% with rec=comp.record_tuple %}
+          {{ comp.nombre }} - <span class="text-success">{{ rec.0 }}</span>-<span class="text-danger">{{ rec.1 }}</span>-<span class="text-primary">{{ rec.2 }}</span> - {{ comp.categoria }}
+          {% endwith %}
           <a href="{% url 'competidor_update' comp.id %}">Editar</a>
           <form method="post" action="{% url 'competidor_delete' comp.id %}" class="d-inline">
             {% csrf_token %}


### PR DESCRIPTION
## Summary
- show boxer avatar and name in a single column
- add fallback initials avatar and 30x30 styling
- colour code record values for wins/losses/draws
- expose record tuple on model
- add template filter for extracting initials

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68523f3d0c908321a1114fe5b3cf8a91