### PR TITLE
Add optional schedule fields

### DIFF
--- a/apps/clubs/admin.py
+++ b/apps/clubs/admin.py
@@ -40,8 +40,19 @@ class ReseñaInline(admin.TabularInline):
     readonly_fields = ('creado',)
 
 
+class HorarioAdminForm(forms.ModelForm):
+    class Meta:
+        model = Horario
+        fields = '__all__'
+        widgets = {
+            'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
+            'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
+        }
+
+
 class HorarioInline(admin.TabularInline):
     model = Horario
+    form = HorarioAdminForm
     extra = 1
 
 

--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -175,7 +175,7 @@ class ClubPhotoForm(forms.ModelForm):
 class HorarioForm(forms.ModelForm):
     class Meta:
         model = models.Horario
-        fields = ['dia', 'hora_inicio', 'hora_fin']
+        fields = ['dia', 'hora_inicio', 'hora_fin', 'estado', 'comentario']
         widgets = {
             'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
             'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),

--- a/apps/clubs/migrations/0019_horario_estado_comentario.py
+++ b/apps/clubs/migrations/0019_horario_estado_comentario.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0018_clubpost_image'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='horario',
+            name='estado',
+            field=models.CharField(choices=[('abierto', 'Abierto'), ('cerrado', 'Cerrado')], default='abierto', max_length=8),
+        ),
+        migrations.AddField(
+            model_name='horario',
+            name='comentario',
+            field=models.CharField(blank=True, max_length=200),
+        ),
+    ]

--- a/apps/clubs/migrations/0020_horario_optional_fields.py
+++ b/apps/clubs/migrations/0020_horario_optional_fields.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0019_horario_estado_comentario'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='horario',
+            name='hora_inicio',
+            field=models.TimeField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='horario',
+            name='hora_fin',
+            field=models.TimeField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='horario',
+            name='estado',
+            field=models.CharField(blank=True, choices=[('abierto', 'Abierto'), ('cerrado', 'Cerrado')], max_length=8),
+        ),
+    ]

--- a/apps/clubs/models/horario.py
+++ b/apps/clubs/models/horario.py
@@ -1,5 +1,6 @@
 from django.db import models
-from django.utils.translation import gettext_lazy as _  
+from django.utils.translation import gettext_lazy as _
+from django.core.exceptions import ValidationError
 from .club import Club
 
     
@@ -13,13 +14,36 @@ class Horario(models.Model):
         SABADO = 'sabado', _('Sábado')
         DOMINGO = 'domingo', _('Domingo')
 
+    class Estado(models.TextChoices):
+        ABIERTO = 'abierto', _('Abierto')
+        CERRADO = 'cerrado', _('Cerrado')
+
     club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='horarios')
     dia = models.CharField(max_length=10, choices=DiasSemana.choices)
-    hora_inicio = models.TimeField()
-    hora_fin = models.TimeField()
+    hora_inicio = models.TimeField(null=True, blank=True)
+    hora_fin = models.TimeField(null=True, blank=True)
+    estado = models.CharField(
+        max_length=8, choices=Estado.choices, blank=True
+    )
+    comentario = models.CharField(max_length=200, blank=True)
 
     class Meta:
         ordering = ['dia', 'hora_inicio']
 
+    def clean(self):
+        super().clean()
+        if not any([self.hora_inicio, self.hora_fin, self.estado, self.comentario]):
+            raise ValidationError(
+                _('Debe proporcionar hora, estado o comentario.')
+            )
+
     def __str__(self):
-        return f"{self.club.name} - {self.get_dia_display()} {self.hora_inicio} - {self.hora_fin}"
+        if self.estado == self.Estado.CERRADO:
+            status = _('Cerrado')
+        elif self.hora_inicio and self.hora_fin:
+            status = f"{self.hora_inicio} - {self.hora_fin}"
+        elif self.comentario:
+            status = self.comentario
+        else:
+            status = _('Sin información')
+        return f"{self.club.name} - {self.get_dia_display()} {status}"

--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -5,8 +5,9 @@ from django.urls import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth.models import User, Group
 from PIL import Image
+from django.core.exceptions import ValidationError
 
-from .models import Club, ClubPhoto, ClubPost
+from .models import Club, ClubPhoto, ClubPost, Horario
 
 
 class SearchResultsTests(TestCase):
@@ -116,3 +117,23 @@ class DashboardPermissionTests(TestCase):
         url = reverse('clubpost_create', args=[self.club.slug])
         response = self.client.post(url, {'titulo': 'x', 'contenido': 'y'})
         self.assertEqual(response.status_code, 403)
+
+
+class HorarioValidationTests(TestCase):
+    def setUp(self):
+        self.club = Club.objects.create(
+            name='Horario Club',
+            city='C',
+            address='A',
+            phone='1',
+            email='c@example.com',
+        )
+
+    def test_at_least_one_field_required(self):
+        horario = Horario(club=self.club, dia=Horario.DiasSemana.LUNES)
+        with self.assertRaises(ValidationError):
+            horario.full_clean()
+
+        horario.hora_inicio = '09:00'
+        horario.hora_fin = '10:00'
+        horario.full_clean()

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -289,11 +289,21 @@
                                                 {% with horarios_dia=club.horarios.all|dictsort:"hora_inicio" %}
                                                     {% for h in horarios_dia %}
                                                         {% if h.dia == dia %}
-                                                            <div class="border-bottom py-1 small text-muted schedule-item"
-                                                                 data-start="{{ h.hora_inicio|time:'H:i' }}"
-                                                                 data-end="{{ h.hora_fin|time:'H:i' }}">
-                                                                {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}
-                                                            </div>
+                                                            {% if h.estado == h.Estado.CERRADO %}
+                                                                <div class="border-bottom py-1 small text-muted schedule-item">
+                                                                    Cerrado{% if h.comentario %}: {{ h.comentario }}{% endif %}
+                                                                </div>
+                                                            {% elif h.hora_inicio and h.hora_fin %}
+                                                                <div class="border-bottom py-1 small text-muted schedule-item"
+                                                                     data-start="{{ h.hora_inicio|time:'H:i' }}"
+                                                                     data-end="{{ h.hora_fin|time:'H:i' }}">
+                                                                    {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}{% if h.comentario %} - {{ h.comentario }}{% endif %}
+                                                                </div>
+                                                            {% elif h.comentario %}
+                                                                <div class="border-bottom py-1 small text-muted schedule-item">
+                                                                    {{ h.comentario }}
+                                                                </div>
+                                                            {% endif %}
                                                         {% endif %}
                                                     {% empty %}
                                                         <span class="text-muted">—</span>


### PR DESCRIPTION
## Summary
- allow Horario fields to be optional and ensure at least one is provided
- adapt schedule template for missing data
- add migration and tests for Horario validation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685bc292b4c88321a1bf8454c8e76cdc