### PR TITLE
Fix schedule header loop

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -279,7 +279,9 @@
                                    style="min-width: 700px">
                                 <thead class="table-dark">
                                     <tr>
-                                        {% for dia, nombre in club.horarios.model.DiasSemana.choices %}<th scope="col">{{ nombre }}</th>{% endfor %}
+                                        {% for dia, nombre in club.horarios.model.DiasSemana.choices %}
+                                            <th scope="col">{{ nombre }}</th>
+                                        {% endfor %}
                                     </tr>
                                 </thead>
                                 <tbody>


### PR DESCRIPTION
## Summary
- break schedule header loop onto separate lines for clarity

## Testing
- `python manage.py runserver` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685bbcf14b3083219f6ad2ad878f79db