### PR TITLE
Add global image dropzone and expand gallery grid

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -154,7 +154,7 @@
 /* Gallery styles */
 .gallery-grid {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(10, 1fr);
   gap: 10px;
 }
 

--- a/static/js/gallery-manager.js
+++ b/static/js/gallery-manager.js
@@ -1,8 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const zone = document.querySelector('.photo-dropzone');
-  if (zone) {
+  document.querySelectorAll('.photo-dropzone').forEach(zone => {
     const input = zone.querySelector('input[type="file"]');
     const msg = zone.querySelector('.photo-dropzone-msg');
+    if (!input || !msg) return;
     const showCount = () => {
       if (input.files.length) {
         msg.textContent = `${input.files.length} archivo(s) seleccionado(s)`;
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
       showCount();
     });
     input.addEventListener('change', showCount);
-  }
+  });
 
   const selectBtn = document.getElementById('toggle-select');
   const gallery = document.getElementById('gallery-grid');

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -13,6 +13,14 @@
     <div class="profile-tab" data-target="tab-bookings">Reservas</div>
   </div>
   <div class="profile-content">
+    <form id="top-upload-form" method="post" enctype="multipart/form-data" action="{% url 'clubphoto_upload' club.slug %}" class="mb-3 w-100">
+      {% csrf_token %}
+      <div class="photo-dropzone mb-2">
+        <input type="file" name="image" id="id_top_gallery_image" multiple class="d-none">
+        <div class="photo-dropzone-msg">Arrastra imágenes aquí o haz clic para seleccionar</div>
+      </div>
+      <button type="submit" class="btn btn-primary btn-sm">Subir</button>
+    </form>
     <div id="tab-profile" class="profile-section active">
       <h1 class="h3 mb-4">Administrar {{ club.name }}</h1>
       <form method="post" action="{% url 'club_edit' club.slug %}" enctype="multipart/form-data" class="profile-form">


### PR DESCRIPTION
## Summary
- allow uploading images from the top of the dashboard with a new drag-and-drop form
- update gallery grid to use 10 columns
- make gallery script handle multiple dropzones

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Django and Pillow)*

------
https://chatgpt.com/codex/tasks/task_e_685eec54ef2c83219154cd9f3bc9b660