### PR TITLE
Add back button to footer pages

### DIFF
--- a/templates/blog/post_list.html
+++ b/templates/blog/post_list.html
@@ -3,6 +3,9 @@
 {% block content %}
 <main class="flex-grow-1 py-5">
     <div class="container">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            {% include 'partials/_back-btn.html' %}
+        </div>
         <h1 class="text-center mb-4">Blog</h1>
         {% for post in posts %}
             <article class="mb-5">

--- a/templates/core/ayuda.html
+++ b/templates/core/ayuda.html
@@ -4,10 +4,10 @@
 {% block content %}
 <main class="flex-grow-1 py-4">
     <div class="container">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            {% include 'partials/_back-btn.html' %}
+        </div>
         <h1 class="text-center mb-4">Preguntas Frecuentes</h1>
-        <p class="text-center mb-5">
-            <a href="{% url 'home' %}" class="btn btn-outline-primary">Volver a la landing page</a>
-        </p>
         <div class="accordion" id="faqAccordion">
             <div class="accordion-item">
                 <h2 class="accordion-header" id="headingOne">

--- a/templates/core/planes.html
+++ b/templates/core/planes.html
@@ -4,6 +4,9 @@
 {% block content %}
 <main class="flex-grow-1 py-5">
     <div class="container">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            {% include 'partials/_back-btn.html' %}
+        </div>
         <h1 class="text-center mb-5">Nuestros Planes</h1>
         <div class="row row-cols-1 row-cols-md-3 g-4">
             <div class="col">

--- a/templates/core/politica_cookies.html
+++ b/templates/core/politica_cookies.html
@@ -4,6 +4,9 @@
 {% block content %}
 <main class="flex-grow-1 py-4">
     <div class="container">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            {% include 'partials/_back-btn.html' %}
+        </div>
         <h1 class="text-center mb-4">Política de Cookies</h1>
         <p>Este sitio utiliza cookies para mejorar la experiencia de navegación y recopilar estadísticas anónimas de uso. Este texto es provisional y debe ser reemplazado por la política completa.</p>
         <p>Puedes configurar tu navegador para rechazar las cookies, aunque esto podría afectar al funcionamiento del sitio.</p>

--- a/templates/core/politica_privacidad.html
+++ b/templates/core/politica_privacidad.html
@@ -4,6 +4,9 @@
 {% block content %}
 <main class="flex-grow-1 py-4">
     <div class="container">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            {% include 'partials/_back-btn.html' %}
+        </div>
         <h1 class="text-center mb-4">Política de Privacidad</h1>
         <p>En ClubsDeBoxeo.com nos tomamos muy en serio la privacidad de nuestros usuarios. Esta es una política de ejemplo que debería sustituirse por el contenido definitivo.</p>
         <p>No compartimos datos personales con terceros, excepto cuando sea necesario para prestar el servicio solicitado o por obligación legal.</p>

--- a/templates/core/terminos_condiciones.html
+++ b/templates/core/terminos_condiciones.html
@@ -4,6 +4,9 @@
 {% block content %}
 <main class="flex-grow-1 py-4">
     <div class="container">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            {% include 'partials/_back-btn.html' %}
+        </div>
         <h1 class="text-center mb-4">Términos y Condiciones</h1>
         <p>¡Bienvenido a ClubsDeBoxeo.com! Al acceder y utilizar nuestro sitio, aceptas cumplir con los siguientes términos y condiciones. Este texto es un ejemplo y debería ser reemplazado por la versión legal correspondiente.</p>
         <p>El contenido del sitio se proporciona con fines informativos y podrá modificarse sin previo aviso. El uso de la información aquí contenida es responsabilidad exclusiva del usuario.</p>


### PR DESCRIPTION
## Summary
- include the back button component on the help page and remove the old link
- add the same back button to the plans page
- show the back button on legal policy pages
- add back button to blog list page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68706686eab883219a2e2f9815bbc9de