### PR TITLE
Improve schedule table in dashboard

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -175,20 +175,41 @@
         {% endfor %}
       </ul>
       <h2 class="h5 mt-4">Horarios</h2>
-      <ul>
-        {% for h in club.horarios.all %}
-        <li>
-          {{ h.get_dia_display }} {{ h.hora_inicio|time:'H:i' }} - {{ h.hora_fin|time:'H:i' }}
-          <a href="{% url 'horario_update' h.id %}">Editar</a>
-          <form method="post" action="{% url 'horario_delete' h.id %}" class="d-inline">
-            {% csrf_token %}
-            <button type="submit" class="btn btn-link p-0">Eliminar</button>
-          </form>
-        </li>
-        {% empty %}
-        <li>No hay horarios.</li>
-        {% endfor %}
-      </ul>
+      <div class="table-responsive">
+        <table class="table table-bordered text-center align-middle" style="min-width: 500px">
+          <thead class="table-dark">
+            <tr>
+              <th scope="col">Día</th>
+              <th scope="col">Horas</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for dia, nombre in club.horarios.model.DiasSemana.choices %}
+            <tr>
+              <th scope="row">{{ nombre }}</th>
+              <td>
+                {% with horarios_dia=club.horarios.filter(dia=dia)|dictsort:"hora_inicio" %}
+                  {% for h in horarios_dia %}
+                  <div class="d-flex justify-content-between align-items-center border-bottom py-1">
+                    <span>{{ h.hora_inicio|time:'H:i' }} - {{ h.hora_fin|time:'H:i' }}</span>
+                    <span>
+                      <a href="{% url 'horario_update' h.id %}" class="me-2">Editar</a>
+                      <form method="post" action="{% url 'horario_delete' h.id %}" class="d-inline">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-link p-0">Eliminar</button>
+                      </form>
+                    </span>
+                  </div>
+                  {% empty %}
+                  <span class="text-muted">—</span>
+                  {% endfor %}
+                {% endwith %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
     <div id="tab-coaches" class="profile-section">
       <a href="{% url 'entrenador_create' club.slug %}" class="btn btn-secondary btn-sm mb-3">Añadir entrenador</a>


### PR DESCRIPTION
## Summary
- show club schedules in a table with days as rows and edit/delete controls

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685cbd6d4dd88321b8d1942a414dddca