### PR TITLE
Style competitors table

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -352,3 +352,15 @@ textarea.form-control {
   object-fit: cover;
   border-radius: 50%;
 }
+
+/* Estilos para la tabla de competidores */
+.competitors-table,
+.competitors-table th,
+.competitors-table td {
+  border: none !important;
+  background-color: transparent !important;
+}
+
+.competitors-table {
+  border-collapse: collapse;
+}

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -353,8 +353,8 @@
                     <div class="p-3 tab-pane fade" id="competitors">
                         {% if competidores %}
                             <div class="table-responsive mt-3">
-                                <table class="table table-sm table-striped table-bordered text-center">
-                                    <thead class="table-dark">
+                                <table class="table table-sm text-center competitors-table">
+                                    <thead>
                                         <tr>
                                             <th>Boxeador</th>
                                             <th>Record</th>
@@ -365,8 +365,8 @@
                                     <tbody>
                                         {% for competidor in competidores %}
                                             <tr>
-                                                <td class="text-start">
-                                                    <div class="d-flex align-items-center">
+                                                <td>
+                                                    <div class="d-flex align-items-center justify-content-center">
                                                         {% if competidor.avatar %}
                                                             <img src="{{ competidor.avatar.url }}" alt="{{ competidor.nombre }}" class="competitor-avatar-img me-2">
                                                         {% else %}


### PR DESCRIPTION
## Summary
- clean up competitor list table for club profile
- center competitor info and keep avatar at 30px

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6853809dc0b8832193ed98f98f696cfc