### PR TITLE
Persist profile tab across reload

### DIFF
--- a/static/js/profile-tabs.js
+++ b/static/js/profile-tabs.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const tabs = document.querySelectorAll('.profile-tab');
   const sections = document.querySelectorAll('.profile-section');
+  const storageKey = 'activeTab:' + window.location.pathname;
 
   function activate(tab) {
     tabs.forEach(t => t.classList.remove('active'));
@@ -9,12 +10,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const target = tab.dataset.target;
     const sec = document.getElementById(target);
     if (sec) sec.classList.add('active');
+    localStorage.setItem(storageKey, target);
   }
 
   tabs.forEach(t => {
     t.addEventListener('click', () => activate(t));
   });
-
-  const activeTab = document.querySelector('.profile-tab.active') || tabs[0];
+  let target = localStorage.getItem(storageKey);
+  let activeTab = tabs[0];
+  if (target) {
+    const stored = document.querySelector(`.profile-tab[data-target="${target}"]`);
+    if (stored) activeTab = stored;
+  } else {
+    activeTab = document.querySelector('.profile-tab.active') || tabs[0];
+  }
   if (activeTab) activate(activeTab);
 });


### PR DESCRIPTION
## Summary
- store the selected profile tab in local storage
- restore the saved tab on the next page load

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6854abc2a2908321954b301870a37f0a