### PR TITLE
Add prelaunch landing page

### DIFF
--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -1,8 +1,9 @@
 # apps/core/urls.py
 from django.urls import path 
-from .views import home   
+from .views import home, prelaunch
 
 urlpatterns = [
     path('', home, name='home'),
+    path('prelaunch/', prelaunch, name='prelaunch'),
 
 ]

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -7,5 +7,10 @@ def home(request):
     return render(request, 'core/home.html', {
         'search_query': search_query,
     })
+
+
+def prelaunch(request):
+    """Landing page para acceso anticipado."""
+    return render(request, 'core/landing.html')
  
  

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -1,0 +1,11 @@
+.landing-body {
+    background-color: #000;
+    color: #fff;
+    font-family: 'Inter', sans-serif;
+    min-height: 100vh;
+}
+
+.landing-logo {
+    width: 120px;
+    height: auto;
+}

--- a/templates/core/landing.html
+++ b/templates/core/landing.html
@@ -1,0 +1,20 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Clubs De Boxeo - Próximamente</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/svg+xml" href="{% static 'img/logo.svg' %}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{% static 'css/landing.css' %}">
+</head>
+<body class="landing-body d-flex align-items-center justify-content-center">
+    <main class="text-center">
+        <img src="{% static 'img/logo.svg' %}" alt="Clubs de Boxeo" class="landing-logo mb-4">
+        <h1 class="text-light display-4 mb-3">Próximamente</h1>
+        <p class="text-light lead mb-4">Únete para obtener acceso anticipado.</p>
+        <a href="{% url 'signup' %}" class="btn btn-light btn-lg">Quiero acceso</a>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create basic landing page in Spanish
- add prelaunch view and route
- style page with black theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f1b94aa108321848996460bb867ba