### PR TITLE
Add estado dropdown for schedule

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -175,10 +175,11 @@ class ClubPhotoForm(forms.ModelForm):
 class HorarioForm(forms.ModelForm):
     class Meta:
         model = models.Horario
-        fields = ['dia', 'hora_inicio', 'hora_fin']
+        fields = ['dia', 'hora_inicio', 'hora_fin', 'estado']
         widgets = {
             'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
             'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
+            'estado': forms.Select(attrs={'class': 'form-select form-select-sm'}),
         }
 
 

--- a/apps/clubs/management/commands/seed_clubs.py
+++ b/apps/clubs/management/commands/seed_clubs.py
@@ -61,6 +61,7 @@ class Command(BaseCommand):
                     dia=random.choice(dias),
                     hora_inicio=fake.time(),
                     hora_fin=fake.time(),
+                    estado='abierto',
                 )
 
             for _ in range(random.randint(1, 4)):

--- a/apps/clubs/migrations/0019_horario_estado.py
+++ b/apps/clubs/migrations/0019_horario_estado.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0018_clubpost_image'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='horario',
+            name='estado',
+            field=models.CharField(choices=[('abierto', 'Abierto'), ('cerrado', 'Cerrado')], default='abierto', max_length=10),
+        ),
+    ]

--- a/apps/clubs/models/horario.py
+++ b/apps/clubs/models/horario.py
@@ -13,10 +13,19 @@ class Horario(models.Model):
         SABADO = 'sabado', _('Sábado')
         DOMINGO = 'domingo', _('Domingo')
 
+    class Estado(models.TextChoices):
+        ABIERTO = 'abierto', _('Abierto')
+        CERRADO = 'cerrado', _('Cerrado')
+
     club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='horarios')
     dia = models.CharField(max_length=10, choices=DiasSemana.choices)
     hora_inicio = models.TimeField()
     hora_fin = models.TimeField()
+    estado = models.CharField(
+        max_length=10,
+        choices=Estado.choices,
+        default=Estado.ABIERTO,
+    )
 
     class Meta:
         ordering = ['dia', 'hora_inicio']

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -289,11 +289,15 @@
                                                 {% with horarios_dia=club.horarios.all|dictsort:"hora_inicio" %}
                                                     {% for h in horarios_dia %}
                                                         {% if h.dia == dia %}
-                                                            <div class="border-bottom py-1 small text-muted schedule-item"
-                                                                 data-start="{{ h.hora_inicio|time:'H:i' }}"
-                                                                 data-end="{{ h.hora_fin|time:'H:i' }}">
-                                                                {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}
-                                                            </div>
+                                                            {% if h.estado == 'abierto' %}
+                                                                <div class="border-bottom py-1 small text-muted schedule-item"
+                                                                     data-start="{{ h.hora_inicio|time:'H:i' }}"
+                                                                     data-end="{{ h.hora_fin|time:'H:i' }}">
+                                                                    {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}
+                                                                </div>
+                                                            {% else %}
+                                                                <div class="border-bottom py-1 small text-danger">Cerrado</div>
+                                                            {% endif %}
                                                         {% endif %}
                                                     {% empty %}
                                                         <span class="text-muted">—</span>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -214,6 +214,12 @@
                 <div class="col">
                   <input type="time" name="hora_fin" value="{{ bloque.hora_fin|time:'H:i' }}" class="form-control form-control-sm" required>
                 </div>
+                <div class="col">
+                  <select name="estado" class="form-select form-select-sm">
+                    <option value="abierto" {% if bloque.estado == 'abierto' %}selected{% endif %}>Abierto</option>
+                    <option value="cerrado" {% if bloque.estado == 'cerrado' %}selected{% endif %}>Cerrado</option>
+                  </select>
+                </div>
                 <div class="col-auto">
                   <button type="submit" class="btn btn-sm btn-primary">Guardar</button>
                 </div>
@@ -237,6 +243,12 @@
         </div>
         <div class="col">
           <input type="time" name="hora_fin" class="form-control form-control-sm" required>
+        </div>
+        <div class="col">
+          <select name="estado" class="form-select form-select-sm">
+            <option value="abierto">Abierto</option>
+            <option value="cerrado">Cerrado</option>
+          </select>
         </div>
         <div class="col-auto">
           <button type="submit" class="btn btn-sm btn-primary">Guardar</button>


### PR DESCRIPTION
## Summary
- add new `estado` field to `Horario` model and create migration
- expose `estado` in `HorarioForm`
- seed sample horarios with default estado
- show dropdown in dashboard horario forms
- display schedule state on club profile

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685da464a8f08321ba96e13acded7f2a