### PR TITLE
Fix clubpost_reply namespace

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
     path('profile/<str:username>/', user_profile.profile_detail, name='user_profile'),
 
     # Clubs: Gestión de Clubs y búsqueda
-    path('clubs/', include('apps.clubs.urls')),
+    path('clubs/', include(('apps.clubs.urls', 'clubs'), namespace='clubs')),
 
 
     # Rutas de autenticación sin el prefijo "accounts/"

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -335,17 +335,11 @@
                                     </p>
                                 {% endif %}
                                 <small class="text-muted">{{ post.user.username }} · {{ post.created_at }}</small>
-                                <div class="mt-2"> 
-                                    <a href="{% url 'clubpost_reply' post.pk %}" class="btn btn-sm btn-outline-primary">Responder</a>
-                                    {% if user.is_authenticated %}
-                                        <a href="{% url 'clubpost_update' post.pk %}"
- 
+                                <div class="mt-2">
                                     <a href="{% url 'clubs:clubpost_reply' post.pk %}" class="btn btn-sm btn-outline-primary">Responder</a>
                                     {% if user.is_authenticated %}
-                                        <a href="{% url 'clubs:clubpost_update' post.pk %}"
-                                            class="btn btn-sm btn-outline-secondary">Editar</a>
-                                        <a href="{% url 'clubs:clubpost_delete' post.pk %}"
-                                           class="btn btn-sm btn-outline-danger">Eliminar</a>
+                                        <a href="{% url 'clubs:clubpost_update' post.pk %}" class="btn btn-sm btn-outline-secondary">Editar</a>
+                                        <a href="{% url 'clubs:clubpost_delete' post.pk %}" class="btn btn-sm btn-outline-danger">Eliminar</a>
                                     {% endif %}
                                 </div>
                                 {% if post.replies.all %}


### PR DESCRIPTION
## Summary
- include `apps.clubs.urls` using the `clubs` namespace so namespaced URLs resolve correctly
- keep club_profile links pointing to the namespaced routes

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685494be9f0c8321915fd0741f2ccbda