### PR TITLE
Fix dashboard schedule time display

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -328,9 +328,10 @@
                   class="d-flex justify-content-between align-items-center border rounded p-1 mb-1"
                 >
                   <span>
-                    {% if bloque.estado == 'abierto' %} {{
-                    bloque.hora_inicio }} - {{
-                    bloque.hora_fin }} {% else %}
+                    {% if bloque.estado == 'abierto' %}
+                    {{ bloque.hora_inicio|time:'H:i' }} -
+                    {{ bloque.hora_fin|time:'H:i' }}
+                    {% else %}
                     <span class="text-danger">Cerrado</span>
                     {% endif %}
                   </span>


### PR DESCRIPTION
## Summary
- show schedule times using the `time` filter again so the added schedules render correctly

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686d0611225483219cbdf409a1799d7e