### PR TITLE
Improve schedule admin

### DIFF
--- a/apps/clubs/admin.py
+++ b/apps/clubs/admin.py
@@ -42,14 +42,45 @@ class ReseñaInline(admin.TabularInline):
 
 class HorarioInline(admin.TabularInline):
     model = Horario
-    extra = 1
+
+    def _missing_days(self, obj):
+        if obj:
+            existing = set(obj.horarios.values_list('dia', flat=True))
+        else:
+            existing = set()
+        return [dia for dia, _ in Horario.DiasSemana.choices if dia not in existing]
+
+    def get_extra(self, request, obj=None, **kwargs):
+        return len(self._missing_days(obj))
+
+    def get_formset(self, request, obj=None, **kwargs):
+        missing = [{"dia": dia} for dia in self._missing_days(obj)]
+        kwargs["extra"] = len(missing)
+        FormSet = super().get_formset(request, obj, **kwargs)
+
+        class InitialFormSet(FormSet):
+            def __init__(self, *args, **kw):
+                kw.setdefault("initial", missing)
+                super().__init__(*args, **kw)
+
+        return InitialFormSet
 
 
 @admin.register(Club)
 class ClubAdmin(admin.ModelAdmin):
     list_display = ('name', 'owner', 'verified', 'city', 'phone', 'email')
     prepopulated_fields = {'slug': ('name',)}
-    inlines = [ClubPhotoInline, HorarioInline, EntrenadorInline]
+    # Show related photos, schedule, classes and competitors in a single page
+    # for easier editing. CompetitorInline may not always be present in older
+    # versions so we include it here to avoid merge conflicts with branches
+    # where it was added.
+    inlines = [
+        ClubPhotoInline,
+        HorarioInline,
+        ClaseInline,
+        CompetidorInline,
+        EntrenadorInline,
+    ]
     fields = ('owner', 'logo', 'name', 'verified', 'slug', 'city', 'address', 'phone', 'whatsapp_link', 'email', 'about', 'features')
 
 @admin.register(Feature)

--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -175,7 +175,7 @@ class ClubPhotoForm(forms.ModelForm):
 class HorarioForm(forms.ModelForm):
     class Meta:
         model = models.Horario
-        fields = ['dia', 'hora_inicio', 'hora_fin']
+        fields = ['dia', 'estado', 'hora_inicio', 'hora_fin', 'nota']
         widgets = {
             'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
             'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),

--- a/apps/clubs/management/commands/seed_clubs.py
+++ b/apps/clubs/management/commands/seed_clubs.py
@@ -59,8 +59,10 @@ class Command(BaseCommand):
                 Horario.objects.create(
                     club=club,
                     dia=random.choice(dias),
+                    estado=random.choice(['abierto', 'cerrado']),
                     hora_inicio=fake.time(),
                     hora_fin=fake.time(),
+                    nota=fake.word()[:20],
                 )
 
             for _ in range(random.randint(1, 4)):

--- a/apps/clubs/migrations/0019_horario_extra_fields.py
+++ b/apps/clubs/migrations/0019_horario_extra_fields.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('clubs', '0018_clubpost_image'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='horario',
+            name='estado',
+            field=models.CharField(choices=[('abierto','Abierto'),('cerrado','Cerrado')],default='abierto',max_length=7),
+        ),
+        migrations.AddField(
+            model_name='horario',
+            name='nota',
+            field=models.CharField(blank=True,max_length=20),
+        ),
+    ]

--- a/apps/clubs/models/horario.py
+++ b/apps/clubs/models/horario.py
@@ -17,9 +17,16 @@ class Horario(models.Model):
     dia = models.CharField(max_length=10, choices=DiasSemana.choices)
     hora_inicio = models.TimeField()
     hora_fin = models.TimeField()
+    estado = models.CharField(
+        max_length=7,
+        choices=[('abierto', 'Abierto'), ('cerrado', 'Cerrado')],
+        default='abierto'
+    )
+    nota = models.CharField(max_length=20, blank=True)
 
     class Meta:
         ordering = ['dia', 'hora_inicio']
 
     def __str__(self):
-        return f"{self.club.name} - {self.get_dia_display()} {self.hora_inicio} - {self.hora_fin}"
+        estado = 'Cerrado' if self.estado == 'cerrado' else f"{self.hora_inicio} - {self.hora_fin}"
+        return f"{self.club.name} - {self.get_dia_display()} {estado}"

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -286,18 +286,22 @@
                                     <tr>
                                         {% for dia, nombre in club.horarios.model.DiasSemana.choices %}
                                             <td class="schedule-day" data-day="{{ dia }}">
-                                                {% with horarios_dia=club.horarios.all|dictsort:"hora_inicio" %}
-                                                    {% for h in horarios_dia %}
-                                                        {% if h.dia == dia %}
-                                                            <div class="border-bottom py-1 small text-muted schedule-item"
-                                                                 data-start="{{ h.hora_inicio|time:'H:i' }}"
-                                                                 data-end="{{ h.hora_fin|time:'H:i' }}">
-                                                                {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}
-                                                            </div>
-                                                        {% endif %}
-                                                    {% empty %}
+                                                {% with horarios_dia=club.horarios.filter(dia=dia)|dictsort:"hora_inicio" %}
+                                                    {% if horarios_dia %}
+                                                        {% for h in horarios_dia %}
+                                                            {% if h.estado == 'cerrado' %}
+                                                                <div class="border-bottom py-1 small text-muted">Cerrado{% if h.nota %} ({{ h.nota }}){% endif %}</div>
+                                                            {% else %}
+                                                                <div class="border-bottom py-1 small text-muted schedule-item"
+                                                                     data-start="{{ h.hora_inicio|time:'H:i' }}"
+                                                                     data-end="{{ h.hora_fin|time:'H:i' }}">
+                                                                    {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}{% if h.nota %} ({{ h.nota }}){% endif %}
+                                                                </div>
+                                                            {% endif %}
+                                                        {% endfor %}
+                                                    {% else %}
                                                         <span class="text-muted">—</span>
-                                                    {% endfor %}
+                                                    {% endif %}
                                                 {% endwith %}
                                             </td>
                                         {% endfor %}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -178,7 +178,13 @@
       <ul>
         {% for h in club.horarios.all %}
         <li>
-          {{ h.get_dia_display }} {{ h.hora_inicio|time:'H:i' }} - {{ h.hora_fin|time:'H:i' }}
+          {{ h.get_dia_display }} -
+          {% if h.estado == 'cerrado' %}
+            Cerrado
+          {% else %}
+            {{ h.hora_inicio|time:'H:i' }} - {{ h.hora_fin|time:'H:i' }}
+          {% endif %}
+          {% if h.nota %}({{ h.nota }}){% endif %}
           <a href="{% url 'horario_update' h.id %}">Editar</a>
           <form method="post" action="{% url 'horario_delete' h.id %}" class="d-inline">
             {% csrf_token %}


### PR DESCRIPTION
## Summary
- remove 7-entry limit on schedule inline to allow multiple slots per day
- keep auto-population for missing days
- expose new schedule fields in forms and templates
- include CompetidorInline to resolve admin merge conflict

## Testing
- `python manage.py makemigrations apps/clubs` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_685ca946d2148321844a95e8ca6c9166