### PR TITLE
Add Clase model for daily schedules

### DIFF
--- a/apps/clubs/admin.py
+++ b/apps/clubs/admin.py
@@ -6,6 +6,7 @@ from .models import (
     Competidor,
     Reseña,
     Horario,
+    Clase,
     ClubPost,
     Entrenador,
     EntrenadorPhoto,
@@ -39,6 +40,17 @@ class HorarioInline(admin.TabularInline):
     model = Horario
     extra = 0
     fields = ('dia', 'estado', 'hora_inicio', 'hora_fin')
+
+class ClaseInline(admin.TabularInline):
+    model = Clase
+    extra = 1
+    fields = ('hora_inicio', 'hora_fin', 'texto')
+
+
+@admin.register(Horario)
+class HorarioAdmin(admin.ModelAdmin):
+    list_display = ('club', 'dia', 'estado', 'hora_inicio', 'hora_fin')
+    inlines = [ClaseInline]
 
 
 @admin.register(Club)

--- a/apps/clubs/migrations/0022_clase.py
+++ b/apps/clubs/migrations/0022_clase.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0021_create_missing_horarios'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Clase',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('hora_inicio', models.TimeField()),
+                ('hora_fin', models.TimeField()),
+                ('texto', models.CharField(blank=True, max_length=255)),
+                ('horario', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='clases', to='clubs.horario')),
+            ],
+            options={'ordering': ['hora_inicio']},
+        ),
+    ]

--- a/apps/clubs/models/__init__.py
+++ b/apps/clubs/models/__init__.py
@@ -3,6 +3,7 @@
 from .club import Club, ClubPhoto
 from .feature import Feature
 from .horario import Horario
+from .clase import Clase
 from .resena import Reseña
 from .competidor import Competidor
 from .entrenador import Entrenador, EntrenadorPhoto, TrainingLevel

--- a/apps/clubs/models/clase.py
+++ b/apps/clubs/models/clase.py
@@ -1,0 +1,18 @@
+from django.db import models
+from .horario import Horario
+
+
+class Clase(models.Model):
+    """Clase programada dentro de un horario semanal."""
+    horario = models.ForeignKey(Horario, related_name="clases", on_delete=models.CASCADE)
+    hora_inicio = models.TimeField()
+    hora_fin = models.TimeField()
+    texto = models.CharField(max_length=255, blank=True)
+
+    class Meta:
+        ordering = ["hora_inicio"]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        if self.texto:
+            return f"{self.hora_inicio} - {self.hora_fin} ({self.texto})"
+        return f"{self.hora_inicio} - {self.hora_fin}"


### PR DESCRIPTION
## Summary
- create `Clase` model so each `Horario` can have multiple classes per day
- expose the new model in the module exports
- register `Clase` in the admin with an inline for `Horario`
- add migration for the new model

## Testing
- `python manage.py makemigrations apps/clubs` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685c10c56f54832180eeb142ba29be66