### PR TITLE
Add day and note fields to Clase

### DIFF
--- a/apps/clubs/admin.py
+++ b/apps/clubs/admin.py
@@ -92,11 +92,11 @@ class ClaseAdminForm(forms.ModelForm):
         widgets = {
             'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
             'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
-        }   
+        }
 @admin.register(Clase)
 class ClaseAdmin(admin.ModelAdmin):
     form = ClaseAdminForm
-    list_display = ('nombre', 'club', 'hora_inicio', 'hora_fin')
+    list_display = ('nombre', 'club', 'dia', 'hora_inicio', 'hora_fin', 'nota')
 
 @admin.register(Competidor)
 class CompetidorAdmin(admin.ModelAdmin):

--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -154,7 +154,7 @@ class ClubForm(forms.ModelForm):
 class ClaseForm(forms.ModelForm):
     class Meta:
         model = models.Clase
-        fields = ['nombre', 'hora_inicio', 'hora_fin']
+        fields = ['nombre', 'dia', 'hora_inicio', 'hora_fin', 'nota']
         widgets = {
             'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
             'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),

--- a/apps/clubs/management/commands/seed_clubs.py
+++ b/apps/clubs/management/commands/seed_clubs.py
@@ -69,8 +69,10 @@ class Command(BaseCommand):
                 Clase.objects.create(
                     club=club,
                     nombre=fake.word(),
+                    dia=random.choice(dias),
                     hora_inicio=fake.time(),
                     hora_fin=fake.time(),
+                    nota=fake.word()[:20],
                 )
 
             for _ in range(random.randint(1, 3)):

--- a/apps/clubs/migrations/0020_clase_dia_nota.py
+++ b/apps/clubs/migrations/0020_clase_dia_nota.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('clubs', '0019_horario_extra_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='clase',
+            name='dia',
+            field=models.CharField(choices=[('lunes','Lunes'),('martes','Martes'),('miercoles','Miércoles'),('jueves','Jueves'),('viernes','Viernes'),('sabado','Sábado'),('domingo','Domingo')], default='lunes', max_length=10),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='clase',
+            name='nota',
+            field=models.CharField(blank=True, max_length=20),
+        ),
+    ]

--- a/apps/clubs/models/clase.py
+++ b/apps/clubs/models/clase.py
@@ -1,14 +1,20 @@
-from .club import Club    
+from .club import Club
+from .horario import Horario
 from django.db import models
 
 
 
 class Clase(models.Model):
     club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='clases')
+    dia = models.CharField(max_length=10, choices=Horario.DiasSemana.choices)
     nombre = models.CharField(max_length=100)
     hora_inicio = models.TimeField()
     hora_fin = models.TimeField()
+    nota = models.CharField(max_length=20, blank=True)
 
     def __str__(self):
-        return f"{self.nombre} ({self.hora_inicio} - {self.hora_fin})"
+        texto = f"{self.hora_inicio} - {self.hora_fin}"
+        if self.nota:
+            texto += f" ({self.nota})"
+        return f"{self.nombre} - {self.get_dia_display()} {texto}"
 

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -315,7 +315,7 @@
                                 <ul class="list-group">
                                     {% for c in club.clases.all %}
                                         <li class="list-group-item d-flex justify-content-between align-items-center">
-                                            <span>{{ c.nombre }} ({{ c.hora_inicio|time:"H:i" }} - {{ c.hora_fin|time:"H:i" }})</span>
+                                            <span>{{ c.get_dia_display }} - {{ c.nombre }} ({{ c.hora_inicio|time:"H:i" }} - {{ c.hora_fin|time:"H:i" }}){% if c.nota %} ({{ c.nota }}){% endif %}</span>
                                             {% if user.is_authenticated %}
                                                 <form action="{% url 'book_clase' c.id %}" method="post" class="ms-2">
                                                     {% csrf_token %}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -163,7 +163,7 @@
       <ul>
         {% for c in classes %}
         <li>
-          {{ c.nombre }} ({{ c.hora_inicio|time:'H:i' }} - {{ c.hora_fin|time:'H:i' }})
+          {{ c.get_dia_display }} - {{ c.nombre }} ({{ c.hora_inicio|time:'H:i' }} - {{ c.hora_fin|time:'H:i' }}){% if c.nota %} ({{ c.nota }}){% endif %}
           <a href="{% url 'clase_update' c.id %}">Editar</a>
           <form method="post" action="{% url 'clase_delete' c.id %}" class="d-inline">
             {% csrf_token %}


### PR DESCRIPTION
## Summary
- allow multiple classes per day
- show day and note in dashboard and club profile
- update seed data
- migration for new fields

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685cb20453788321bfd81325ec36a7a5