### PR TITLE
Organize dashboard cards in 5 columns

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -516,7 +516,7 @@
         class="btn btn-secondary btn-sm mb-3"
         >Añadir entrenador</a
       >
-      <div class="row ">
+      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 g-4">
         {% for coach in club.entrenadores.all %}
         <div class="col">
           <div class="card h-100 text-center">
@@ -567,7 +567,7 @@
         class="btn btn-secondary btn-sm mb-3"
         >Añadir competidor</a
       >
-      <div class="row ">
+      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 g-4">
         {% for comp in club.competidores.all %}
         <div class="col">
           <div class="card h-100 text-center">


### PR DESCRIPTION
## Summary
- show coaches and competitors in five-column grids on the dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Django and Pillow)*

------
https://chatgpt.com/codex/tasks/task_e_686f3c3a7134832181db5c4563b2bba9