### PR TITLE
Replace /faq link with /planes

### DIFF
--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -12,7 +12,7 @@
             <!-- Enlaces principales -->
             <div class="col-md-10 d-flex justify-content-md-end justify-content-center text-center gap-3 flex-md-row flex-column">
                 <a class="text-dark fw-bold text-decoration-none" href="{% url 'ayuda' %}">Ayuda</a>
-                <a class="text-dark fw-bold text-decoration-none" href="{% url 'ayuda' %}">F.A.Q</a>
+                <a class="text-dark fw-bold text-decoration-none" href="/planes">Planes</a>
                 <a class="text-dark fw-bold text-decoration-none" href="#">Contacto</a>
                 <a class="text-dark fw-bold text-decoration-none d-flex justify-content-center " href="#">
                     <img src="{% static 'img/instagram-icon.svg' %}" alt="Instagram">


### PR DESCRIPTION
## Summary
- update footer to link to `/planes` instead of the FAQ page

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68704f011a288321b2bfcd6d3624f0ed