### PR TITLE
Add abierto/cerrado option for horarios

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -175,7 +175,7 @@ class ClubPhotoForm(forms.ModelForm):
 class HorarioForm(forms.ModelForm):
     class Meta:
         model = models.Horario
-        fields = ['dia', 'hora_inicio', 'hora_fin']
+        fields = ['dia', 'hora_inicio', 'hora_fin', 'estado']
         widgets = {
             'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
             'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),

--- a/apps/clubs/migrations/0019_horario_estado.py
+++ b/apps/clubs/migrations/0019_horario_estado.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0018_clubpost_image'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='horario',
+            name='estado',
+            field=models.CharField(choices=[('abierto', 'Abierto'), ('cerrado', 'Cerrado')], default='abierto', max_length=10),
+        ),
+    ]

--- a/apps/clubs/models/horario.py
+++ b/apps/clubs/models/horario.py
@@ -13,13 +13,28 @@ class Horario(models.Model):
         SABADO = 'sabado', _('Sábado')
         DOMINGO = 'domingo', _('Domingo')
 
+    ESTADO_CHOICES = [
+        ('abierto', _('Abierto')),
+        ('cerrado', _('Cerrado')),
+    ]
+
     club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='horarios')
     dia = models.CharField(max_length=10, choices=DiasSemana.choices)
     hora_inicio = models.TimeField()
     hora_fin = models.TimeField()
+    estado = models.CharField(
+        max_length=10,
+        choices=ESTADO_CHOICES,
+        default='abierto'
+    )
 
     class Meta:
         ordering = ['dia', 'hora_inicio']
 
     def __str__(self):
-        return f"{self.club.name} - {self.get_dia_display()} {self.hora_inicio} - {self.hora_fin}"
+        status = dict(self.ESTADO_CHOICES).get(self.estado, self.estado)
+        if self.estado == 'cerrado':
+            time_range = _('Cerrado')
+        else:
+            time_range = f"{self.hora_inicio} - {self.hora_fin}"
+        return f"{self.club.name} - {self.get_dia_display()} {time_range} ({status})"

--- a/static/js/schedule-status.js
+++ b/static/js/schedule-status.js
@@ -35,4 +35,4 @@ document.addEventListener('DOMContentLoaded', () => {
       statusEl.classList.add('text-danger');
     }
   }
-});
+})

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -289,11 +289,15 @@
                                                 {% with horarios_dia=club.horarios.all|dictsort:"hora_inicio" %}
                                                     {% for h in horarios_dia %}
                                                         {% if h.dia == dia %}
-                                                            <div class="border-bottom py-1 small text-muted schedule-item"
-                                                                 data-start="{{ h.hora_inicio|time:'H:i' }}"
-                                                                 data-end="{{ h.hora_fin|time:'H:i' }}">
-                                                                {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}
-                                                            </div>
+                                                            {% if h.estado == 'cerrado' %}
+                                                                <div class="small text-muted">Cerrado</div>
+                                                            {% else %}
+                                                                <div class="border-bottom py-1 small text-muted schedule-item"
+                                                                     data-start="{{ h.hora_inicio|time:'H:i' }}"
+                                                                     data-end="{{ h.hora_fin|time:'H:i' }}">
+                                                                    {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}
+                                                                </div>
+                                                            {% endif %}
                                                         {% endif %}
                                                     {% empty %}
                                                         <span class="text-muted">—</span>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -178,7 +178,12 @@
       <ul>
         {% for h in club.horarios.all %}
         <li>
-          {{ h.get_dia_display }} {{ h.hora_inicio|time:'H:i' }} - {{ h.hora_fin|time:'H:i' }}
+          {{ h.get_dia_display }}
+          {% if h.estado == 'cerrado' %}
+            Cerrado
+          {% else %}
+            {{ h.hora_inicio|time:'H:i' }} - {{ h.hora_fin|time:'H:i' }}
+          {% endif %}
           <a href="{% url 'horario_update' h.id %}">Editar</a>
           <form method="post" action="{% url 'horario_delete' h.id %}" class="d-inline">
             {% csrf_token %}


### PR DESCRIPTION
## Summary
- support open/closed status on schedules
- update schedule forms and templates
- fix schedule status script ending
- add migration for new field

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685cb5b7fff083218bbe095d1d298f1d