### PR TITLE
Implement like & share for posts

### DIFF
--- a/apps/clubs/models/post.py
+++ b/apps/clubs/models/post.py
@@ -10,6 +10,11 @@ class ClubPost(models.Model):
     contenido = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)
     evento_fecha = models.DateField(blank=True, null=True)
+    likes = models.ManyToManyField(
+        User,
+        related_name="liked_clubposts",
+        blank=True,
+    )
 
     class Meta:
         ordering = ['-created_at']

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -8,6 +8,7 @@ from .views import (
     post_update,
     post_delete,
     post_reply,
+    post_toggle_like,
     book_clase,
     cancel_booking,
 )
@@ -58,6 +59,7 @@ urlpatterns = [
     path('posts/<int:pk>/editar/', post_update, name='clubpost_update'),
     path('posts/<int:pk>/eliminar/', post_delete, name='clubpost_delete'),
     path('posts/<int:pk>/responder/', post_reply, name='clubpost_reply'),
+    path('posts/<int:pk>/like/', post_toggle_like, name='clubpost_like'),
 
     path('clase/<int:clase_id>/reservar/', book_clase, name='book_clase'),
     path('reserva/<int:pk>/cancelar/', cancel_booking, name='cancel_booking'),

--- a/apps/clubs/views/post.py
+++ b/apps/clubs/views/post.py
@@ -2,6 +2,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import HttpResponseForbidden
+from django.http import JsonResponse
 
 from ..models import Club, ClubPost
 from ..forms import ClubPostForm, ClubPostReplyForm
@@ -76,3 +77,19 @@ def post_reply(request, pk):
         'post': parent,
         'club': parent.club,
     })
+
+
+@login_required
+def post_toggle_like(request, pk):
+    post = get_object_or_404(ClubPost, pk=pk)
+    if request.user in post.likes.all():
+        post.likes.remove(request.user)
+        liked = False
+    else:
+        post.likes.add(request.user)
+        liked = True
+
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+        return JsonResponse({'liked': liked, 'count': post.likes.count()})
+
+    return redirect('club_profile', slug=post.club.slug)

--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -361,3 +361,34 @@ textarea.form-control {
 .competitors-table {
   border-collapse: collapse;
 }
+
+/* Post avatars */
+.post-avatar {
+  width: 32px;
+  height: 32px;
+  background-color: #000;
+  color: #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+
+.post-avatar-img {
+  width: 32px;
+  height: 32px;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.post-like.liked svg path {
+  fill: #e63946;
+  stroke: #e63946;
+}
+
+.post-like svg path,
+.post-share svg path {
+  stroke: #000;
+}
+

--- a/static/js/post-like.js
+++ b/static/js/post-like.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.post-like').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const url = btn.dataset.url;
+      const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
+      const countSpan = btn.querySelector('.like-count');
+
+      btn.classList.toggle('liked');
+
+      try {
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'X-CSRFToken': csrftoken,
+            'X-Requested-With': 'XMLHttpRequest'
+          },
+          credentials: 'same-origin'
+        });
+        if (res.redirected) {
+          const modal = document.getElementById('loginModal');
+          if (modal) new bootstrap.Modal(modal).show();
+          btn.classList.toggle('liked');
+          return;
+        }
+        if (res.ok) {
+          const data = await res.json();
+          btn.classList.toggle('liked', data.liked);
+          if (countSpan) countSpan.textContent = data.count;
+        } else {
+          btn.classList.toggle('liked');
+        }
+      } catch (err) {
+        console.error(err);
+        btn.classList.toggle('liked');
+      }
+    });
+  });
+});

--- a/static/js/share-modal.js
+++ b/static/js/share-modal.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const modalEl = document.getElementById('shareProfileModal');
   if (!modalEl) return;
 
-  const triggers = document.querySelectorAll('#profile-share, #club-share');
+  const triggers = document.querySelectorAll('#profile-share, #club-share, .post-share');
   const copyBtn = modalEl.querySelector('.share-copy');
   const embedBtn = modalEl.querySelector('.share-embed');
 

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -325,23 +325,47 @@
                     <div class="p-3 tab-pane fade" id="posts" role="tabpanel">
                         {% for post in posts %}
                             <div class="mb-3 border rounded p-3">
-                                {% if post.titulo %}
-                                    <h5 class="mb-1">{{ post.titulo }}</h5>
-                                {% endif %}
-                                <p class="mb-1">{{ post.contenido }}</p>
-                                {% if post.evento_fecha %}
-                                    <p class="mb-1">
-                                        <strong>Evento:</strong> {{ post.evento_fecha }}
-                                    </p>
-                                {% endif %}
-                                <small class="text-muted">{{ post.user.username }} · {{ post.created_at }}</small>
+                                <div class="d-flex mb-2">
+                                    {% if post.user.profile.avatar %}
+                                        <img src="{{ post.user.profile.avatar.url }}" alt="{{ post.user.username }}" class="review-avatar-img rounded-circle me-2">
+                                    {% else %}
+                                        <div class="review-avatar me-2">{{ post.user.username|first|upper }}</div>
+                                    {% endif %}
+                                    <div class="flex-grow-1">
+                                        {% if post.titulo %}
+                                            <h5 class="mb-1">{{ post.titulo }}</h5>
+                                        {% endif %}
+                                        <p class="mb-1">{{ post.contenido }}</p>
+                                        {% if post.evento_fecha %}
+                                            <p class="mb-1"><strong>Evento:</strong> {{ post.evento_fecha }}</p>
+                                        {% endif %}
+                                        <small class="text-muted">{{ post.user.username }} · {{ post.created_at }}</small>
+                                    </div>
+                                </div>
+                                <div class="d-flex align-items-center gap-3 mt-2">
+                                    <button class="btn p-0 post-like {% if user.is_authenticated and user in post.likes.all %}liked{% endif %}" data-url="{% url 'clubpost_like' post.pk %}">
+                                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24">
+                                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
+                                        </svg>
+                                        <span class="like-count ms-1">{{ post.likes.count }}</span>
+                                    </button>
+                                    <a href="{% url 'clubpost_reply' post.pk %}" class="text-decoration-none text-reset">
+                                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24">
+                                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                                        </svg>
+                                        <span class="ms-1">{{ post.replies.count }}</span>
+                                    </a>
+                                    <button type="button" class="btn p-0 post-share">
+                                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24">
+                                            <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M7.926 10.898 15 7.727m-7.074 5.39L15 16.29M8 12a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm12 5.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm0-11a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Z" />
+                                        </svg>
+                                    </button>
+                                </div>
                                 <div class="mt-2">
                                     <a href="{% url 'clubpost_reply' post.pk %}" class="btn btn-sm btn-outline-primary">Responder</a>
                                     {% if user.is_authenticated %}
-                                        <a href="{% url 'clubpost_update' post.pk %}"
-                                           class="btn btn-sm btn-outline-secondary">Editar</a>
-                                        <a href="{% url 'clubpost_delete' post.pk %}"
-                                           class="btn btn-sm btn-outline-danger">Eliminar</a>
+                                        <a href="{% url 'clubpost_update' post.pk %}" class="btn btn-sm btn-outline-secondary">Editar</a>
+                                        <a href="{% url 'clubpost_delete' post.pk %}" class="btn btn-sm btn-outline-danger">Eliminar</a>
                                     {% endif %}
                                 </div>
                                 {% if post.replies.all %}
@@ -550,6 +574,7 @@
     <script src="{% static 'js/rating.js' %}"></script>
     <script src="{% static 'js/share-like.js' %}"></script>
     <script src="{% static 'js/share-modal.js' %}"></script>
+    <script src="{% static 'js/post-like.js' %}"></script>
     <script src="{% static 'js/gallery-slideshow.js' %}"></script>
     <script src="{% static 'js/schedule-status.js' %}"></script>
 {% endblock %}

--- a/templates/users/feed.html
+++ b/templates/users/feed.html
@@ -18,15 +18,49 @@
                 <p class="mb-0">{{ post.comentario }}</p>
                 <small class="text-muted">{{ post.creado }}</small>
             {% else %}
-                <p class="mb-1"><a href="{% url 'club_profile' slug=post.club.slug %}">{{ post.club.name }}</a></p>
-                {% if post.titulo %}<h5 class="mb-1">{{ post.titulo }}</h5>{% endif %}
-                <p class="mb-0">{{ post.contenido }}</p>
-                {% if post.evento_fecha %}<p class="mb-0">Evento: {{ post.evento_fecha }}</p>{% endif %}
-                <small class="text-muted">{{ post.user.username }} · {{ post.created_at }}</small>
+                <div class="d-flex mb-1">
+                    {% if post.user.profile.avatar %}
+                        <img src="{{ post.user.profile.avatar.url }}" alt="{{ post.user.username }}" class="review-avatar-img rounded-circle me-2">
+                    {% else %}
+                        <div class="review-avatar me-2">{{ post.user.username|first|upper }}</div>
+                    {% endif %}
+                    <div class="flex-grow-1">
+                        <p class="mb-1"><a href="{% url 'club_profile' slug=post.club.slug %}">{{ post.club.name }}</a></p>
+                        {% if post.titulo %}<h5 class="mb-1">{{ post.titulo }}</h5>{% endif %}
+                        <p class="mb-0">{{ post.contenido }}</p>
+                        {% if post.evento_fecha %}<p class="mb-0">Evento: {{ post.evento_fecha }}</p>{% endif %}
+                        <small class="text-muted">{{ post.user.username }} · {{ post.created_at }}</small>
+                    </div>
+                </div>
+                <div class="d-flex align-items-center gap-3 mt-1">
+                    <button class="btn p-0 post-like {% if user.is_authenticated and user in post.likes.all %}liked{% endif %}" data-url="{% url 'clubpost_like' post.pk %}">
+                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
+                        </svg>
+                        <span class="like-count ms-1">{{ post.likes.count }}</span>
+                    </button>
+                    <a href="{% url 'clubpost_reply' post.pk %}" class="text-decoration-none text-reset">
+                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                        </svg>
+                        <span class="ms-1">{{ post.replies.count }}</span>
+                    </a>
+                    <button type="button" class="btn p-0 post-share">
+                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M7.926 10.898 15 7.727m-7.074 5.39L15 16.29M8 12a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm12 5.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm0-11a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Z" />
+                        </svg>
+                    </button>
+                </div>
             {% endif %}
         </div>
     {% empty %}
         <p>No hay publicaciones aún.</p>
-    {% endfor %}
+{% endfor %}
 </div>
+{% include 'partials/_share_profile_modal.html' %}
+{% endblock %}
+
+{% block extra_js %}
+<script src="{% static 'js/post-like.js' %}"></script>
+<script src="{% static 'js/share-modal.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `likes` M2M field to `ClubPost`
- allow toggling likes via new view and route
- display avatars, likes, comments and share button on posts
- enable like button behaviour with `post-like.js`
- support sharing posts through existing modal

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6854a2c44b648321a288b7683570a230