### PR TITLE
Fix feed to show followed club posts

### DIFF
--- a/apps/users/tests/test_feed.py
+++ b/apps/users/tests/test_feed.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+
+from apps.clubs.models import Club, ClubPost, Reseña
+from apps.users.models import Follow
+
+class FeedViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='follower', password='pass')
+        self.poster = User.objects.create_user(username='poster', password='pass')
+        self.club = Club.objects.create(name='Club', city='C', address='A', phone='1', email='e@e.com')
+        self.post = ClubPost.objects.create(club=self.club, user=self.poster, titulo='t', contenido='club post')
+        self.review = Reseña.objects.create(club=self.club, usuario=self.poster, titulo='r', comentario='club review', instalaciones=1, entrenadores=1, ambiente=1, calidad_precio=1, variedad_clases=1)
+
+    def test_feed_shows_followed_club_posts(self):
+        self.client.login(username='follower', password='pass')
+        url = reverse('toggle_follow', args=['club', self.club.id])
+        self.client.post(url)
+
+        response = self.client.get(reverse('feed'))
+
+        self.assertContains(response, 'club post')
+        self.assertContains(response, 'club review')
+

--- a/apps/users/views/follow.py
+++ b/apps/users/views/follow.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
+from django.db import models
 from django.shortcuts import get_object_or_404, redirect, render
 from django.http import JsonResponse
 from django.contrib import messages
@@ -43,34 +44,33 @@ def feed(request):
         follower_content_type=follower_ct,
         follower_object_id=request.user.id,
     )
-    posts = []
+
     ct_user = ContentType.objects.get_for_model(User)
     ct_club = ContentType.objects.get_for_model(Club)
+
+    club_ids = []
+    user_ids = []
     for f in follows:
-        if f.followed_content_type == ct_club:
-            posts.extend(
-                Reseña.objects
-                .select_related("usuario__profile", "club")
-                .filter(club_id=f.followed_object_id)
-            )
-            posts.extend(
-                ClubPost.objects.select_related("club", "user").filter(
-                    club_id=f.followed_object_id,
-                    parent__isnull=True,
-                )
-            )
-        elif f.followed_content_type == ct_user:
-            posts.extend(
-                Reseña.objects
-                .select_related("usuario__profile", "club")
-                .filter(usuario_id=f.followed_object_id)
-            )
-            posts.extend(
-                ClubPost.objects.select_related("club", "user").filter(
-                    user_id=f.followed_object_id,
-                    parent__isnull=True,
-                )
-            )
-    posts = sorted(posts, key=lambda r: getattr(r, 'creado', r.created_at), reverse=True)[:20]
+        if f.followed_content_type_id == ct_club.id:
+            club_ids.append(f.followed_object_id)
+        elif f.followed_content_type_id == ct_user.id:
+            user_ids.append(f.followed_object_id)
+
+    posts = list(
+        Reseña.objects
+        .select_related("usuario__profile", "club")
+        .filter(models.Q(club_id__in=club_ids) | models.Q(usuario_id__in=user_ids))
+    )
+    posts += list(
+        ClubPost.objects.select_related("club", "user").filter(
+            models.Q(club_id__in=club_ids) | models.Q(user_id__in=user_ids),
+            parent__isnull=True,
+        )
+    )
+    posts = sorted(
+        posts,
+        key=lambda r: getattr(r, "creado", getattr(r, "created_at", None)),
+        reverse=True,
+    )[:20]
     reply_form = ClubPostReplyForm()
     return render(request, 'users/feed.html', {'posts': posts, 'reply_form': reply_form})


### PR DESCRIPTION
## Summary
- gather posts for followed clubs and users in bulk for feed
- test that followed club posts appear in feed
- fix ordering by using the correct timestamp field

## Testing
- `pytest -k feed -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6859bcb78e6c8321a1531288a5075502