### PR TITLE
Improve reply threading visuals

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -19,6 +19,13 @@
     box-sizing: border-box;
     -webkit-tap-highlight-color: transparent;
     scroll-behavior: smooth;
+} 
+
+/* Reply thread styling */
+.reply-thread {
+    border-left: 2px solid #dee2e6;
+    margin-left: 1rem;
+    padding-left: 1rem;
 }
 
 /* 2. Modernizing HTML5 elements */

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -370,7 +370,7 @@
                                         <a href="{% url 'clubpost_delete' post.pk %}" class="btn btn-sm btn-outline-danger">Eliminar</a>
                                     {% endif %}
                                 </div>
-                                <div class="collapse mt-3 ms-3" id="replies-{{ post.pk }}">
+                                <div class="collapse mt-3 reply-thread" id="replies-{{ post.pk }}">
                                     {% for reply in post.replies.all %}
                                         <div class="d-flex border-top pt-2">
                                             {% if reply.user.profile.avatar %}

--- a/templates/users/feed.html
+++ b/templates/users/feed.html
@@ -55,7 +55,7 @@
                         </svg>
                     </button>
                 </div>
-                <div class="collapse ms-3 mt-2" id="feed-replies-{{ post.pk }}">
+                <div class="collapse mt-2 reply-thread" id="feed-replies-{{ post.pk }}">
                     {% for reply in post.replies.all %}
                         <div class="d-flex border-top pt-2">
                             {% if reply.user.profile.avatar %}


### PR DESCRIPTION
## Summary
- style reply sections with a left border to emphasize conversation threads
- indent reply sections using a new `reply-thread` class

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6855941b6ed4832196ab6438b7e79c14