### PR TITLE
Add schedule interval highlighting

### DIFF
--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -29,6 +29,7 @@ def club_profile(request, slug):
     if request.user.is_authenticated:
         reseña_existente = club.reseñas.filter(usuario=request.user).first()
 
+
     form = ReseñaForm()
     register_form = RegistroUsuarioForm()
     if request.method == 'POST' and not reseña_existente:

--- a/apps/core/templatetags/utils_filters.py
+++ b/apps/core/templatetags/utils_filters.py
@@ -12,3 +12,11 @@ def initials(value):
         return ""
     initials = "".join(p[0] for p in parts[:2])
     return initials.upper()
+
+
+@register.filter
+def get_item(dictionary, key):
+    """Return dictionary value for the given key."""
+    if isinstance(dictionary, dict):
+        return dictionary.get(key, '')
+    return ''

--- a/static/js/schedule-status.js
+++ b/static/js/schedule-status.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const dayMap = ['domingo','lunes','martes','miercoles','jueves','viernes','sabado'];
+  const now = new Date();
+  const currentDay = dayMap[now.getDay()];
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+  const statusEl = document.getElementById('open-status');
+  const cell = document.querySelector(`td[data-day="${currentDay}"]`);
+  let openNow = false;
+
+  if (cell) {
+    const items = cell.querySelectorAll('.schedule-item');
+    items.forEach((item) => {
+      const start = item.dataset.start;
+      const end = item.dataset.end;
+      if (start && end) {
+        const [sh, sm] = start.split(':').map(Number);
+        const [eh, em] = end.split(':').map(Number);
+        const startMin = sh * 60 + sm;
+        const endMin = eh * 60 + em;
+        if (currentMinutes >= startMin && currentMinutes <= endMin) {
+          openNow = true;
+          item.classList.add('bg-success-subtle', 'fw-bold');
+          item.classList.remove('text-muted');
+        }
+      }
+    });
+  }
+
+  if (statusEl) {
+    if (openNow) {
+      statusEl.textContent = 'Abierto ahora';
+      statusEl.classList.add('text-success');
+    } else {
+      statusEl.textContent = 'Cerrado ahora';
+      statusEl.classList.add('text-danger');
+    }
+  }
+});

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -269,6 +269,7 @@
                    
                     <!-- Horarios -->
                     <div class=" p-3 tab-pane fade" id="schedule" role="tabpanel">
+                        <p id="open-status" class="fw-bold"></p>
                         <div class="table-responsive mt-3">
                             <table class="table table-bordered text-center align-middle mb-0"
                                    style="min-width: 700px">
@@ -280,11 +281,11 @@
                                 <tbody>
                                     <tr>
                                         {% for dia, nombre in club.horarios.model.DiasSemana.choices %}
-                                            <td>
+                                            <td class="schedule-day" data-day="{{ dia }}">
                                                 {% with horarios_dia=club.horarios.all|dictsort:"hora_inicio" %}
                                                     {% for h in horarios_dia %}
                                                         {% if h.dia == dia %}
-                                                            <div class="border-bottom py-1 small text-muted">{{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}</div>
+                                                            <div class="border-bottom py-1 small text-muted schedule-item" data-start="{{ h.hora_inicio|time:'H:i' }}" data-end="{{ h.hora_fin|time:'H:i' }}">{{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}</div>
                                                         {% endif %}
                                                     {% empty %}
                                                         <span class="text-muted">—</span>
@@ -537,4 +538,5 @@
     <script src="{% static 'js/share-like.js' %}"></script>
     <script src="{% static 'js/share-modal.js' %}"></script>
     <script src="{% static 'js/gallery-slideshow.js' %}"></script>
+    <script src="{% static 'js/schedule-status.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show schedule times with data attributes
- highlight just the active schedule interval instead of the whole day

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68538e1eef408321b5f5c96e3968e900