### PR TITLE
Add schedule status options

### DIFF
--- a/apps/clubs/admin.py
+++ b/apps/clubs/admin.py
@@ -40,8 +40,19 @@ class ReseñaInline(admin.TabularInline):
     readonly_fields = ('creado',)
 
 
+class HorarioAdminForm(forms.ModelForm):
+    class Meta:
+        model = Horario
+        fields = '__all__'
+        widgets = {
+            'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
+            'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
+        }
+
+
 class HorarioInline(admin.TabularInline):
     model = Horario
+    form = HorarioAdminForm
     extra = 1
 
 

--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -175,7 +175,7 @@ class ClubPhotoForm(forms.ModelForm):
 class HorarioForm(forms.ModelForm):
     class Meta:
         model = models.Horario
-        fields = ['dia', 'hora_inicio', 'hora_fin']
+        fields = ['dia', 'hora_inicio', 'hora_fin', 'estado', 'comentario']
         widgets = {
             'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
             'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),

--- a/apps/clubs/migrations/0019_horario_estado_comentario.py
+++ b/apps/clubs/migrations/0019_horario_estado_comentario.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0018_clubpost_image'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='horario',
+            name='estado',
+            field=models.CharField(choices=[('abierto', 'Abierto'), ('cerrado', 'Cerrado')], default='abierto', max_length=8),
+        ),
+        migrations.AddField(
+            model_name='horario',
+            name='comentario',
+            field=models.CharField(blank=True, max_length=200),
+        ),
+    ]

--- a/apps/clubs/models/horario.py
+++ b/apps/clubs/models/horario.py
@@ -13,13 +13,25 @@ class Horario(models.Model):
         SABADO = 'sabado', _('Sábado')
         DOMINGO = 'domingo', _('Domingo')
 
+    class Estado(models.TextChoices):
+        ABIERTO = 'abierto', _('Abierto')
+        CERRADO = 'cerrado', _('Cerrado')
+
     club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='horarios')
     dia = models.CharField(max_length=10, choices=DiasSemana.choices)
     hora_inicio = models.TimeField()
     hora_fin = models.TimeField()
+    estado = models.CharField(
+        max_length=8, choices=Estado.choices, default=Estado.ABIERTO
+    )
+    comentario = models.CharField(max_length=200, blank=True)
 
     class Meta:
         ordering = ['dia', 'hora_inicio']
 
     def __str__(self):
-        return f"{self.club.name} - {self.get_dia_display()} {self.hora_inicio} - {self.hora_fin}"
+        if self.estado == self.Estado.CERRADO:
+            status = _('Cerrado')
+        else:
+            status = f"{self.hora_inicio} - {self.hora_fin}"
+        return f"{self.club.name} - {self.get_dia_display()} {status}"

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -289,11 +289,17 @@
                                                 {% with horarios_dia=club.horarios.all|dictsort:"hora_inicio" %}
                                                     {% for h in horarios_dia %}
                                                         {% if h.dia == dia %}
-                                                            <div class="border-bottom py-1 small text-muted schedule-item"
-                                                                 data-start="{{ h.hora_inicio|time:'H:i' }}"
-                                                                 data-end="{{ h.hora_fin|time:'H:i' }}">
-                                                                {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}
-                                                            </div>
+                                                            {% if h.estado == h.Estado.CERRADO %}
+                                                                <div class="border-bottom py-1 small text-muted schedule-item">
+                                                                    Cerrado{% if h.comentario %}: {{ h.comentario }}{% endif %}
+                                                                </div>
+                                                            {% else %}
+                                                                <div class="border-bottom py-1 small text-muted schedule-item"
+                                                                     data-start="{{ h.hora_inicio|time:'H:i' }}"
+                                                                     data-end="{{ h.hora_fin|time:'H:i' }}">
+                                                                    {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}{% if h.comentario %} - {{ h.comentario }}{% endif %}
+                                                                </div>
+                                                            {% endif %}
                                                         {% endif %}
                                                     {% empty %}
                                                         <span class="text-muted">—</span>


### PR DESCRIPTION
## Summary
- add `estado` and `comentario` fields to `Horario`
- include new fields in forms and admin
- show schedule status in club profile
- create migration for new fields

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685bc292b4c88321a1bf8454c8e76cdc