### PR TITLE
Add feboxeo scraping command

### DIFF
--- a/apps/clubs/management/commands/scrape_feboxeo.py
+++ b/apps/clubs/management/commands/scrape_feboxeo.py
@@ -1,0 +1,69 @@
+from django.core.management.base import BaseCommand
+from django.core.files.base import ContentFile
+from apps.clubs.models import Club
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+import os
+
+
+class Command(BaseCommand):
+    help = 'Scrape club data from feboxeo.es and store it in the database.'
+
+    def handle(self, *args, **options):
+        url = 'https://feboxeo.es/donde-boxeo/'
+        headers = {
+            'User-Agent': (
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                'AppleWebKit/537.36 (KHTML, like Gecko) '
+                'Chrome/119.0.0.0 Safari/537.36'
+            )
+        }
+        try:
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            self.stderr.write(f'Error fetching {url}: {exc}')
+            return
+
+        soup = BeautifulSoup(response.text, 'html.parser')
+
+        clubs = soup.select('.club-list-item')
+        for item in clubs:
+            name_el = item.select_one('.club-name')
+            if not name_el:
+                continue
+            name = name_el.get_text(strip=True)
+
+            address_el = item.select_one('.club-address')
+            email_el = item.select_one('a[href^=mailto]')
+            logo_el = item.select_one('img')
+
+            address = address_el.get_text(strip=True) if address_el else ''
+            email = email_el['href'].replace('mailto:', '') if email_el else ''
+            logo_url = None
+            if logo_el and logo_el.get('src'):
+                logo_url = urljoin(url, logo_el['src'])
+
+            club, created = Club.objects.get_or_create(
+                name=name,
+                defaults={'address': address, 'email': email}
+            )
+            if not created:
+                club.address = address
+                club.email = email
+                club.save(update_fields=['address', 'email'])
+
+            if logo_url:
+                try:
+                    img_resp = requests.get(logo_url, headers=headers)
+                    img_resp.raise_for_status()
+                    club.logo.save(
+                        os.path.basename(logo_url),
+                        ContentFile(img_resp.content),
+                        save=True
+                    )
+                except requests.RequestException:
+                    self.stderr.write(f'Failed to download logo for {name}')
+
+        self.stdout.write(self.style.SUCCESS('Scraping completado'))

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,18 @@ export CSRF_TRUSTED_ORIGINS="https://tu-dominio.example.com"
 
 El sitio quedará disponible en http://127.0.0.1:8000/.
 
+### Importar clubes desde feboxeo.es
+
+Para cargar los clubes listados en [feboxeo.es](https://feboxeo.es/donde-boxeo/) ejecuta el siguiente comando:
+
+```bash
+python manage.py scrape_feboxeo
+```
+
+Esto creará o actualizará registros de clubes con su logo, dirección y correo electrónico. Si el sitio
+rechaza la solicitud con un error *403 Forbidden*, el comando ya incluye un encabezado "User-Agent"
+que simula un navegador para evitar dicho bloqueo.
+
 
 ## Instalación de dependencias
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ django-allauth
 cryptography
 PyJWT
 Faker
+requests
+beautifulsoup4
 


### PR DESCRIPTION
## Summary
- add management command `scrape_feboxeo` to fetch clubs from feboxeo.es
- document command usage in README
- add requests and beautifulsoup4 as dependencies
- fix command headers to avoid 403 error when fetching site

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6855907b24488321a33899a7e07d9d1f