### PR TITLE
Improve club posts UX

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -94,7 +94,7 @@ class ReseñaForm(forms.ModelForm):
 class ClubPostForm(forms.ModelForm):
     class Meta:
         model = models.ClubPost
-        fields = ['titulo', 'contenido', 'evento_fecha']
+        fields = ['titulo', 'contenido', 'image', 'evento_fecha']
         widgets = {
             'evento_fecha': forms.DateInput(attrs={'type': 'date'})
         }

--- a/apps/clubs/migrations/0018_clubpost_image.py
+++ b/apps/clubs/migrations/0018_clubpost_image.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0017_resena_titulo'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='clubpost',
+            name='image',
+            field=models.ImageField(blank=True, null=True, upload_to='club_post_images/'),
+        ),
+    ]

--- a/apps/clubs/models/post.py
+++ b/apps/clubs/models/post.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.contrib.auth.models import User
 
+from apps.core.utils.image_utils import resize_image
+
 
 class ClubPost(models.Model):
     club = models.ForeignKey('Club', on_delete=models.CASCADE, related_name='posts')
@@ -8,6 +10,7 @@ class ClubPost(models.Model):
     parent = models.ForeignKey('self', null=True, blank=True, on_delete=models.CASCADE, related_name='replies')
     titulo = models.CharField(max_length=200, blank=True)
     contenido = models.TextField()
+    image = models.ImageField(upload_to='club_post_images/', blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     evento_fecha = models.DateField(blank=True, null=True)
     likes = models.ManyToManyField(
@@ -25,3 +28,8 @@ class ClubPost(models.Model):
     @property
     def is_root(self):
         return self.parent is None
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        if self.image and hasattr(self.image, 'path'):
+            resize_image(self.image.path)

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render, get_object_or_404, redirect 
 from ..models import Club, Entrenador
 from django.contrib import messages
-from apps.clubs.forms import ReseñaForm
+from apps.clubs.forms import ReseñaForm, ClubPostForm, ClubPostReplyForm
 from apps.users.forms import RegistroUsuarioForm
 from apps.users.models import Follow
 from django.contrib.contenttypes.models import ContentType
@@ -40,6 +40,8 @@ def club_profile(request, slug):
         schedule_data[day] = "|".join(intervals)
 
     form = ReseñaForm()
+    post_form = ClubPostForm()
+    reply_form = ClubPostReplyForm()
     register_form = RegistroUsuarioForm()
     if request.method == 'POST' and not reseña_existente:
         form = ReseñaForm(request.POST)
@@ -69,6 +71,8 @@ def club_profile(request, slug):
         'reseñas': reseñas,
         'posts': posts,
         'form': form,
+        'post_form': post_form,
+        'reply_form': reply_form,
         'reseña_existente': reseña_existente,
         'detallado': detallado,
         'competidores': competidores,

--- a/apps/core/templatetags/utils_filters.py
+++ b/apps/core/templatetags/utils_filters.py
@@ -20,3 +20,31 @@ def get_item(dictionary, key):
     if isinstance(dictionary, dict):
         return dictionary.get(key, '')
     return ''
+
+
+@register.filter
+def time_since_short(value):
+    """Return relative time from ``value`` to now in Spanish."""
+    if not value:
+        return ""
+    from django.utils import timezone
+
+    now = timezone.now()
+    diff = now - value
+    seconds = int(diff.total_seconds())
+
+    if seconds < 60:
+        return f"hace {seconds} segundos"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"hace {minutes} minutos"
+    hours = minutes // 60
+    if hours < 24:
+        return f"hace {hours}h"
+    days = hours // 24
+    if days < 7:
+        return f"hace {days}d"
+    weeks = days // 7
+    if weeks == 1:
+        return "hace 1 semana"
+    return f"hace {weeks} semanas"

--- a/apps/users/views/follow.py
+++ b/apps/users/views/follow.py
@@ -6,6 +6,7 @@ from django.contrib import messages
 from django.contrib.auth.models import User
 
 from apps.clubs.models import Club, Reseña, ClubPost
+from apps.clubs.forms import ClubPostReplyForm
 from ..models import Follow
 
 
@@ -71,4 +72,5 @@ def feed(request):
                 )
             )
     posts = sorted(posts, key=lambda r: getattr(r, 'creado', r.created_at), reverse=True)[:20]
-    return render(request, 'users/feed.html', {'posts': posts})
+    reply_form = ClubPostReplyForm()
+    return render(request, 'users/feed.html', {'posts': posts, 'reply_form': reply_form})

--- a/templates/clubs/_post_modal.html
+++ b/templates/clubs/_post_modal.html
@@ -1,0 +1,17 @@
+<div class="modal fade" id="postModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content p-3">
+      <div class="modal-header">
+        <h5 class="modal-title">Nueva publicación</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form method="post" action="{% url 'clubpost_create' club.slug %}" enctype="multipart/form-data">
+          {% csrf_token %}
+          {{ post_form.as_p }}
+          <button type="submit" class="btn btn-primary">Publicar</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/clubs/_reply_modal.html
+++ b/templates/clubs/_reply_modal.html
@@ -1,0 +1,17 @@
+<div class="modal fade" id="replyModal-{{ post.pk }}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content p-3">
+      <div class="modal-header">
+        <h5 class="modal-title">Responder a {{ post.titulo|default:'publicación' }}</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form method="post" action="{% url 'clubpost_reply' post.pk %}">
+          {% csrf_token %}
+          {{ reply_form.as_p }}
+          <button type="submit" class="btn btn-primary">Responder</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -336,10 +336,13 @@
                                             <h5 class="mb-1">{{ post.titulo }}</h5>
                                         {% endif %}
                                         <p class="mb-1">{{ post.contenido }}</p>
+                                        {% if post.image %}
+                                            <img src="{{ post.image.url }}" class="img-fluid mb-2" alt="imagen">
+                                        {% endif %}
                                         {% if post.evento_fecha %}
                                             <p class="mb-1"><strong>Evento:</strong> {{ post.evento_fecha }}</p>
                                         {% endif %}
-                                        <small class="text-muted">{{ post.user.username }} · {{ post.created_at }}</small>
+                                        <small class="text-muted">{{ post.user.username }} · {{ post.created_at|time_since_short }}</small>
                                     </div>
                                 </div>
                                 <div class="d-flex align-items-center gap-3 mt-2">
@@ -349,7 +352,7 @@
                                         </svg>
                                         <span class="like-count ms-1">{{ post.likes.count }}</span>
                                     </button>
-                                    <a href="{% url 'clubpost_reply' post.pk %}" class="text-decoration-none text-reset">
+                                    <a class="text-decoration-none text-reset" data-bs-toggle="collapse" href="#replies-{{ post.pk }}" role="button" aria-expanded="false">
                                         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24">
                                             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
                                         </svg>
@@ -362,17 +365,17 @@
                                     </button>
                                 </div>
                                 <div class="mt-2">
-                                    <a href="{% url 'clubpost_reply' post.pk %}" class="btn btn-sm btn-outline-primary">Responder</a>
+                                    <button type="button" class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#replyModal-{{ post.pk }}">Responder</button>
                                     {% if user.is_authenticated %}
                                         <a href="{% url 'clubpost_update' post.pk %}" class="btn btn-sm btn-outline-secondary">Editar</a>
                                         <a href="{% url 'clubpost_delete' post.pk %}" class="btn btn-sm btn-outline-danger">Eliminar</a>
                                     {% endif %}
                                 </div>
                                 {% if post.replies.all %}
-                                    <div class="mt-3 ms-3">
+                                    <div class="collapse mt-3 ms-3" id="replies-{{ post.pk }}">
                                         {% for reply in post.replies.all %}
                                             <div class="border-top pt-2">
-                                                <small class="text-muted">{{ reply.user.username }} · {{ reply.created_at }}</small>
+                                                <small class="text-muted">{{ reply.user.username }} · {{ reply.created_at|time_since_short }}</small>
                                                 <p class="mb-1">{{ reply.contenido }}</p>
                                             </div>
                                         {% endfor %}
@@ -383,8 +386,7 @@
                             <p>No hay publicaciones.</p>
                         {% endfor %}
                         {% if user.is_authenticated and user == club.owner %}
-                            <a href="{% url 'clubpost_create' club.slug %}"
-                               class="btn btn-primary mt-3">Crear publicación</a>
+                            <button type="button" class="btn btn-primary mt-3" data-bs-toggle="modal" data-bs-target="#postModal">Crear publicación</button>
                         {% endif %}
                     </div>
                     <!-- Competidores -->
@@ -525,6 +527,10 @@
     </div>
     {% include 'partials/_share_profile_modal.html' %}
     {% include 'partials/_register_modal.html' %}
+    {% include 'clubs/_post_modal.html' %}
+    {% for post in posts %}
+        {% include 'clubs/_reply_modal.html' with post=post %}
+    {% endfor %}
     <div class="modal fade" id="reviewModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content p-3">

--- a/templates/clubs/post_form.html
+++ b/templates/clubs/post_form.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container py-4">
     <h1 class="h3 mb-4">Publicación de {{ club.name }}</h1>
-    <form method="post">
+    <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
         {{ form.as_p }}
         <button type="submit" class="btn btn-primary">Guardar</button>

--- a/templates/users/feed.html
+++ b/templates/users/feed.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load utils_filters %}
 
 {% block content %}
 <div class="container py-4">
@@ -28,8 +29,11 @@
                         <p class="mb-1"><a href="{% url 'club_profile' slug=post.club.slug %}">{{ post.club.name }}</a></p>
                         {% if post.titulo %}<h5 class="mb-1">{{ post.titulo }}</h5>{% endif %}
                         <p class="mb-0">{{ post.contenido }}</p>
+                        {% if post.image %}
+                            <img src="{{ post.image.url }}" class="img-fluid mb-1" alt="imagen">
+                        {% endif %}
                         {% if post.evento_fecha %}<p class="mb-0">Evento: {{ post.evento_fecha }}</p>{% endif %}
-                        <small class="text-muted">{{ post.user.username }} · {{ post.created_at }}</small>
+                        <small class="text-muted">{{ post.user.username }} · {{ post.created_at|time_since_short }}</small>
                     </div>
                 </div>
                 <div class="d-flex align-items-center gap-3 mt-1">
@@ -39,7 +43,7 @@
                         </svg>
                         <span class="like-count ms-1">{{ post.likes.count }}</span>
                     </button>
-                    <a href="{% url 'clubpost_reply' post.pk %}" class="text-decoration-none text-reset">
+                    <a class="text-decoration-none text-reset" data-bs-toggle="collapse" href="#feed-replies-{{ post.pk }}" role="button" aria-expanded="false">
                         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24">
                             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
                         </svg>
@@ -51,12 +55,28 @@
                         </svg>
                     </button>
                 </div>
+                <div class="mt-1">
+                    <button type="button" class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#replyModal-{{ post.pk }}">Responder</button>
+                </div>
+                {% if post.replies.all %}
+                    <div class="collapse ms-3 mt-2" id="feed-replies-{{ post.pk }}">
+                        {% for reply in post.replies.all %}
+                            <div class="border-top pt-2">
+                                <small class="text-muted">{{ reply.user.username }} · {{ reply.created_at|time_since_short }}</small>
+                                <p class="mb-1">{{ reply.contenido }}</p>
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% endif %}
             {% endif %}
         </div>
     {% empty %}
         <p>No hay publicaciones aún.</p>
 {% endfor %}
 </div>
+{% for post in posts %}
+    {% include 'clubs/_reply_modal.html' with post=post %}
+{% endfor %}
 {% include 'partials/_share_profile_modal.html' %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- add `time_since_short` filter for relative timestamps
- allow uploading images in club posts
- open post creation and replies in modals
- toggle replies with a collapse element
- show relative publication time in feed and profiles

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68558aeea7c88321bd9bf7163cf10208