### PR TITLE
Add open/closed status and default schedules

### DIFF
--- a/apps/clubs/admin.py
+++ b/apps/clubs/admin.py
@@ -37,7 +37,8 @@ class ReseñaInline(admin.TabularInline):
 
 class HorarioInline(admin.TabularInline):
     model = Horario
-    extra = 1
+    extra = 0
+    fields = ('dia', 'estado', 'hora_inicio', 'hora_fin')
 
 
 @admin.register(Club)

--- a/apps/clubs/apps.py
+++ b/apps/clubs/apps.py
@@ -5,3 +5,6 @@ from django.apps import AppConfig
 class ClubsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'apps.clubs'  # ✅ Ahora está bien referenciado
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -161,7 +161,7 @@ class ClubPhotoForm(forms.ModelForm):
 class HorarioForm(forms.ModelForm):
     class Meta:
         model = models.Horario
-        fields = ['dia', 'hora_inicio', 'hora_fin']
+        fields = ['dia', 'estado', 'hora_inicio', 'hora_fin']
         widgets = {
             'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
             'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),

--- a/apps/clubs/management/commands/seed_clubs.py
+++ b/apps/clubs/management/commands/seed_clubs.py
@@ -7,7 +7,7 @@ import random
 import os
 
 from apps.clubs.models import (
-    Club, ClubPhoto, Entrenador, Horario, Clase,
+    Club, ClubPhoto, Entrenador, Horario,
     Competidor, ClubPost, Reseña, Feature
 )
 
@@ -54,22 +54,15 @@ class Command(BaseCommand):
                     apellidos=fake.last_name(),
                 )
 
-            dias = [choice[0] for choice in Horario.DiasSemana.choices]
-            for _ in range(random.randint(3, 5)):
+            for dia, _ in Horario.DiasSemana.choices:
                 Horario.objects.create(
                     club=club,
-                    dia=random.choice(dias),
+                    dia=dia,
+                    estado=Horario.Estado.ABIERTO,
                     hora_inicio=fake.time(),
                     hora_fin=fake.time(),
                 )
 
-            for _ in range(random.randint(1, 4)):
-                Clase.objects.create(
-                    club=club,
-                    nombre=fake.word(),
-                    hora_inicio=fake.time(),
-                    hora_fin=fake.time(),
-                )
 
             for _ in range(random.randint(1, 3)):
                 wins = random.randint(0, 10)

--- a/apps/clubs/migrations/0020_horario_estado.py
+++ b/apps/clubs/migrations/0020_horario_estado.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0019_delete_clase'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='horario',
+            name='estado',
+            field=models.CharField(choices=[('abierto', 'Abierto'), ('cerrado', 'Cerrado')], default='abierto', max_length=10),
+        ),
+        migrations.AlterField(
+            model_name='horario',
+            name='hora_inicio',
+            field=models.TimeField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='horario',
+            name='hora_fin',
+            field=models.TimeField(blank=True, null=True),
+        ),
+    ]

--- a/apps/clubs/migrations/0021_create_missing_horarios.py
+++ b/apps/clubs/migrations/0021_create_missing_horarios.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+from datetime import time
+
+def create_horarios(apps, schema_editor):
+    Horario = apps.get_model('clubs', 'Horario')
+    Club = apps.get_model('clubs', 'Club')
+    dias = [choice[0] for choice in Horario.DiasSemana.choices]
+    for club in Club.objects.all():
+        existing = set(Horario.objects.filter(club=club).values_list('dia', flat=True))
+        for dia in dias:
+            if dia not in existing:
+                Horario.objects.create(
+                    club=club,
+                    dia=dia,
+                    estado='abierto',
+                    hora_inicio=time(9, 0),
+                    hora_fin=time(17, 0),
+                )
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0020_horario_estado'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_horarios, migrations.RunPython.noop),
+    ]

--- a/apps/clubs/models/horario.py
+++ b/apps/clubs/models/horario.py
@@ -13,13 +13,21 @@ class Horario(models.Model):
         SABADO = 'sabado', _('Sábado')
         DOMINGO = 'domingo', _('Domingo')
 
+    class Estado(models.TextChoices):
+        ABIERTO = 'abierto', _('Abierto')
+        CERRADO = 'cerrado', _('Cerrado')
+
     club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='horarios')
     dia = models.CharField(max_length=10, choices=DiasSemana.choices)
-    hora_inicio = models.TimeField()
-    hora_fin = models.TimeField()
+    estado = models.CharField(max_length=10, choices=Estado.choices, default=Estado.ABIERTO)
+    hora_inicio = models.TimeField(blank=True, null=True)
+    hora_fin = models.TimeField(blank=True, null=True)
 
     class Meta:
         ordering = ['dia', 'hora_inicio']
 
     def __str__(self):
-        return f"{self.club.name} - {self.get_dia_display()} {self.hora_inicio} - {self.hora_fin}"
+        estado = self.get_estado_display()
+        if self.estado == self.Estado.CERRADO:
+            return f"{self.club.name} - {self.get_dia_display()} ({estado})"
+        return f"{self.club.name} - {self.get_dia_display()} {self.hora_inicio} - {self.hora_fin} ({estado})"

--- a/apps/clubs/signals.py
+++ b/apps/clubs/signals.py
@@ -1,0 +1,17 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from datetime import time
+
+from .models import Club, Horario
+
+@receiver(post_save, sender=Club)
+def create_default_horarios(sender, instance, created, **kwargs):
+    if created and not instance.horarios.exists():
+        for dia, _ in Horario.DiasSemana.choices:
+            Horario.objects.create(
+                club=instance,
+                dia=dia,
+                estado=Horario.Estado.ABIERTO,
+                hora_inicio=time(9, 0),
+                hora_fin=time(17, 0),
+            )

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -289,11 +289,15 @@
                                                 {% with horarios_dia=club.horarios.all|dictsort:"hora_inicio" %}
                                                     {% for h in horarios_dia %}
                                                         {% if h.dia == dia %}
-                                                            <div class="border-bottom py-1 small text-muted schedule-item"
-                                                                 data-start="{{ h.hora_inicio|time:'H:i' }}"
-                                                                 data-end="{{ h.hora_fin|time:'H:i' }}">
-                                                                {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}
-                                                            </div>
+                                                            {% if h.estado == 'cerrado' %}
+                                                                <div class="border-bottom py-1 small text-muted">Cerrado</div>
+                                                            {% else %}
+                                                                <div class="border-bottom py-1 small text-muted schedule-item"
+                                                                     data-start="{{ h.hora_inicio|time:'H:i' }}"
+                                                                     data-end="{{ h.hora_fin|time:'H:i' }}">
+                                                                    {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}
+                                                                </div>
+                                                            {% endif %}
                                                         {% endif %}
                                                     {% empty %}
                                                         <span class="text-muted">—</span>


### PR DESCRIPTION
## Summary
- extend `Horario` model with `estado` to mark open/closed and allow blank times
- display `estado` in admin inline and make no extra rows
- include new field in `HorarioForm`
- create default schedules for new clubs via post-save signal
- generate migrations and update seed data
- show "Cerrado" on club profile when a day is closed

## Testing
- `python manage.py makemigrations` *(fails: ImportError No module named 'django')*
- `python manage.py test apps.clubs.tests.SearchResultsTests.test_search_returns_results` *(fails: ImportError No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685c0a6f3bc483218afe93ae241f32c6