### PR TITLE
Persist active tab on club profile

### DIFF
--- a/static/js/club-tabs.js
+++ b/static/js/club-tabs.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const tabs = document.querySelectorAll('#clubTabs button[data-bs-toggle="tab"]');
+  if (!tabs.length) return;
+
+  const storageKey = 'clubActiveTab:' + window.location.pathname;
+
+  tabs.forEach(tab => {
+    tab.addEventListener('shown.bs.tab', e => {
+      localStorage.setItem(storageKey, e.target.getAttribute('data-bs-target'));
+    });
+  });
+
+  const active = localStorage.getItem(storageKey);
+  if (active) {
+    const stored = document.querySelector(`#clubTabs button[data-bs-target="${active}"]`);
+    if (stored) {
+      const bootstrapTab = new bootstrap.Tab(stored);
+      bootstrapTab.show();
+    }
+  }
+});

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -577,4 +577,5 @@
     <script src="{% static 'js/post-like.js' %}"></script>
     <script src="{% static 'js/gallery-slideshow.js' %}"></script>
     <script src="{% static 'js/schedule-status.js' %}"></script>
+    <script src="{% static 'js/club-tabs.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- keep club profile tabs active after page reloads with localStorage

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6854ae4c94108321a924d794f437b89d