### PR TITLE
Add schedule model for clubs

### DIFF
--- a/apps/clubs/admin.py
+++ b/apps/clubs/admin.py
@@ -4,6 +4,7 @@ from .models import (
     Feature,
     ClubPhoto,
     Competidor,
+    Horario,
     Reseña,
     ClubPost,
     Entrenador,
@@ -19,6 +20,12 @@ class ClubPhotoInline(admin.TabularInline):
 class CompetidorInline(admin.TabularInline):
     model = Competidor
     extra = 1
+
+class HorarioInline(admin.TabularInline):
+    model = Horario
+    extra = 0
+    min_num = 7
+    max_num = 7
 
 class EntrenadorInline(admin.TabularInline):
     model = Entrenador
@@ -40,8 +47,21 @@ class ReseñaInline(admin.TabularInline):
 class ClubAdmin(admin.ModelAdmin):
     list_display = ('name', 'owner', 'verified', 'city', 'phone', 'email')
     prepopulated_fields = {'slug': ('name',)}
-    inlines = [ClubPhotoInline, EntrenadorInline]
-    fields = ('owner', 'logo', 'name', 'verified', 'slug', 'city', 'address', 'phone', 'whatsapp_link', 'email', 'about', 'features')
+    inlines = [ClubPhotoInline, EntrenadorInline, HorarioInline]
+    fields = (
+        'owner',
+        'logo',
+        'name',
+        'verified',
+        'slug',
+        'city',
+        'address',
+        'phone',
+        'whatsapp_link',
+        'email',
+        'about',
+        'features',
+    )
 
 @admin.register(Feature)
 class FeatureAdmin(admin.ModelAdmin):

--- a/apps/clubs/apps.py
+++ b/apps/clubs/apps.py
@@ -5,3 +5,7 @@ from django.apps import AppConfig
 class ClubsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'apps.clubs'  # ✅ Ahora está bien referenciado
+
+    def ready(self):
+        # Ensure signals are loaded
+        from . import signals  # noqa: F401

--- a/apps/clubs/migrations/0019_horario_model.py
+++ b/apps/clubs/migrations/0019_horario_model.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0018_clubpost_image'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Horario',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('dia', models.CharField(choices=[('lunes', 'Lunes'), ('martes', 'Martes'), ('miercoles', 'Mi\u00e9rcoles'), ('jueves', 'Jueves'), ('viernes', 'Viernes'), ('sabado', 'S\u00e1bado'), ('domingo', 'Domingo')], max_length=10)),
+                ('abierto', models.BooleanField(default=False)),
+                ('hora_inicio', models.TimeField(blank=True, null=True)),
+                ('hora_fin', models.TimeField(blank=True, null=True)),
+                ('nota', models.CharField(blank=True, max_length=30)),
+                ('club', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='horarios', to='clubs.club')),
+            ],
+            options={
+                'ordering': ['dia'],
+                'unique_together': {('club', 'dia')},
+            },
+        ),
+    ]

--- a/apps/clubs/models/__init__.py
+++ b/apps/clubs/models/__init__.py
@@ -7,3 +7,4 @@ from .competidor import Competidor
 from .entrenador import Entrenador, EntrenadorPhoto, TrainingLevel
 from .post import ClubPost
 from .booking import Booking
+from .horario import Horario

--- a/apps/clubs/models/horario.py
+++ b/apps/clubs/models/horario.py
@@ -1,0 +1,28 @@
+from django.db import models
+
+from .club import Club
+
+
+class Horario(models.Model):
+    class DiaSemana(models.TextChoices):
+        LUNES = 'lunes', 'Lunes'
+        MARTES = 'martes', 'Martes'
+        MIERCOLES = 'miercoles', 'Miércoles'
+        JUEVES = 'jueves', 'Jueves'
+        VIERNES = 'viernes', 'Viernes'
+        SABADO = 'sabado', 'Sábado'
+        DOMINGO = 'domingo', 'Domingo'
+
+    club = models.ForeignKey(Club, related_name='horarios', on_delete=models.CASCADE)
+    dia = models.CharField(max_length=10, choices=DiaSemana.choices)
+    abierto = models.BooleanField(default=False)
+    hora_inicio = models.TimeField(blank=True, null=True)
+    hora_fin = models.TimeField(blank=True, null=True)
+    nota = models.CharField(max_length=30, blank=True)
+
+    class Meta:
+        unique_together = ('club', 'dia')
+        ordering = ['dia']
+
+    def __str__(self) -> str:
+        return f"{self.get_dia_display()} - {'Abierto' if self.abierto else 'Cerrado'}"

--- a/apps/clubs/signals.py
+++ b/apps/clubs/signals.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import Club, Horario
+
+
+@receiver(post_save, sender=Club)
+def create_default_schedule(sender, instance, created, **kwargs):
+    if created:
+        for dia, _ in Horario.DiaSemana.choices:
+            Horario.objects.create(club=instance, dia=dia)

--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User, Group
 from PIL import Image
 
 from .models import Club, ClubPhoto, ClubPost
+from .models import Horario
 
 
 class SearchResultsTests(TestCase):
@@ -116,3 +117,15 @@ class DashboardPermissionTests(TestCase):
         url = reverse('clubpost_create', args=[self.club.slug])
         response = self.client.post(url, {'titulo': 'x', 'contenido': 'y'})
         self.assertEqual(response.status_code, 403)
+
+class HorarioCreationTests(TestCase):
+    def test_schedule_created_for_new_club(self):
+        club = Club.objects.create(
+            name='Schedule Club',
+            city='City',
+            address='Addr',
+            phone='123',
+            email='a@example.com',
+        )
+        self.assertEqual(Horario.objects.filter(club=club).count(), 7)
+


### PR DESCRIPTION
## Summary
- add `Horario` model to store weekly schedules with open/closed state
- automatically create 7 days when a club is created
- expose schedule inline on the club admin page
- load new signals in `ClubsConfig`
- include simple test for schedule creation

## Testing
- `python manage.py makemigrations apps/clubs --name horario_model` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685c9fe15b408321b0a1e99c05bae82a