### PR TITLE
Add login modal prompt for replies

### DIFF
--- a/templates/clubs/posts_list.html
+++ b/templates/clubs/posts_list.html
@@ -71,11 +71,17 @@
                     <p class="mb-0">{{ reply.contenido }}</p>
                 </div>
             {% endfor %}
-            <form method="post" action="{% url 'clubpost_reply' post.pk %}">
-                {% csrf_token %}
-                {{ reply_form.contenido }}
-                <button type="submit" class="btn btn-sm btn-dark mt-2">Responder</button>
-            </form>
+            {% if user.is_authenticated %}
+                <form method="post" action="{% url 'clubpost_reply' post.pk %}">
+                    {% csrf_token %}
+                    {{ reply_form.contenido }}
+                    <button type="submit" class="btn btn-sm btn-dark mt-2">Responder</button>
+                </form>
+            {% else %}
+                <button type="button" class="btn btn-sm btn-dark mt-2" data-bs-toggle="modal" data-bs-target="#loginModal">
+                    Inicia sesión para responder
+                </button>
+            {% endif %}
         </div>
       </div>
     </div>

--- a/templates/users/feed.html
+++ b/templates/users/feed.html
@@ -83,7 +83,7 @@
                             </form>
                         </div>
                     {% else %}
-                        <p class="text-muted mt-2">Inicia sesión para responder.</p>
+                        <button type="button" class="btn btn-primary btn-sm mt-2" data-bs-toggle="modal" data-bs-target="#loginModal">Inicia sesión para responder</button>
                     {% endif %}
                 </div>
             {% endif %}


### PR DESCRIPTION
## Summary
- open login modal on club posts list when trying to reply while logged out
- open login modal on feed replies when user isn't authenticated

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6859cd6da1148321bd061aff3d01f105