### PR TITLE
Add bulk schedule management view

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -181,6 +181,11 @@ class HorarioForm(forms.ModelForm):
             'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            self.fields['dia'].widget = forms.HiddenInput()
+
 
 class CompetidorForm(forms.ModelForm):
     class Meta:

--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -133,3 +133,23 @@ class HorarioDefaultsTests(TestCase):
         self.assertEqual(dias, expected)
         for h in club.horarios.all():
             self.assertEqual(h.estado, h.Estado.CERRADO)
+
+
+class HorarioManageViewTests(TestCase):
+    def setUp(self):
+        self.owner = User.objects.create_user(username='owner2', password='pass')
+        self.club = Club.objects.create(
+            name='Owner Club2',
+            city='C',
+            address='A',
+            phone='1',
+            email='e2@example.com',
+            owner=self.owner,
+        )
+
+    def test_owner_can_access_manage_view(self):
+        self.client.login(username='owner2', password='pass')
+        url = reverse('horario_manage', args=[self.club.slug])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Lunes')

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -23,6 +23,7 @@ from apps.clubs.views.dashboard import (
     horario_create,
     horario_update,
     horario_delete,
+    horario_manage,
     competidor_create,
     competidor_update,
     competidor_delete,
@@ -46,6 +47,7 @@ urlpatterns = [
     path('<slug:slug>/horario/nuevo/', horario_create, name='horario_create'),
     path('horario/<int:pk>/editar/', horario_update, name='horario_update'),
     path('horario/<int:pk>/eliminar/', horario_delete, name='horario_delete'),
+    path('<slug:slug>/horarios/editar/', horario_manage, name='horario_manage'),
 
     path('<slug:slug>/competidor/nuevo/', competidor_create, name='competidor_create'),
     path('competidor/<int:pk>/editar/', competidor_update, name='competidor_update'),

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -159,6 +159,7 @@
     <div id="tab-schedule" class="profile-section">
       <a href="{% url 'clase_create' club.slug %}" class="btn btn-secondary btn-sm me-2 mb-3">Añadir clase</a>
       <a href="{% url 'horario_create' club.slug %}" class="btn btn-secondary btn-sm mb-3">Añadir horario</a>
+      <a href="{% url 'horario_manage' club.slug %}" class="btn btn-secondary btn-sm mb-3 ms-2">Editar todos</a>
       <h2 class="h5 mt-4">Clases</h2>
       <ul>
         {% for c in classes %}

--- a/templates/clubs/horario_manage.html
+++ b/templates/clubs/horario_manage.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">Editar horarios</h1>
+  <form method="post">
+    {% csrf_token %}
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Día</th>
+          <th>Hora inicio</th>
+          <th>Hora fin</th>
+          <th>Descripción</th>
+          <th>Estado</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for form in formset %}
+        <tr>
+          <td>{{ form.instance.get_dia_display }}{{ form.dia }}</td>
+          <td>{{ form.hora_inicio }}</td>
+          <td>{{ form.hora_fin }}</td>
+          <td>{{ form.descripcion }}</td>
+          <td>{{ form.estado }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <button type="submit" class="btn btn-primary">Guardar</button>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- hide `dia` field when editing an existing schedule
- add new view to edit all schedules for a club in one page
- link new page from dashboard
- test manage view accessibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_685c96e827e883219ce43a260c3f6074