### PR TITLE
Fix media helpers

### DIFF
--- a/apps/core/templatetags/utils_filters.py
+++ b/apps/core/templatetags/utils_filters.py
@@ -59,7 +59,11 @@ def youtube_embed(text):
     from django.utils.html import escape
     from django.utils.safestring import mark_safe
 
-    pattern = r"(https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)([\w-]+))"
+    pattern = (
+        r"(https?://(?:www\.)?"
+        r"(?:youtube\.com/(?:watch\?v=|shorts/)|youtu\.be/)([\w-]+))"
+        r"(?:\S*)"
+    )
     match = re.search(pattern, text)
     if not match:
         return escape(text)

--- a/apps/core/tests.py
+++ b/apps/core/tests.py
@@ -1,0 +1,18 @@
+from django.test import SimpleTestCase
+
+from .templatetags.utils_filters import youtube_embed
+
+
+class YoutubeEmbedTests(SimpleTestCase):
+    def test_embed_with_extra_params(self):
+        text = 'Check this https://youtu.be/abc123?si=XYZ'
+        html = youtube_embed(text)
+        self.assertIn('iframe', html)
+        self.assertIn('abc123', html)
+
+    def test_no_match_returns_escaped(self):
+        text = '<script>alert(1)</script>'
+        html = youtube_embed(text)
+        self.assertNotIn('iframe', html)
+        self.assertIn('&lt;script&gt;alert(1)&lt;/script&gt;', html)
+

--- a/static/js/giphy.js
+++ b/static/js/giphy.js
@@ -1,7 +1,8 @@
-(document => {
+document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('giphyBtn');
   const modalEl = document.getElementById('giphyModal');
   if (!btn || !modalEl) return;
+
   const modal = new bootstrap.Modal(modalEl);
   const form = modalEl.querySelector('form');
   const results = modalEl.querySelector('.giphy-results');
@@ -40,4 +41,4 @@
       modal.hide();
     }
   });
-})(document);
+});


### PR DESCRIPTION
## Summary
- run giphy code after DOM is ready so the modal works
- improve youtube embedding with a more flexible regex
- add tests for youtube embedding

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_685622a90d788321bdf3ddd6ebef637c