### PR TITLE
Update reviews star rendering

### DIFF
--- a/apps/core/templatetags/star_rating.py
+++ b/apps/core/templatetags/star_rating.py
@@ -14,9 +14,7 @@ def render_stars(rating):
         rating = 0
     filled = int(round(rating))
     filled = max(0, min(filled, 5))
-    empty = 5 - filled
     def star(color):
         return f'<svg width="20" height="20" viewBox="0 0 24 24" fill="{color}" stroke="#666"><path d="{STAR_PATH}"/></svg>'
     stars_html = ''.join(star('#000') for _ in range(filled))
-    stars_html += ''.join(star('transparent') for _ in range(empty))
     return mark_safe(stars_html)

--- a/templates/clubs/reviews_list.html
+++ b/templates/clubs/reviews_list.html
@@ -1,3 +1,4 @@
+{% load star_rating %}
 {% for reseña in reseñas %}
   <div class="mb-3 rounded p-4 border position-relative" style="min-height: 120px;">
     <div class="d-flex justify-content-between align-items-center mb-2">
@@ -9,7 +10,10 @@
           {% endif %}
           <div class="fw-medium ms-2">{{ reseña.usuario.username }}</div>
         </div>
-      <div class=" fw-bold  ">⭐ {{ reseña.promedio }}</div> 
+      <div class="fw-bold d-flex align-items-center">
+        {% render_stars reseña.promedio %}
+        <span class="ms-1">{{ reseña.promedio }}</span>
+      </div>
 
     </div>
     <p class="mb-3 review-text">{{ reseña.comentario }}</p>


### PR DESCRIPTION
## Summary
- show only filled stars in the `render_stars` template tag

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6854bd2b497c8321bb1309fae7c6ae34