### PR TITLE
Update schedule UI

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -36,7 +36,7 @@ def dashboard(request, slug):
     horarios_por_dia = []
     for dia, nombre in dias_semana:
         horarios = club.horarios.filter(dia=dia).order_by('hora_inicio')
-        horarios_por_dia.append((nombre, horarios))
+        horarios_por_dia.append({'dia': dia, 'nombre': nombre, 'horarios': horarios})
     if club.owner != request.user:
         return redirect('home')
     classes = club.clases.all()

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -158,7 +158,6 @@
     </div>
     <div id="tab-schedule" class="profile-section">
       <a href="{% url 'clase_create' club.slug %}" class="btn btn-secondary btn-sm me-2 mb-3">Añadir clase</a>
-      <a href="{% url 'horario_create' club.slug %}" class="btn btn-secondary btn-sm mb-3">Añadir horario</a>
       <h2 class="h5 mt-4">Clases</h2>
       <ul>
         {% for c in classes %}
@@ -184,31 +183,73 @@
             </tr>
           </thead>
          <tbody>
-  {% for nombre, horarios in horarios_por_dia %}
+  {% for item in horarios_por_dia %}
   <tr>
-    <th scope="row">{{ nombre }}</th>
+    <th scope="row">{{ item.nombre }}</th>
     <td>
-      {% if horarios %}
-        {% for h in horarios %}
+      {% if item.horarios %}
+        {% for h in item.horarios %}
         <div class="d-flex justify-content-between align-items-center border-bottom py-1">
           <span>{{ h.hora_inicio|time:'H:i' }} - {{ h.hora_fin|time:'H:i' }}</span>
           <span>
-            <a href="{% url 'horario_update' h.id %}" class="me-2">Editar</a>
+            <a data-bs-toggle="collapse" href="#edit-{{ h.id }}" role="button" aria-expanded="false" aria-controls="edit-{{ h.id }}" class="btn btn-sm btn-link me-2">
+              <svg  style="height:15px;" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg"><path d="M495.6 49.23l-32.82-32.82C451.8 5.471 437.5 0 423.1 0c-14.33 0-28.66 5.469-39.6 16.41L167.5 232.5C159.1 240 154.8 249.5 152.4 259.8L128.3 367.2C126.5 376.1 133.4 384 141.1 384c.916 0 1.852-.0918 2.797-.2813c0 0 74.03-15.71 107.4-23.56c10.1-2.377 19.13-7.459 26.46-14.79l217-217C517.5 106.5 517.4 71.1 495.6 49.23zM461.7 94.4L244.7 311.4C243.6 312.5 242.5 313.1 241.2 313.4c-13.7 3.227-34.65 7.857-54.3 12.14l12.41-55.2C199.6 268.9 200.3 267.5 201.4 266.5l216.1-216.1C419.4 48.41 421.6 48 423.1 48s3.715 .4062 5.65 2.342l32.82 32.83C464.8 86.34 464.8 91.27 461.7 94.4zM424 288c-13.25 0-24 10.75-24 24v128c0 13.23-10.78 24-24 24h-304c-13.22 0-24-10.77-24-24v-304c0-13.23 10.78-24 24-24h144c13.25 0 24-10.75 24-24S229.3 64 216 64L71.1 63.99C32.31 63.99 0 96.29 0 135.1v304C0 479.7 32.31 512 71.1 512h303.1c39.69 0 71.1-32.3 71.1-72L448 312C448 298.8 437.3 288 424 288z"/></svg>
+            </a>
             <form method="post" action="{% url 'horario_delete' h.id %}" class="d-inline">
               {% csrf_token %}
-              <button type="submit" class="btn btn-link p-0">Eliminar</button>
+              <button type="submit" class="btn btn-sm btn-link text-danger">
+                <svg style="height:15px;"viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg"><path d="M432 80h-82.38l-34-56.75C306.1 8.827 291.4 0 274.6 0H173.4C156.6 0 141 8.827 132.4 23.25L98.38 80H16C7.125 80 0 87.13 0 96v16C0 120.9 7.125 128 16 128H32v320c0 35.35 28.65 64 64 64h256c35.35 0 64-28.65 64-64V128h16C440.9 128 448 120.9 448 112V96C448 87.13 440.9 80 432 80zM171.9 50.88C172.9 49.13 174.9 48 177 48h94c2.125 0 4.125 1.125 5.125 2.875L293.6 80H154.4L171.9 50.88zM352 464H96c-8.837 0-16-7.163-16-16V128h288v320C368 456.8 360.8 464 352 464zM224 416c8.844 0 16-7.156 16-16V192c0-8.844-7.156-16-16-16S208 183.2 208 192v208C208 408.8 215.2 416 224 416zM144 416C152.8 416 160 408.8 160 400V192c0-8.844-7.156-16-16-16S128 183.2 128 192v208C128 408.8 135.2 416 144 416zM304 416c8.844 0 16-7.156 16-16V192c0-8.844-7.156-16-16-16S288 183.2 288 192v208C288 408.8 295.2 416 304 416z"/></svg>
+              </button>
             </form>
           </span>
+        </div>
+        <div class="collapse" id="edit-{{ h.id }}">
+          <form method="post" action="{% url 'horario_update' h.id %}">
+            {% csrf_token %}
+            <div class="row g-2 mt-2">
+              <div class="col">
+                <input type="time" name="hora_inicio" value="{{ h.hora_inicio|time:'H:i' }}" class="form-control form-control-sm" required>
+              </div>
+              <div class="col">
+                <input type="time" name="hora_fin" value="{{ h.hora_fin|time:'H:i' }}" class="form-control form-control-sm" required>
+              </div>
+              <div class="col-auto">
+                <button type="submit" class="btn btn-sm btn-primary">Guardar</button>
+              </div>
+            </div>
+          </form>
         </div>
         {% endfor %}
       {% else %}
         <span class="text-muted">—</span>
       {% endif %}
+      <div class="mt-2">
+        <a data-bs-toggle="collapse" href="#add-{{ item.dia }}" role="button" aria-expanded="false" aria-controls="add-{{ item.dia }}" class="btn btn-sm btn-link p-0">
+          <svg style="height:15px;" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg"><path d="M416 208H272V64c0-17.7-14.3-32-32-32s-32 14.3-32 32v144H32c-17.7 0-32 14.3-32 32s14.3 32 32 32h176v176c0 17.7 14.3 32 32 32s32-14.3 32-32V272h144c17.7 0 32-14.3 32-32s-14.3-32-32-32z"/></svg>
+        </a>
+        <div class="collapse mt-2" id="add-{{ item.dia }}">
+          <form method="post" action="{% url 'horario_create' club.slug %}">
+            {% csrf_token %}
+            <input type="hidden" name="dia" value="{{ item.dia }}">
+            <div class="row g-2">
+              <div class="col">
+                <input type="time" name="hora_inicio" class="form-control form-control-sm" required>
+              </div>
+              <div class="col">
+                <input type="time" name="hora_fin" class="form-control form-control-sm" required>
+              </div>
+              <div class="col-auto">
+                <button type="submit" class="btn btn-sm btn-primary">Guardar</button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
     </td>
   </tr>
   {% endfor %}
-</tbody>
-        </table>
+  </tbody>
+          </table>
       </div>
     </div> 
     <div id="tab-coaches" class="profile-section">


### PR DESCRIPTION
## Summary
- restructure horario data in dashboard view
- allow adding schedule times inline per day
- show edit/delete as icons
- remove Add schedule button
- show inline schedule edit form

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685cc1baf518832192fb0a0d41f30775