### PR TITLE
Move club posts to standalone feed

### DIFF
--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -138,3 +138,18 @@ def ajax_posts(request, slug):
         'request': request,
         'club': club,
     })
+
+def club_feed(request, slug):
+    """Mostrar todas las publicaciones de un club."""
+    club = get_object_or_404(Club, slug=slug)
+    posts_qs = club.posts.filter(parent__isnull=True).select_related('user').prefetch_related('replies__user')
+    paginator = Paginator(posts_qs, 5)
+    posts = paginator.get_page(request.GET.get('post_page'))
+    post_form = ClubPostForm()
+    reply_form = ClubPostReplyForm()
+    return render(request, 'clubs/club_feed.html', {
+        'club': club,
+        'posts': posts,
+        'post_form': post_form,
+        'reply_form': reply_form,
+    })

--- a/config/urls.py
+++ b/config/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
 
     # Perfil público de clubs
     path('@<slug:slug>/admin/', dashboard, name='club_dashboard'),
+    path('@<slug:slug>/feed/', club_public.club_feed, name='club_feed'),
     path('@<slug:slug>/', club_public.club_profile, name='club_profile'),
     path('coach/@<slug:slug>/', club_public.coach_profile, name='coach_profile'),
 

--- a/templates/clubs/club_feed.html
+++ b/templates/clubs/club_feed.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% load utils_filters %}
+
+{% block content %}
+<div class="container py-4">
+    <h1 class="h3 mb-4">{{ club.name }} - Publicaciones</h1>
+    <div class="justify-content-center d-flex flex-column align-items-center">
+        {% if user.is_authenticated and user == club.owner %}
+            {% include 'clubs/_post_form.html' %}
+        {% endif %}
+    </div>
+    <div id="posts-list" class="fade-container mt-2">
+        {% include 'clubs/posts_list.html' %}
+    </div>
+</div>
+{% include 'partials/_share_profile_modal.html' %}
+{% endblock %}
+
+{% block extra_js %}
+<script src="{% static 'js/post-like.js' %}"></script>
+<script src="{% static 'js/share-modal.js' %}"></script>
+{% endblock %}

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -83,6 +83,7 @@
                             <a href="mailto:{{ club.email }}"
                                class="text-decoration-none text-reset">{{ club.email }}</a>
                         </p>
+                        <a href="{% url 'club_feed' slug=club.slug %}" target="_blank" class="btn btn-dark btn-sm">Ver publicaciones</a>
                     </div>
                 </div>
             </div>
@@ -180,14 +181,6 @@
                                 data-bs-target="#schedule"
                                 type="button"
                                 role="tab">Horarios</button>
-                    </li>
-                    <li class="nav-item" role="presentation">
-                        <button class="nav-link"
-                                id="posts-tab"
-                                data-bs-toggle="tab"
-                                data-bs-target="#posts"
-                                type="button"
-                                role="tab">Publicaciones</button>
                     </li>
                     <li class="nav-item" role="presentation">
                         <button class="nav-link"
@@ -328,17 +321,6 @@
                                 </ul>
                             </div>
                         {% endif %}
-                    </div>
-                    <!-- Posts -->
-                    <div class="p-3 tab-pane fade" id="posts" role="tabpanel">
-                        <div class="justify-content-center d-flex flex-column align-items-center">
-                            {% if user.is_authenticated and user == club.owner %}
-                                {% include 'clubs/_post_form.html' %}
-                            {% endif %}
-                        </div>
-                        <div id="posts-list" class="fade-container mt-2">
-                            {% include 'clubs/posts_list.html' %}
-                        </div>
                     </div>
                     <!-- Competidores -->
                     <div class="p-1 tab-pane fade" id="competitors">


### PR DESCRIPTION
## Summary
- add new route `/@slug/feed/` for club posts
- create `club_feed` view and template
- remove posts tab from club profile and add button linking to feed

## Testing
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6859621dfc34832184270fb5564906ee