### PR TITLE
UI tweaks for dashboard

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -48,7 +48,6 @@ def dashboard(request, slug):
         return redirect('home')
     classes = club.clases.all()
     coaches = club.entrenadores.all()
-    posts = club.posts.filter(parent__isnull=True).select_related('user').prefetch_related('replies__user')
     bookings = Booking.objects.filter(
         Q(clase__club=club) | Q(evento__club=club)
     ).select_related('user', 'clase', 'evento')
@@ -63,7 +62,6 @@ def dashboard(request, slug):
             'dias_semana': dias_semana,
             'horarios_por_dia': horarios_por_dia,
             'classes': classes,
-            'posts': posts,
             'bookings': bookings,
             'form': form,
             'coaches': coaches,

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -154,13 +154,13 @@
 /* Gallery styles */
 .gallery-grid {
   display: grid;
-  grid-template-columns: repeat(10, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   gap: 10px;
 }
 
 .gallery-item {
   position: relative;
-  height: 100px;
+  height: 150px;
   overflow: hidden;
 }
 

--- a/static/js/gallery-manager.js
+++ b/static/js/gallery-manager.js
@@ -26,12 +26,20 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const selectBtn = document.getElementById('toggle-select');
+  const selectAllBtn = document.getElementById('select-all');
   const gallery = document.getElementById('gallery-grid');
   const deleteForm = document.getElementById('bulk-delete-form');
   const deleteIds = document.getElementById('delete-ids');
 
   selectBtn && selectBtn.addEventListener('click', () => {
     gallery.classList.toggle('select-mode');
+    if (selectAllBtn) selectAllBtn.classList.toggle('d-none');
+  });
+
+  selectAllBtn && selectAllBtn.addEventListener('click', () => {
+    const boxes = gallery.querySelectorAll('.photo-checkbox');
+    const allChecked = Array.from(boxes).every(cb => cb.checked);
+    boxes.forEach(cb => { cb.checked = !allChecked; });
   });
 
   deleteForm && deleteForm.addEventListener('submit', e => {

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -7,7 +7,6 @@
     <div class="profile-tab" data-target="tab-schedule">Horarios</div>
     <div class="profile-tab" data-target="tab-coaches">Entrenadores</div>
     <div class="profile-tab" data-target="tab-competitors">Competidores</div>
-    <div class="profile-tab" data-target="tab-posts">Publicaciones</div>
     <div class="profile-tab" data-target="tab-bookings">Reservas</div>
   </div>
   <div class="profile-content">
@@ -233,6 +232,13 @@
         >
           Seleccionar
         </button>
+        <button
+          id="select-all"
+          type="button"
+          class="btn btn-sm btn-outline-secondary d-none"
+        >
+          Seleccionar todo
+        </button>
         <form
           id="bulk-delete-form"
           method="post"
@@ -323,8 +329,8 @@
                 >
                   <span>
                     {% if bloque.estado == 'abierto' %} {{
-                    bloque.hora_inicio|time:'H:i' }} - {{
-                    bloque.hora_fin|time:'H:i' }} {% else %}
+                    bloque.hora_inicio }} - {{
+                    bloque.hora_fin }} {% else %}
                     <span class="text-danger">Cerrado</span>
                     {% endif %}
                   </span>
@@ -508,24 +514,35 @@
         class="btn btn-secondary btn-sm mb-3"
         >Añadir entrenador</a
       >
-      <ul>
+      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
         {% for coach in club.entrenadores.all %}
-        <li>
-          {{ coach.nombre }} {{ coach.apellidos }}
-          <a href="{% url 'entrenador_update' coach.id %}">Editar</a>
-          <form
-            method="post"
-            action="{% url 'entrenador_delete' coach.id %}"
-            class="d-inline"
-          >
-            {% csrf_token %}
-            <button type="submit" class="btn btn-link p-0">Eliminar</button>
-          </form>
-        </li>
+        <div class="col">
+          <div class="card h-100 text-center">
+            {% if coach.avatar %}
+              <img src="{{ coach.avatar.url }}" class="card-img-top object-fit-cover" style="height:150px" alt="{{ coach.nombre }}">
+            {% else %}
+              <div class="card-img-top d-flex align-items-center justify-content-center bg-light" style="height:150px;">
+                <span class="text-muted">{{ coach.nombre|first|upper }}</span>
+              </div>
+            {% endif %}
+            <div class="card-body p-2">
+              <div class="d-flex justify-content-between align-items-center">
+                <span>{{ coach.nombre }} {{ coach.apellidos }}</span>
+                <div class="d-flex gap-2">
+                  <a href="{% url 'entrenador_update' coach.id %}" class="text-decoration-none"><i class="bi bi-pencil"></i></a>
+                  <form method="post" action="{% url 'entrenador_delete' coach.id %}">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-link p-0 text-danger"><i class="bi bi-trash"></i></button>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
         {% empty %}
-        <li>No hay entrenadores.</li>
+        <p>No hay entrenadores.</p>
         {% endfor %}
-      </ul>
+      </div>
     </div>
     <div id="tab-competitors" class="profile-section">
       <a
@@ -533,78 +550,40 @@
         class="btn btn-secondary btn-sm mb-3"
         >Añadir competidor</a
       >
-      <ul>
+      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
         {% for comp in club.competidores.all %}
-        <li>
-          {% with rec=comp.record_tuple %} {{ comp.nombre }} -
-          <span class="text-success">{{ rec.0 }}</span>-<span
-            class="text-danger"
-            >{{ rec.1 }}</span
-          >-<span class="text-primary">{{ rec.2 }}</span> - {{ comp.categoria }}
-          {% endwith %}
-          <a href="{% url 'competidor_update' comp.id %}">Editar</a>
-          <form
-            method="post"
-            action="{% url 'competidor_delete' comp.id %}"
-            class="d-inline"
-          >
-            {% csrf_token %}
-            <button type="submit" class="btn btn-link p-0">Eliminar</button>
-          </form>
-        </li>
+        <div class="col">
+          <div class="card h-100 text-center">
+            {% if comp.avatar %}
+              <img src="{{ comp.avatar.url }}" class="card-img-top object-fit-cover" style="height:150px" alt="{{ comp.nombre }}">
+            {% else %}
+              <div class="card-img-top d-flex align-items-center justify-content-center bg-light" style="height:150px;">
+                <span class="text-muted">{{ comp.nombre|initials }}</span>
+              </div>
+            {% endif %}
+            <div class="card-body p-2">
+              <div class="d-flex justify-content-between align-items-center">
+                <span>{{ comp.nombre }}</span>
+                <div class="d-flex gap-2">
+                  <a href="{% url 'competidor_update' comp.id %}" class="text-decoration-none"><i class="bi bi-pencil"></i></a>
+                  <form method="post" action="{% url 'competidor_delete' comp.id %}">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-link p-0 text-danger"><i class="bi bi-trash"></i></button>
+                  </form>
+                </div>
+              </div>
+              <small class="text-muted">
+                {% with rec=comp.record_tuple %}
+                  <span class="text-success">{{ rec.0 }}</span>-<span class="text-danger">{{ rec.1 }}</span>-<span class="text-primary">{{ rec.2 }}</span> - {{ comp.categoria }}
+                {% endwith %}
+              </small>
+            </div>
+          </div>
+        </div>
         {% empty %}
-        <li>No hay competidores.</li>
+        <p>No hay competidores.</p>
         {% endfor %}
-      </ul>
-    </div>
-    <div id="tab-posts" class="profile-section">
-      <a
-        href="{% url 'clubpost_create' club.slug %}"
-        class="btn btn-secondary btn-sm mb-3"
-        >Nueva publicación</a
-      >
-      <ul>
-        {% for p in posts %}
-        <li>
-          {{ p.titulo }} {% if user.is_authenticated and user == p.user %}
-          <a
-            href="{% url 'clubpost_update' p.id %}"
-            class="btn btn-sm btn-link"
-          >
-            <svg
-              style="height: 15px"
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M495.6 49.23l-32.82-32.82C451.8 5.471 437.5 0 423.1 0c-14.33 0-28.66 5.469-39.6 16.41L167.5 232.5C159.1 240 154.8 249.5 152.4 259.8L128.3 367.2C126.5 376.1 133.4 384 141.1 384c.916 0 1.852-.0918 2.797-.2813c0 0 74.03-15.71 107.4-23.56c10.1-2.377 19.13-7.459 26.46-14.79l217-217C517.5 106.5 517.4 71.1 495.6 49.23zM461.7 94.4L244.7 311.4C243.6 312.5 242.5 313.1 241.2 313.4c-13.7 3.227-34.65 7.857-54.3 12.14l12.41-55.2C199.6 268.9 200.3 267.5 201.4 266.5l216.1-216.1C419.4 48.41 421.6 48 423.1 48s3.715 .4062 5.65 2.342l32.82 32.83C464.8 86.34 464.8 91.27 461.7 94.4zM424 288c-13.25 0-24 10.75-24 24v128c0 13.23-10.78 24-24 24h-304c-13.22 0-24-10.77-24-24v-304c0-13.23 10.78-24 24-24h144c13.25 0 24-10.75 24-24S229.3 64 216 64L71.1 63.99C32.31 63.99 0 96.29 0 135.1v304C0 479.7 32.31 512 71.1 512h303.1c39.69 0 71.1-32.3 71.1-72L448 312C448 298.8 437.3 288 424 288z"
-              />
-            </svg>
-          </a>
-          <form
-            method="post"
-            action="{% url 'clubpost_delete' p.id %}"
-            class="d-inline"
-          >
-            {% csrf_token %}
-            <button type="submit" class="btn btn-sm btn-link text-danger">
-              <svg
-                style="height: 15px"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M432 80h-82.38l-34-56.75C306.1 8.827 291.4 0 274.6 0H173.4C156.6 0 141 8.827 132.4 23.25L98.38 80H16C7.125 80 0 87.13 0 96v16C0 120.9 7.125 128 16 128H32v320c0 35.35 28.65 64 64 64h256c35.35 0 64-28.65 64-64V128h16C440.9 128 448 120.9 448 112V96C448 87.13 440.9 80 432 80zM171.9 50.88C172.9 49.13 174.9 48 177 48h94c2.125 0 4.125 1.125 5.125 2.875L293.6 80H154.4L171.9 50.88zM352 464H96c-8.837 0-16-7.163-16-16V128h288v320C368 456.8 360.8 464 352 464zM224 416c8.844 0 16-7.156 16-16V192c0-8.844-7.156-16-16-16S208 183.2 208 192v208C208 408.8 215.2 416 224 416zM144 416C152.8 416 160 408.8 160 400V192c0-8.844-7.156-16-16-16S128 183.2 128 192v208C128 408.8 135.2 416 144 416zM304 416c8.844 0 16-7.156 16-16V192c0-8.844-7.156-16-16-16S288 183.2 288 192v208C288 408.8 295.2 416 304 416z"
-                />
-              </svg>
-            </button>
-          </form>
-          {% endif %}
-        </li>
-        {% empty %}
-        <li>No hay posts.</li>
-        {% endfor %}
-      </ul>
+      </div>
     </div>
     <div id="tab-bookings" class="profile-section">
       <ul>


### PR DESCRIPTION
## Summary
- show schedule entries with raw times
- add select all button and 5-column layout for gallery
- display coaches and competitors as cards
- remove posts from dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d031d148c83218f0120c33de87642