### PR TITLE
Fix missing template error

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -550,9 +550,6 @@
     {% include 'partials/_share_profile_modal.html' %}
     {% include 'partials/_register_modal.html' %}
     {% include 'clubs/_post_modal.html' %}
-    {% for post in posts %}
-        {% include 'clubs/_reply_modal.html' with post=post %}
-    {% endfor %}
     <div class="modal fade" id="reviewModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content p-3">


### PR DESCRIPTION
## Summary
- remove leftover reference to deleted reply modal

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6855a3543bc083219f849a92f26a2dfa