### PR TITLE
Add FAQ page

### DIFF
--- a/apps/core/tests.py
+++ b/apps/core/tests.py
@@ -16,3 +16,10 @@ class YoutubeEmbedTests(SimpleTestCase):
         self.assertNotIn('iframe', html)
         self.assertIn('&lt;script&gt;alert(1)&lt;/script&gt;', html)
 
+
+class FaqViewTests(SimpleTestCase):
+    def test_faq_url_resolves(self):
+        response = self.client.get('/faq/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'core/faq.html')
+

--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -1,8 +1,9 @@
 # apps/core/urls.py
 from django.urls import path 
-from .views import home   
+from .views import home, faq
 
 urlpatterns = [
     path('', home, name='home'),
+    path('faq/', faq, name='faq'),
 
 ]

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -7,5 +7,10 @@ def home(request):
     return render(request, 'core/home.html', {
         'search_query': search_query,
     })
+
+
+def faq(request):
+    """Display frequently asked questions."""
+    return render(request, 'core/faq.html')
  
  

--- a/templates/core/faq.html
+++ b/templates/core/faq.html
@@ -1,0 +1,51 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
+{% block content %}
+<main class="flex-grow-1 py-4">
+    <div class="container">
+        <h1 class="text-center mb-4">Preguntas Frecuentes</h1>
+        <p class="text-center mb-5">
+            <a href="{% url 'home' %}" class="btn btn-outline-primary">Volver a la landing page</a>
+        </p>
+        <div class="accordion" id="faqAccordion">
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingOne">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+                        ¿Cómo me registro en la plataforma?
+                    </button>
+                </h2>
+                <div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="headingOne" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        Puedes crear una cuenta haciendo clic en el botón <strong>Registro</strong> en la parte superior de la página de inicio y completando el formulario.
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingTwo">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+                        ¿Es necesario pagar para unirse a un club?
+                    </button>
+                </h2>
+                <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        La inscripción en un club puede ser gratuita o de pago según cada institución. Consulta los detalles en el perfil de cada club antes de unirte.
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingThree">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+                        ¿Cómo puedo contactar con soporte?
+                    </button>
+                </h2>
+                <div id="collapseThree" class="accordion-collapse collapse" aria-labelledby="headingThree" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        Si tienes alguna duda o problema puedes escribirnos a <a href="mailto:soporte@clubsdeboxeo.com">soporte@clubsdeboxeo.com</a> y te responderemos lo antes posible.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+{% endblock %}

--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -12,7 +12,7 @@
             <!-- Enlaces principales -->
             <div class="col-md-10 d-flex justify-content-md-end justify-content-center text-center gap-3 flex-md-row flex-column">
                 <a class="text-dark fw-bold text-decoration-none" href="#">Ayuda</a>
-                <a class="text-dark fw-bold text-decoration-none" href="#">F.A.Q</a>
+                <a class="text-dark fw-bold text-decoration-none" href="{% url 'faq' %}">F.A.Q</a>
                 <a class="text-dark fw-bold text-decoration-none" href="#">Contacto</a>
                 <a class="text-dark fw-bold text-decoration-none d-flex justify-content-center " href="#">
                     <img src="{% static 'img/instagram-icon.svg' %}" alt="Instagram">


### PR DESCRIPTION
## Summary
- create a FAQ page template with Bootstrap accordion
- add `faq` view and route
- link from footer to the new FAQ page
- test that the page loads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_686fc93837d483218c593fbb3ba30470