### PR TITLE
Implement default weekly schedules

### DIFF
--- a/apps/clubs/models/club.py
+++ b/apps/clubs/models/club.py
@@ -37,9 +37,23 @@ class Club(models.Model):
 
 
     def save(self, *args, **kwargs):
+        creating = self.pk is None
         if not self.slug:
             self.slug = slugify(self.name)
         super().save(*args, **kwargs)
+
+        if creating:
+            from datetime import time
+            from .horario import Horario
+
+            for day, _ in Horario.DiasSemana.choices:
+                Horario.objects.create(
+                    club=self,
+                    dia=day,
+                    hora_inicio=time(0, 0),
+                    hora_fin=time(0, 0),
+                    estado=Horario.Estado.CERRADO,
+                )
 
     def __str__(self):
         return self.name

--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -116,3 +116,20 @@ class DashboardPermissionTests(TestCase):
         url = reverse('clubpost_create', args=[self.club.slug])
         response = self.client.post(url, {'titulo': 'x', 'contenido': 'y'})
         self.assertEqual(response.status_code, 403)
+
+
+class HorarioDefaultsTests(TestCase):
+    def test_default_schedules_created(self):
+        club = Club.objects.create(
+            name='Test Club',
+            city='City',
+            address='Addr',
+            phone='1',
+            email='test@example.com',
+        )
+
+        dias = {h.dia for h in club.horarios.all()}
+        expected = {d for d, _ in club.horarios.model.DiasSemana.choices}
+        self.assertEqual(dias, expected)
+        for h in club.horarios.all():
+            self.assertEqual(h.estado, h.Estado.CERRADO)


### PR DESCRIPTION
## Summary
- auto-create schedule entries for every day of the week when a club is created
- test default schedules creation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685c958131248321ad2bb0e893735f62