### PR TITLE
Add paginated posts and reviews with fade effect

### DIFF
--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -1,4 +1,5 @@
-from django.shortcuts import render, get_object_or_404, redirect 
+from django.shortcuts import render, get_object_or_404, redirect
+from django.core.paginator import Paginator
 from ..models import Club, Entrenador
 from django.contrib import messages
 from apps.clubs.forms import ReseñaForm, ClubPostForm, ClubPostReplyForm
@@ -66,10 +67,17 @@ def club_profile(request, slug):
     else:  # relevantes (por defecto)
         reseñas = reseñas.order_by('-creado')  # puedes mejorar esto más adelante
 
+    posts_paginator = Paginator(posts, 5)
+    reviews_paginator = Paginator(reseñas, 5)
+    posts_page_number = request.GET.get('posts_page')
+    reviews_page_number = request.GET.get('reviews_page')
+    posts_page = posts_paginator.get_page(posts_page_number)
+    reseñas_page = reviews_paginator.get_page(reviews_page_number)
+
     return render(request, 'clubs/club_profile.html', {
         'club': club,
-        'reseñas': reseñas,
-        'posts': posts,
+        'reseñas_page': reseñas_page,
+        'posts_page': posts_page,
         'form': form,
         'post_form': post_form,
         'reply_form': reply_form,
@@ -79,6 +87,7 @@ def club_profile(request, slug):
         'club_followed': club_followed,
         'register_form': register_form,
         'schedule_data': schedule_data,
+        'orden': orden,
 
     })
 
@@ -108,4 +117,11 @@ def ajax_reviews(request, slug):
     else:
         reseñas = reseñas.order_by('-creado')
 
-    return render(request, 'clubs/reviews_list.html', {'reseñas': reseñas})
+    paginator = Paginator(reseñas, 5)
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
+    return render(request, 'clubs/reviews_list.html', {
+        'page_obj': page_obj,
+        'orden': orden,
+    })

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -206,3 +206,6 @@ p {
         transform: translateX(0);
     }
 }
+.fade-section{opacity:0;transition:opacity 0.3s ease;}
+.fade-section.show{opacity:1;}
+

--- a/static/js/review-filter.js
+++ b/static/js/review-filter.js
@@ -5,7 +5,26 @@ document.addEventListener('DOMContentLoaded', function () {
     const sortSelected = sortDropdown.querySelector('.selected-text');
     const sortMenu = document.getElementById('sort-menu');
     const sortInput = document.getElementById('sort-input');
+    const pageInput = document.getElementById('page-input');
     const reviewsContainer = document.getElementById('review-list');
+
+    function fetchReviews(page) {
+        if (page) pageInput.value = page;
+        const url = form.getAttribute('action');
+        const params = new URLSearchParams(new FormData(form));
+        fetch(url + '?' + params.toString(), {
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+        })
+            .then(res => res.text())
+            .then(html => {
+                reviewsContainer.classList.remove('show');
+                reviewsContainer.innerHTML = html;
+                requestAnimationFrame(() => reviewsContainer.classList.add('show'));
+            })
+            .catch(err => console.error(err));
+    }
 
     sortDropdown.querySelector('.selected').addEventListener('click', function (e) {
         e.stopPropagation();
@@ -16,23 +35,21 @@ document.addEventListener('DOMContentLoaded', function () {
         item.addEventListener('click', function () {
             sortSelected.textContent = item.textContent;
             sortInput.value = item.dataset.value;
+            pageInput.value = 1;
             sortMenu.style.display = 'none';
-            const url = form.getAttribute('action');
-            const params = new URLSearchParams(new FormData(form));
-            fetch(url + '?' + params.toString(), {
-                headers: {
-                    'X-Requested-With': 'XMLHttpRequest'
-                }
-            })
-                .then(res => res.text())
-                .then(html => {
-                    reviewsContainer.innerHTML = html;
-                })
-                .catch(err => console.error(err));
+            fetchReviews();
         });
     });
 
     document.addEventListener('click', function () {
         sortMenu.style.display = 'none';
+    });
+
+    reviewsContainer.addEventListener('click', function (e) {
+        const link = e.target.closest('.page-link');
+        if (link) {
+            e.preventDefault();
+            fetchReviews(link.dataset.page);
+        }
     });
 });

--- a/static/js/section-fade.js
+++ b/static/js/section-fade.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.fade-section').forEach(el => {
+    requestAnimationFrame(() => el.classList.add('show'));
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,6 +39,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{% static 'js/page-loader.js' %}"></script>
 <script src="{% static 'js/clear-input.js' %}"></script>
+<script src="{% static 'js/section-fade.js' %}"></script>
 {% block extra_js %}{% endblock %}
 
 </body>

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -330,14 +330,15 @@
                         {% endif %}
                     </div>
                     <!-- Posts -->
-                    <div class="p-3 tab-pane fade" id="posts" role="tabpanel"> 
-                            <div class=" justify-content-center  d-flex flex-column align-items-center">
-                                {% if user.is_authenticated and user == club.owner %}
-                                    {% include 'clubs/_post_form.html' %}  
-                                {% endif %}
-                            </div> 
-                        {% for post in posts %}
-                          <div class="mt-3 mb-3 col-8 border rounded p-4 mx-auto"> 
+                    <div class="p-3 tab-pane fade" id="posts" role="tabpanel">
+                        <div class="justify-content-center d-flex flex-column align-items-center">
+                            {% if user.is_authenticated and user == club.owner %}
+                                {% include 'clubs/_post_form.html' %}
+                            {% endif %}
+                        </div>
+                        <div id="post-list" class="fade-section">
+                        {% for post in posts_page %}
+                          <div class="mt-3 mb-3 col-8 border rounded p-4 mx-auto">
                                 <div class="d-flex mb-2   justify-content-center  ">
                                     {% if post.user.profile.avatar %}
                                         <img src="{{ post.user.profile.avatar.url }}"   alt="{{ post.user.username }}"  class="review-avatar-img rounded-circle">
@@ -490,7 +491,34 @@
                                 
                                 No hay publicaciones.</p>
                         {% endfor %}
-                    </div>
+                        {% if posts_page.has_other_pages %}
+                            <nav class="mt-3" aria-label="Posts">
+                                <ul class="pagination justify-content-center">
+                                    {% if posts_page.has_previous %}
+                                        <li class="page-item">
+                                            <a class="page-link" href="?posts_page={{ posts_page.previous_page_number }}#posts">&laquo;</a>
+                                        </li>
+                                    {% else %}
+                                        <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+                                    {% endif %}
+                                    {% for num in posts_page.paginator.page_range %}
+                                        {% if posts_page.number == num %}
+                                            <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+                                        {% else %}
+                                            <li class="page-item"><a class="page-link" href="?posts_page={{ num }}#posts">{{ num }}</a></li>
+                                        {% endif %}
+                                    {% endfor %}
+                                    {% if posts_page.has_next %}
+                                        <li class="page-item">
+                                            <a class="page-link" href="?posts_page={{ posts_page.next_page_number }}#posts">&raquo;</a>
+                                        </li>
+                                    {% else %}
+                                        <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+                                    {% endif %}
+                                </ul>
+                            </nav>
+                        {% endif %}
+                        </div>
                     <!-- Competidores -->
                     <div class="p-1 tab-pane fade" id="competitors">
                         {% if competidores %}
@@ -549,7 +577,7 @@
                                     </div>
                                     <div class="col-auto">{% include 'partials/_review-filter.html' with orden=orden club=club %}</div>
                                 </div>
-                                <div class="mt-2 " id="review-list">{% include 'clubs/reviews_list.html' %}</div>
+                                <div class="mt-2 fade-section" id="review-list">{% include 'clubs/reviews_list.html' with page_obj=reseñas_page orden=orden %}</div>
                             </div>
                         </div>
                     </div>

--- a/templates/clubs/reviews_list.html
+++ b/templates/clubs/reviews_list.html
@@ -1,5 +1,5 @@
 {% load star_rating %}
-{% for reseña in reseñas %}
+{% for reseña in page_obj %}
   <div class="mb-3 rounded position-relative">
     <div class="row justify-content-between"> 
       <!-- Columna izquierda (3 col): avatar -->
@@ -56,3 +56,30 @@
 {% empty %}
   <p class="text-muted">Este club todavía no tiene comentarios escritos.</p>
 {% endfor %}
+{% if page_obj.has_other_pages %}
+<nav class="mt-3" aria-label="Reseñas">
+  <ul class="pagination justify-content-center">
+    {% if page_obj.has_previous %}
+    <li class="page-item">
+      <a class="page-link" href="?orden={{ orden }}&reviews_page={{ page_obj.previous_page_number }}#comments" data-page="{{ page_obj.previous_page_number }}">&laquo;</a>
+    </li>
+    {% else %}
+    <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+    {% endif %}
+    {% for num in page_obj.paginator.page_range %}
+      {% if page_obj.number == num %}
+      <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+      {% else %}
+      <li class="page-item"><a class="page-link" href="?orden={{ orden }}&reviews_page={{ num }}#comments" data-page="{{ num }}">{{ num }}</a></li>
+      {% endif %}
+    {% endfor %}
+    {% if page_obj.has_next %}
+    <li class="page-item">
+      <a class="page-link" href="?orden={{ orden }}&reviews_page={{ page_obj.next_page_number }}#comments" data-page="{{ page_obj.next_page_number }}">&raquo;</a>
+    </li>
+    {% else %}
+    <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}

--- a/templates/partials/_review-filter.html
+++ b/templates/partials/_review-filter.html
@@ -1,6 +1,7 @@
  
       <form method="get" id="review-filter-form" action="{% url 'ajax_reviews' club.slug %}" class="d-flex align-items-center" style="gap: 10px;">
         <input type="hidden" name="orden" id="sort-input" value="{{ request.GET.orden|default:'' }}">
+        <input type="hidden" name="page" id="page-input" value="{{ request.GET.reviews_page|default:1 }}">
 
     <div class="custom-dropdown small" id="sort-dropdown">
         <div class="selected">


### PR DESCRIPTION
## Summary
- paginate posts and reviews to five per page
- update templates with pagination controls and fade-in sections
- load new JavaScript for fading sections
- enhance review filter script to handle pagination via AJAX

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for PIL/Django)*

------
https://chatgpt.com/codex/tasks/task_e_685632b007588321bbcc90133a88c55c