### PR TITLE
Make review filter arrow clickable

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -394,3 +394,16 @@ textarea.form-control {
   stroke: #000;
 }
 
+
+.review-filter-dropdown .selected-text {
+    display: inline-flex;
+    align-items: center;
+}
+
+.review-filter-dropdown .select-arrow {
+    position: relative;
+    top: auto;
+    right: auto;
+    margin-left: 5px;
+    pointer-events: auto;
+}

--- a/templates/partials/_review-filter.html
+++ b/templates/partials/_review-filter.html
@@ -2,9 +2,9 @@
       <form method="get" id="review-filter-form" action="{% url 'ajax_reviews' club.slug %}" class="d-flex align-items-center" style="gap: 0px;">
         <input type="hidden" name="orden" id="sort-input" value="{{ request.GET.orden|default:'' }}">
 
-    <div class="custom-dropdown small m-0 p-0" id="sort-dropdown">
+    <div class="custom-dropdown small m-0 p-0 review-filter-dropdown" id="sort-dropdown">
             <div class="selected">
-                <span class="selected-text">
+                <span class="selected-text d-flex align-items-center">
                 
                 {% if request.GET.orden == 'recientes' %}Más recientes
                     {% elif request.GET.orden == 'relevantes' %}Más relevantes
@@ -12,8 +12,8 @@
                 {% elif request.GET.orden == 'puntuacion_baja' %}Puntuación más baja
                 {% elif request.GET.orden == 'puntuacion_alta' %}Puntuación más alta 
                 {% else %}Ordenar por{% endif %}
+                <span class="select-arrow m-0 p-0"></span>
                 </span>
-            <span class="select-arrow m-0 p-0"></span>
             </div>
             <div class="dropdown-menu" id="sort-menu">
             <div class="dropdown-item" data-value="relevantes">Más relevantes</div>


### PR DESCRIPTION
## Summary
- make the review filter arrow part of the clickable text
- tweak CSS so the arrow is inline with the text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686f13d80b4c8321895f23342d66d1b9