### PR TITLE
Replace /faq link with /planes

### DIFF
--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -1,9 +1,10 @@
 # apps/core/urls.py
 from django.urls import path 
-from .views import home, ayuda
+from .views import home, ayuda, planes
 
 urlpatterns = [
     path('', home, name='home'),
     path('ayuda/', ayuda, name='ayuda'),
+    path('planes/', planes, name='planes'),
 
 ]

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -12,5 +12,10 @@ def home(request):
 def ayuda(request):
     """Display frequently asked questions."""
     return render(request, 'core/ayuda.html')
+
+
+def planes(request):
+    """Display available subscription plans."""
+    return render(request, 'core/planes.html')
  
  

--- a/templates/core/planes.html
+++ b/templates/core/planes.html
@@ -1,0 +1,54 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
+{% block content %}
+<main class="flex-grow-1 py-5">
+    <div class="container">
+        <h1 class="text-center mb-5">Nuestros Planes</h1>
+        <div class="row row-cols-1 row-cols-md-3 g-4">
+            <div class="col">
+                <div class="card h-100 text-center shadow-sm">
+                    <div class="card-body d-flex flex-column justify-content-between">
+                        <div>
+                            <h3 class="card-title">Plan Gratuito</h3>
+                            <p class="card-text">Acceso básico al directorio y funciones esenciales.</p>
+                        </div>
+                        <div>
+                            <p class="display-6 fw-bold">€0</p>
+                            <a class="btn btn-outline-dark mt-2 disabled" href="#">Actual</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card h-100 text-center shadow-sm border-dark">
+                    <div class="card-body d-flex flex-column justify-content-between">
+                        <div>
+                            <h3 class="card-title">Plan Amateur</h3>
+                            <p class="card-text">Funciones ampliadas y visibilidad para tu club.</p>
+                        </div>
+                        <div>
+                            <p class="display-6 fw-bold">€9<span class="fs-6">/mes</span></p>
+                            <a class="btn btn-dark mt-2" href="#">Elegir</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card h-100 text-center shadow-sm">
+                    <div class="card-body d-flex flex-column justify-content-between">
+                        <div>
+                            <h3 class="card-title">Plan Pro</h3>
+                            <p class="card-text">Todas las ventajas para destacar y atraer más boxeadores.</p>
+                        </div>
+                        <div>
+                            <p class="display-6 fw-bold">€19<span class="fs-6">/mes</span></p>
+                            <a class="btn btn-dark mt-2" href="#">Elegir</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+{% endblock %}

--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -12,7 +12,7 @@
             <!-- Enlaces principales -->
             <div class="col-md-10 d-flex justify-content-md-end justify-content-center text-center gap-3 flex-md-row flex-column">
                 <a class="text-dark fw-bold text-decoration-none" href="{% url 'ayuda' %}">Ayuda</a>
-                <a class="text-dark fw-bold text-decoration-none" href="{% url 'ayuda' %}">F.A.Q</a>
+                <a class="text-dark fw-bold text-decoration-none" href="/planes">Planes</a>
                 <a class="text-dark fw-bold text-decoration-none" href="#">Contacto</a>
                 <a class="text-dark fw-bold text-decoration-none d-flex justify-content-center " href="#">
                     <img src="{% static 'img/instagram-icon.svg' %}" alt="Instagram">


### PR DESCRIPTION
## Summary
- update footer to link to `/planes` instead of the FAQ page
- add new `/planes` route in core app
- create `planes.html` with Free, Amateur and Pro plans

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68704f011a288321b2bfcd6d3624f0ed