### PR TITLE
Implement threaded posts

### DIFF
--- a/apps/clubs/admin.py
+++ b/apps/clubs/admin.py
@@ -86,7 +86,7 @@ class ReseñaAdmin(admin.ModelAdmin):
 
 @admin.register(ClubPost)
 class ClubPostAdmin(admin.ModelAdmin):
-    list_display = ('titulo', 'club', 'created_at', 'evento_fecha')
+    list_display = ('titulo', 'club', 'user', 'created_at', 'evento_fecha')
 
 
 @admin.register(Entrenador)

--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -92,6 +92,11 @@ class ClubPostForm(forms.ModelForm):
             'evento_fecha': forms.DateInput(attrs={'type': 'date'})
         }
 
+class ClubPostReplyForm(forms.ModelForm):
+    class Meta:
+        model = models.ClubPost
+        fields = ['contenido']
+
 
 class BookingForm(forms.ModelForm):
     class Meta:

--- a/apps/clubs/management/commands/seed_clubs.py
+++ b/apps/clubs/management/commands/seed_clubs.py
@@ -88,6 +88,7 @@ class Command(BaseCommand):
             for _ in range(random.randint(1, 3)):
                 ClubPost.objects.create(
                     club=club,
+                    user=club.owner,
                     titulo=fake.sentence(),
                     contenido=fake.paragraph(),
                     evento_fecha=fake.date_this_year(),

--- a/apps/clubs/migrations/0015_clubpost_threads.py
+++ b/apps/clubs/migrations/0015_clubpost_threads.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0014_competidor_new_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='clubpost',
+            name='user',
+            field=models.ForeignKey(default=1, on_delete=django.db.models.deletion.CASCADE, related_name='club_posts', to=settings.AUTH_USER_MODEL),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='clubpost',
+            name='parent',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='replies', to='clubs.clubpost'),
+        ),
+        migrations.AlterField(
+            model_name='clubpost',
+            name='titulo',
+            field=models.CharField(blank=True, max_length=200),
+        ),
+    ]

--- a/apps/clubs/models/post.py
+++ b/apps/clubs/models/post.py
@@ -1,9 +1,12 @@
 from django.db import models
+from django.contrib.auth.models import User
 
 
 class ClubPost(models.Model):
     club = models.ForeignKey('Club', on_delete=models.CASCADE, related_name='posts')
-    titulo = models.CharField(max_length=200)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='club_posts')
+    parent = models.ForeignKey('self', null=True, blank=True, on_delete=models.CASCADE, related_name='replies')
+    titulo = models.CharField(max_length=200, blank=True)
     contenido = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)
     evento_fecha = models.DateField(blank=True, null=True)
@@ -13,3 +16,7 @@ class ClubPost(models.Model):
 
     def __str__(self):
         return f"{self.titulo} - {self.club.name}"
+
+    @property
+    def is_root(self):
+        return self.parent is None

--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -105,7 +105,7 @@ class DashboardPermissionTests(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_non_owner_cannot_edit_post(self):
-        post = ClubPost.objects.create(club=self.club, titulo='t', contenido='c')
+        post = ClubPost.objects.create(club=self.club, user=self.owner, titulo='t', contenido='c')
         self.client.login(username='other', password='pass')
         url = reverse('clubpost_update', args=[post.pk])
         response = self.client.post(url, {'titulo': 'x', 'contenido': 'y'})

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -7,6 +7,7 @@ from .views import (
     post_create,
     post_update,
     post_delete,
+    post_reply,
     book_clase,
     cancel_booking,
 )
@@ -56,6 +57,7 @@ urlpatterns = [
     path('<slug:slug>/posts/nuevo/', post_create, name='clubpost_create'),
     path('posts/<int:pk>/editar/', post_update, name='clubpost_update'),
     path('posts/<int:pk>/eliminar/', post_delete, name='clubpost_delete'),
+    path('posts/<int:pk>/responder/', post_reply, name='clubpost_reply'),
 
     path('clase/<int:clase_id>/reservar/', book_clase, name='book_clase'),
     path('reserva/<int:pk>/cancelar/', cancel_booking, name='cancel_booking'),

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -33,7 +33,7 @@ def dashboard(request, slug):
         return redirect('home')
     classes = club.clases.all()
     coaches = club.entrenadores.all()
-    posts = club.posts.all()
+    posts = club.posts.filter(parent__isnull=True)
     bookings = Booking.objects.filter(
         Q(clase__club=club) | Q(evento__club=club)
     ).select_related('user', 'clase', 'evento')

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -12,7 +12,7 @@ def club_profile(request, slug):
     reseñas = club.reseñas.select_related('usuario__profile', 'usuario').all()
     detallado = club.get_detailed_ratings()
     competidores = club.competidores.all()
-    posts = club.posts.all()
+    posts = club.posts.filter(parent__isnull=True).select_related('user').prefetch_related('replies__user')
     orden = request.GET.get('orden', 'relevantes')
     club_followed = False
     if request.user.is_authenticated:

--- a/apps/users/views/follow.py
+++ b/apps/users/views/follow.py
@@ -53,7 +53,7 @@ def feed(request):
                 .filter(club_id=f.followed_object_id)
             )
             posts.extend(
-                ClubPost.objects.select_related("club").filter(
+                ClubPost.objects.select_related("club", "user").filter(
                     club_id=f.followed_object_id
                 )
             )
@@ -62,6 +62,11 @@ def feed(request):
                 Reseña.objects
                 .select_related("usuario__profile", "club")
                 .filter(usuario_id=f.followed_object_id)
+            )
+            posts.extend(
+                ClubPost.objects.select_related("club", "user").filter(
+                    user_id=f.followed_object_id
+                )
             )
     posts = sorted(posts, key=lambda r: getattr(r, 'creado', r.created_at), reverse=True)[:20]
     return render(request, 'users/feed.html', {'posts': posts})

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -325,20 +325,33 @@
                     <div class="p-3 tab-pane fade" id="posts" role="tabpanel">
                         {% for post in posts %}
                             <div class="mb-3 border rounded p-3">
-                                <h5 class="mb-1">{{ post.titulo }}</h5>
+                                {% if post.titulo %}
+                                    <h5 class="mb-1">{{ post.titulo }}</h5>
+                                {% endif %}
                                 <p class="mb-1">{{ post.contenido }}</p>
                                 {% if post.evento_fecha %}
                                     <p class="mb-1">
                                         <strong>Evento:</strong> {{ post.evento_fecha }}
                                     </p>
                                 {% endif %}
-                                <small class="text-muted">{{ post.created_at }}</small>
-                                {% if user.is_authenticated %}
-                                    <div class="mt-2">
+                                <small class="text-muted">{{ post.user.username }} · {{ post.created_at }}</small>
+                                <div class="mt-2">
+                                    <a href="{% url 'clubpost_reply' post.pk %}" class="btn btn-sm btn-outline-primary">Responder</a>
+                                    {% if user.is_authenticated %}
                                         <a href="{% url 'clubpost_update' post.pk %}"
                                            class="btn btn-sm btn-outline-secondary">Editar</a>
                                         <a href="{% url 'clubpost_delete' post.pk %}"
                                            class="btn btn-sm btn-outline-danger">Eliminar</a>
+                                    {% endif %}
+                                </div>
+                                {% if post.replies.all %}
+                                    <div class="mt-3 ms-3">
+                                        {% for reply in post.replies.all %}
+                                            <div class="border-top pt-2">
+                                                <small class="text-muted">{{ reply.user.username }} · {{ reply.created_at }}</small>
+                                                <p class="mb-1">{{ reply.contenido }}</p>
+                                            </div>
+                                        {% endfor %}
                                     </div>
                                 {% endif %}
                             </div>

--- a/templates/clubs/post_reply_form.html
+++ b/templates/clubs/post_reply_form.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+    <h1 class="h3 mb-4">Responder a {{ post.titulo }}</h1>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit" class="btn btn-primary">Responder</button>
+    </form>
+</div>
+{% endblock %}

--- a/templates/users/feed.html
+++ b/templates/users/feed.html
@@ -19,10 +19,10 @@
                 <small class="text-muted">{{ post.creado }}</small>
             {% else %}
                 <p class="mb-1"><a href="{% url 'club_profile' slug=post.club.slug %}">{{ post.club.name }}</a></p>
-                <h5 class="mb-1">{{ post.titulo }}</h5>
+                {% if post.titulo %}<h5 class="mb-1">{{ post.titulo }}</h5>{% endif %}
                 <p class="mb-0">{{ post.contenido }}</p>
                 {% if post.evento_fecha %}<p class="mb-0">Evento: {{ post.evento_fecha }}</p>{% endif %}
-                <small class="text-muted">{{ post.created_at }}</small>
+                <small class="text-muted">{{ post.user.username }} · {{ post.created_at }}</small>
             {% endif %}
         </div>
     {% empty %}


### PR DESCRIPTION
## Summary
- add parent/user fields to `ClubPost` for replies
- create migration for thread support
- allow replying to posts and show them under each post
- extend feed and dashboard to account for new relationships
- update tests and seed data

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685393f42a148321804d22dd02758766