### PR TITLE
Add legal policy pages

### DIFF
--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -1,10 +1,13 @@
 # apps/core/urls.py
 from django.urls import path 
-from .views import home, ayuda, planes
+from .views import home, ayuda, planes, terminos, privacidad, cookies
 
 urlpatterns = [
     path('', home, name='home'),
     path('ayuda/', ayuda, name='ayuda'),
     path('planes/', planes, name='planes'),
+    path('terminos/', terminos, name='terminos'),
+    path('privacidad/', privacidad, name='privacidad'),
+    path('cookies/', cookies, name='cookies'),
 
 ]

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -17,5 +17,20 @@ def ayuda(request):
 def planes(request):
     """Display available subscription plans."""
     return render(request, 'core/planes.html')
+
+
+def terminos(request):
+    """Display terms and conditions page."""
+    return render(request, 'core/terminos_condiciones.html')
+
+
+def privacidad(request):
+    """Display privacy policy page."""
+    return render(request, 'core/politica_privacidad.html')
+
+
+def cookies(request):
+    """Display cookies policy page."""
+    return render(request, 'core/politica_cookies.html')
  
  

--- a/templates/core/politica_cookies.html
+++ b/templates/core/politica_cookies.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
+{% block content %}
+<main class="flex-grow-1 py-4">
+    <div class="container">
+        <h1 class="text-center mb-4">Política de Cookies</h1>
+        <p>Este sitio utiliza cookies para mejorar la experiencia de navegación y recopilar estadísticas anónimas de uso. Este texto es provisional y debe ser reemplazado por la política completa.</p>
+        <p>Puedes configurar tu navegador para rechazar las cookies, aunque esto podría afectar al funcionamiento del sitio.</p>
+    </div>
+</main>
+{% endblock %}

--- a/templates/core/politica_privacidad.html
+++ b/templates/core/politica_privacidad.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
+{% block content %}
+<main class="flex-grow-1 py-4">
+    <div class="container">
+        <h1 class="text-center mb-4">Política de Privacidad</h1>
+        <p>En ClubsDeBoxeo.com nos tomamos muy en serio la privacidad de nuestros usuarios. Esta es una política de ejemplo que debería sustituirse por el contenido definitivo.</p>
+        <p>No compartimos datos personales con terceros, excepto cuando sea necesario para prestar el servicio solicitado o por obligación legal.</p>
+    </div>
+</main>
+{% endblock %}

--- a/templates/core/terminos_condiciones.html
+++ b/templates/core/terminos_condiciones.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
+{% block content %}
+<main class="flex-grow-1 py-4">
+    <div class="container">
+        <h1 class="text-center mb-4">Términos y Condiciones</h1>
+        <p>¡Bienvenido a ClubsDeBoxeo.com! Al acceder y utilizar nuestro sitio, aceptas cumplir con los siguientes términos y condiciones. Este texto es un ejemplo y debería ser reemplazado por la versión legal correspondiente.</p>
+        <p>El contenido del sitio se proporciona con fines informativos y podrá modificarse sin previo aviso. El uso de la información aquí contenida es responsabilidad exclusiva del usuario.</p>
+    </div>
+</main>
+{% endblock %}

--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -31,9 +31,9 @@
             </div>
 
             <div class="col-md-6 d-flex text-center justify-content-md-end justify-content-center gap-3 order-md-2 order-1 flex-md-row flex-column small" >
-                <a href="#" class="text-decoration-none  hover-underline">Términos y Condiciones</a>
-                <a href="#" class="text-decoration-none  hover-underline">Política de Privacidad</a>
-                <a href="#" class="text-decoration-none  hover-underline">Política de Cookies</a>
+                <a href="{% url 'terminos' %}" class="text-decoration-none  hover-underline">Términos y Condiciones</a>
+                <a href="{% url 'privacidad' %}" class="text-decoration-none  hover-underline">Política de Privacidad</a>
+                <a href="{% url 'cookies' %}" class="text-decoration-none  hover-underline">Política de Cookies</a>
             </div>
         </div>
 

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -31,9 +31,9 @@
 <footer class="bg-white border-top py-3">
     <div class="container text-center text-muted small">
         <div class="mb-2">
-            <a href="#" class="text-muted text-decoration-none me-3">Terminos y condiciones</a>
-            <a href="#" class="text-muted text-decoration-none me-3">Política de Privacidad</a>
-            <a href="#" class="text-muted text-decoration-none">Política de cookies</a>
+            <a href="{% url 'terminos' %}" class="text-muted text-decoration-none me-3">Terminos y condiciones</a>
+            <a href="{% url 'privacidad' %}" class="text-muted text-decoration-none me-3">Política de Privacidad</a>
+            <a href="{% url 'cookies' %}" class="text-muted text-decoration-none">Política de cookies</a>
         </div>
         <div>
             &copy; 2025 ClubsDeBoxeo.com

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -115,8 +115,8 @@
         <div class="border-top mt-4 pt-3 text-center">
             <p class="mb-0 small text-muted">
                 Al crear una cuenta aceptas nuestros
-                <a href="#" class="text-decoration-none">Términos y Condiciones</a> y la 
-                <a href="#" class="text-decoration-none">Política de Privacidad</a>.
+                <a href="{% url 'terminos' %}" class="text-decoration-none">Términos y Condiciones</a> y la
+                <a href="{% url 'privacidad' %}" class="text-decoration-none">Política de Privacidad</a>.
             </p>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add Terms, Privacy, and Cookies templates
- wire up views and urls for new legal pages
- link the legal pages from footer, login and register pages

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68705ec2b22883219f42d877acadddcf