### PR TITLE
Persist profile tab across reload

### DIFF
--- a/static/js/profile-tabs.js
+++ b/static/js/profile-tabs.js
@@ -1,20 +1,33 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const tabs = document.querySelectorAll('.profile-tab');
+  const tabs = document.querySelectorAll('.profile-tab[data-target]');
   const sections = document.querySelectorAll('.profile-section');
+  if (!tabs.length) return;
+  const storageKey = 'activeTab:' + window.location.pathname;
 
   function activate(tab) {
+    const target = tab.dataset.target;
+    if (!target) return;
+
     tabs.forEach(t => t.classList.remove('active'));
     sections.forEach(s => s.classList.remove('active'));
     tab.classList.add('active');
-    const target = tab.dataset.target;
     const sec = document.getElementById(target);
     if (sec) sec.classList.add('active');
+    localStorage.setItem(storageKey, target);
   }
 
   tabs.forEach(t => {
     t.addEventListener('click', () => activate(t));
   });
 
-  const activeTab = document.querySelector('.profile-tab.active') || tabs[0];
+  let target = localStorage.getItem(storageKey);
+  let activeTab = null;
+  if (target) {
+    const stored = document.querySelector(`.profile-tab[data-target="${target}"]`);
+    if (stored) activeTab = stored;
+  }
+  if (!activeTab) {
+    activeTab = document.querySelector('.profile-tab.active[data-target]') || tabs[0];
+  }
   if (activeTab) activate(activeTab);
 });


### PR DESCRIPTION
## Summary
- store selected profile tab using localStorage
- restore the saved tab on next load even if the logout button is clicked

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6854abc2a2908321954b301870a37f0a