### PR TITLE
Update avatar dropzone layout

### DIFF
--- a/apps/core/templatetags/utils_filters.py
+++ b/apps/core/templatetags/utils_filters.py
@@ -79,3 +79,14 @@ def youtube_embed(text):
     html = f"<p>{safe_text}</p>" if cleaned else ""
     html += embed
     return mark_safe(html)
+
+
+@register.filter
+def safe_url(file_field):
+    """Return the file URL or empty string if missing."""
+    try:
+        if file_field:
+            return file_field.url
+    except (ValueError, AttributeError):
+        return ""
+    return ""

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -122,8 +122,8 @@
 }
 /* Avatar dropzone styles */
 .avatar-dropzone {
-  width: 120px;
-  height: 120px;
+  width: 200px;
+  height: 200px;
   position: relative;
 }
 .avatar-dropzone input[type="file"] {
@@ -133,7 +133,7 @@
   width: 100%;
   height: 100%;
   border: 2px dashed #666;
-  border-radius: 50%;
+  border-radius: 0;
   background-size: cover;
   background-position: center;
   cursor: pointer;

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -9,8 +9,8 @@
             <!-- Columna Izquierda: Info del Club -->
             <div class="col-lg-2 ">
          <div class="position-relative bg-black club-logo d-flex align-items-center justify-content-center" style="height: 200px;">
-            {% if club.logo %}
-                <img src="{{ club.logo.url }}"
+            {% if club.logo|safe_url %}
+                <img src="{{ club.logo|safe_url }}"
                     class="w-100 h-100"
                     style="object-fit: contain;"
                     alt="{{ club.name }}">

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -23,17 +23,17 @@
           <div class="avatar-dropzone">
             {{ form.logo }}
             <div
-              class="avatar-preview{% if club.logo %} has-image{% endif %}"
-              {%
-              if
-              club.logo
-              %}
-              style="background-image:url('{{ club.logo.url }}')"
-              {%
-              endif
-              %}
+              class="avatar-preview{% if club.logo|safe_url %} has-image{% endif %}"
+              {% if club.logo|safe_url %}
+              style="background-image:url('{{ club.logo|safe_url }}')"
+              {% endif %}
             >
-              {% if not club.logo %}+{% endif %}
+              {% if not club.logo|safe_url %}
+                <span class="d-flex flex-column align-items-center text-white">
+                  <svg fill="#fff" width="50px" height="50px" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><g data-name="Layer 28" id="Layer_28"><path d="M32,3A29,29,0,1,0,61,32,29,29,0,0,0,32,3Zm0,56A27,27,0,1,1,59,32,27,27,0,0,1,32,59ZM43,37a1,1,0,0,1-1,1H22a1,1,0,0,1,0-2H42A1,1,0,0,1,43,37Zm5.71-19.29L44.41,22l4.3,4.29a1,1,0,0,1,0,1.42,1,1,0,0,1-1.42,0L43,23.41l-4.29,4.3a1,1,0,0,1-1.42,0,1,1,0,0,1,0-1.42L41.59,22l-4.3-4.29a1,1,0,0,1,1.42-1.42L43,20.59l4.29-4.3a1,1,0,0,1,1.42,1.42ZM23,23.41l-4.29,4.3a1,1,0,0,1-1.42,0,1,1,0,0,1,0-1.42L21.59,22l-4.3-4.29a1,1,0,0,1,1.42-1.42L23,20.59l4.29-4.3a1,1,0,0,1,1.42,1.42L24.41,22l4.3,4.29a1,1,0,0,1,0,1.42,1,1,0,0,1-1.42,0Z"/></g></svg>
+                  <small class="mt-2">Sin logo</small>
+                </span>
+              {% endif %}
             </div>
           </div>
           <label for="{{ form.logo.id_for_label }}"

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -18,10 +18,9 @@
             <h1 class="mb-4">Mi Cuenta</h1>
             <form method="post" enctype="multipart/form-data" class="profile-form mb-5">
                 {% csrf_token %}
-                <div class="form-field">
-                    <div class="avatar-dropzone">
-                         {{ form.avatar }}
-
+                <div class="mb-5 text-center">
+                    <div class="avatar-dropzone mx-auto">
+                        {{ form.avatar }}
                         <div class="avatar-preview{% if profile.avatar %} has-image{% endif %}"{% if profile.avatar %} style="background-image:url('{{ profile.avatar.url }}')"{% endif %}>
                             <div class="avatar-dropzone-msg">
                                 <i class="bi bi-cloud-upload mb-1 fs-4"></i>
@@ -29,7 +28,7 @@
                             </div>
                         </div>
                     </div>
-                    <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
+                    <label class="form-label mt-2" for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
                     {% if form.avatar.errors %}
                     <div class="invalid-feedback d-block">
                         {{ form.avatar.errors.as_text|striptags }}


### PR DESCRIPTION
## Summary
- adjust avatar dropzone to 200x200 square
- move avatar input to the top of the profile form with Bootstrap spacing
- avoid missing-logo errors using a new `safe_url` filter and show the same placeholder as search results

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e2c6acc688321953f0d6e6fcce56e