### PR TITLE
Add custom fields to Horario model

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -175,7 +175,7 @@ class ClubPhotoForm(forms.ModelForm):
 class HorarioForm(forms.ModelForm):
     class Meta:
         model = models.Horario
-        fields = ['dia', 'hora_inicio', 'hora_fin']
+        fields = ['dia', 'hora_inicio', 'hora_fin', 'descripcion', 'estado']
         widgets = {
             'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
             'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),

--- a/apps/clubs/migrations/0019_horario_extra_fields.py
+++ b/apps/clubs/migrations/0019_horario_extra_fields.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0018_clubpost_image'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='horario',
+            name='descripcion',
+            field=models.CharField(blank=True, max_length=30),
+        ),
+        migrations.AddField(
+            model_name='horario',
+            name='estado',
+            field=models.CharField(choices=[('abierto', 'Abierto'), ('cerrado', 'Cerrado')], default='abierto', max_length=8),
+            preserve_default=False,
+        ),
+    ]
+

--- a/apps/clubs/models/horario.py
+++ b/apps/clubs/models/horario.py
@@ -4,6 +4,9 @@ from .club import Club
 
     
 class Horario(models.Model):
+    class Estado(models.TextChoices):
+        ABIERTO = 'abierto', _('Abierto')
+        CERRADO = 'cerrado', _('Cerrado')
     class DiasSemana(models.TextChoices):
         LUNES = 'lunes', _('Lunes')
         MARTES = 'martes', _('Martes')
@@ -17,6 +20,8 @@ class Horario(models.Model):
     dia = models.CharField(max_length=10, choices=DiasSemana.choices)
     hora_inicio = models.TimeField()
     hora_fin = models.TimeField()
+    descripcion = models.CharField(max_length=30, blank=True)
+    estado = models.CharField(max_length=8, choices=Estado.choices)
 
     class Meta:
         ordering = ['dia', 'hora_inicio']

--- a/static/js/schedule-status.js
+++ b/static/js/schedule-status.js
@@ -12,7 +12,8 @@ document.addEventListener('DOMContentLoaded', () => {
     items.forEach((item) => {
       const start = item.dataset.start;
       const end = item.dataset.end;
-      if (start && end) {
+      const estado = item.dataset.estado;
+      if (estado === 'abierto' && start && end) {
         const [sh, sm] = start.split(':').map(Number);
         const [eh, em] = end.split(':').map(Number);
         const startMin = sh * 60 + sm;

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -291,8 +291,11 @@
                                                         {% if h.dia == dia %}
                                                             <div class="border-bottom py-1 small text-muted schedule-item"
                                                                  data-start="{{ h.hora_inicio|time:'H:i' }}"
-                                                                 data-end="{{ h.hora_fin|time:'H:i' }}">
+                                                                 data-end="{{ h.hora_fin|time:'H:i' }}"
+                                                                 data-estado="{{ h.estado }}">
                                                                 {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}
+                                                                {% if h.descripcion %}<span class="ms-1">{{ h.descripcion }}</span>{% endif %}
+                                                                {% if h.estado == 'cerrado' %} <span class="text-danger">(Cerrado)</span>{% endif %}
                                                             </div>
                                                         {% endif %}
                                                     {% empty %}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -179,6 +179,8 @@
         {% for h in club.horarios.all %}
         <li>
           {{ h.get_dia_display }} {{ h.hora_inicio|time:'H:i' }} - {{ h.hora_fin|time:'H:i' }}
+          {% if h.descripcion %} ({{ h.descripcion }}){% endif %}
+          - {{ h.get_estado_display }}
           <a href="{% url 'horario_update' h.id %}">Editar</a>
           <form method="post" action="{% url 'horario_delete' h.id %}" class="d-inline">
             {% csrf_token %}


### PR DESCRIPTION
## Summary
- add `descripcion` and `estado` fields to Horario model
- include new fields in HorarioForm
- display schedule description and state on dashboard and club profile
- update schedule status script to ignore closed times
- create migration for the new fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685c916cd8888321b1d3c12b14736364