### PR TITLE
Inline horario editing fix

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -207,6 +207,7 @@
                   <div class="collapse" id="edit-{{ h.id }}">
                     <form method="post" action="{% url 'horario_update' h.id %}">
                       {% csrf_token %}
+                      <input type="hidden" name="dia" value="{{ h.dia }}">
                       <div class="row g-2 mt-2">
                         <div class="col">
                           <input type="time" name="hora_inicio" value="{{ h.hora_inicio|time:'H:i' }}" class="form-control form-control-sm" required>


### PR DESCRIPTION
## Summary
- keep horario edits inline in the dashboard by submitting the current day value

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685ccbd28c388321a52010c473df1efa