### PR TITLE
Pin logged-in user review first

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -116,3 +116,55 @@ class DashboardPermissionTests(TestCase):
         url = reverse('clubpost_create', args=[self.club.slug])
         response = self.client.post(url, {'titulo': 'x', 'contenido': 'y'})
         self.assertEqual(response.status_code, 403)
+
+
+class UserReviewFirstTests(TestCase):
+    def setUp(self):
+        self.club = Club.objects.create(
+            name='My Club',
+            city='City',
+            address='Addr',
+            phone='111',
+            email='club@example.com',
+        )
+        self.user1 = User.objects.create_user(username='user1', password='pass')
+        self.user2 = User.objects.create_user(username='user2', password='pass')
+
+        self.review1 = Reseña.objects.create(
+            club=self.club,
+            usuario=self.user1,
+            titulo='U1',
+            instalaciones=5,
+            entrenadores=5,
+            ambiente=5,
+            calidad_precio=5,
+            variedad_clases=5,
+            comentario='great',
+        )
+        self.review2 = Reseña.objects.create(
+            club=self.club,
+            usuario=self.user2,
+            titulo='U2',
+            instalaciones=4,
+            entrenadores=4,
+            ambiente=4,
+            calidad_precio=4,
+            variedad_clases=4,
+            comentario='ok',
+        )
+
+    def test_user_review_first_in_profile(self):
+        self.client.login(username='user1', password='pass')
+        url = reverse('club_profile', args=[self.club.slug])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        reviews = list(response.context['reseñas'])
+        self.assertEqual(reviews[0].usuario, self.user1)
+
+    def test_user_review_first_in_ajax(self):
+        self.client.login(username='user1', password='pass')
+        url = reverse('ajax_reviews', args=[self.club.slug])
+        response = self.client.get(url, {'orden': 'recientes'}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 200)
+        reviews = list(response.context['reseñas'])
+        self.assertEqual(reviews[0].usuario, self.user1)

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -66,6 +66,15 @@ def club_profile(request, slug):
     else:  # relevantes (por defecto)
         reseñas = reseñas.order_by('-creado')  # puedes mejorar esto más adelante
 
+    # Ensure the logged in user's review is shown first
+    if request.user.is_authenticated:
+        if not isinstance(reseñas, list):
+            reseñas = list(reseñas)
+        user_review = next((r for r in reseñas if r.usuario == request.user), None)
+        if user_review:
+            reseñas.remove(user_review)
+            reseñas.insert(0, user_review)
+
     # Attach forms for editing
     posts = list(posts)
     for p in posts:
@@ -117,6 +126,14 @@ def ajax_reviews(request, slug):
         reseñas = sorted(reseñas, key=lambda r: r.promedio())
     else:
         reseñas = reseñas.order_by('-creado')
+
+    if request.user.is_authenticated:
+        if not isinstance(reseñas, list):
+            reseñas = list(reseñas)
+        user_review = next((r for r in reseñas if r.usuario == request.user), None)
+        if user_review:
+            reseñas.remove(user_review)
+            reseñas.insert(0, user_review)
 
     if not isinstance(reseñas, list):
         reseñas = list(reseñas)


### PR DESCRIPTION
## Summary
- prioritize the logged-in user's review in club profile and ajax views
- test the new ordering logic

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686f0231d61483218a55b2d3c5769c99