### PR TITLE
Restrict post creation to club owner

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -110,3 +110,9 @@ class DashboardPermissionTests(TestCase):
         url = reverse('clubpost_update', args=[post.pk])
         response = self.client.post(url, {'titulo': 'x', 'contenido': 'y'})
         self.assertEqual(response.status_code, 403)
+
+    def test_non_owner_cannot_create_post(self):
+        self.client.login(username='other', password='pass')
+        url = reverse('clubpost_create', args=[self.club.slug])
+        response = self.client.post(url, {'titulo': 'x', 'contenido': 'y'})
+        self.assertEqual(response.status_code, 403)

--- a/apps/clubs/views/post.py
+++ b/apps/clubs/views/post.py
@@ -12,7 +12,8 @@ from ..permissions import has_club_permission
 @login_required
 def post_create(request, slug):
     club = get_object_or_404(Club, slug=slug)
-    if not has_club_permission(request.user, club):
+    # Only the owner of the club is allowed to create new posts
+    if request.user != club.owner:
         return HttpResponseForbidden()
     if request.method == 'POST':
         form = ClubPostForm(request.POST)

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -382,7 +382,7 @@
                         {% empty %}
                             <p>No hay publicaciones.</p>
                         {% endfor %}
-                        {% if user.is_authenticated %}
+                        {% if user.is_authenticated and user == club.owner %}
                             <a href="{% url 'clubpost_create' club.slug %}"
                                class="btn btn-primary mt-3">Crear publicación</a>
                         {% endif %}


### PR DESCRIPTION
## Summary
- restrict post creation so only the club owner can create posts
- hide the create button from other users
- add test for this permission rule

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6855855f065c832181de96aad587e4c5