### PR TITLE
Implement professional registration flow

### DIFF
--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -1,0 +1,31 @@
+from django import forms
+
+class ProfessionalRegistrationForm(forms.Form):
+    REGISTRATION_CHOICES = [
+        ('entrenador', 'Alta entrenador'),
+        ('club', 'Alta club'),
+        ('manager', 'Alta manager'),
+        ('servicio', 'Alta servicio'),
+    ]
+    PLAN_CHOICES = [
+        ('gratis', 'Plan Gratuito'),
+        ('amateur', 'Plan Amateur'),
+        ('pro', 'Plan Pro'),
+    ]
+
+    registration_type = forms.ChoiceField(
+        label='Tipo de alta',
+        choices=REGISTRATION_CHOICES,
+        widget=forms.RadioSelect
+    )
+    plan = forms.ChoiceField(
+        label='Plan de suscripción',
+        choices=PLAN_CHOICES,
+        widget=forms.RadioSelect
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            css = field.widget.attrs.get('class', '')
+            field.widget.attrs['class'] = (css + ' form-check-input').strip()

--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -1,11 +1,20 @@
 # apps/core/urls.py
 from django.urls import path 
-from .views import home, ayuda, planes, terminos, privacidad, cookies
+from .views import (
+    home,
+    ayuda,
+    planes,
+    terminos,
+    privacidad,
+    cookies,
+    professional_register,
+)
 
 urlpatterns = [
     path('', home, name='home'),
     path('ayuda/', ayuda, name='ayuda'),
     path('planes/', planes, name='planes'),
+    path('planes/registro/', professional_register, name='professional_register'),
     path('terminos/', terminos, name='terminos'),
     path('privacidad/', privacidad, name='privacidad'),
     path('cookies/', cookies, name='cookies'),

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -1,5 +1,9 @@
 # apps/core/views.py
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+
+from .forms import ProfessionalRegistrationForm
 
 
 def home(request):
@@ -32,5 +36,20 @@ def privacidad(request):
 def cookies(request):
     """Display cookies policy page."""
     return render(request, 'core/politica_cookies.html')
+
+
+@login_required
+def professional_register(request):
+    """Handle professional registration form."""
+    if request.method == 'POST':
+        form = ProfessionalRegistrationForm(request.POST)
+        if form.is_valid():
+            messages.success(request, 'Solicitud enviada correctamente.')
+            return redirect('planes')
+    else:
+        form = ProfessionalRegistrationForm()
+    return render(request, 'core/professional_register.html', {
+        'form': form,
+    })
  
  

--- a/templates/core/planes.html
+++ b/templates/core/planes.html
@@ -52,6 +52,9 @@
                 </div>
             </div>
         </div>
+        <div class="text-center mt-5">
+            <a class="btn btn-dark" {% if user.is_authenticated %}href="{% url 'professional_register' %}"{% else %}href="#" data-bs-toggle="modal" data-bs-target="#loginModal"{% endif %}>Empezar ahora</a>
+        </div>
     </div>
 </main>
 {% endblock %}

--- a/templates/core/professional_register.html
+++ b/templates/core/professional_register.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
+{% block content %}
+<main class="flex-grow-1 py-5">
+    <div class="container">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            {% include 'partials/_back-btn.html' %}
+        </div>
+        <h1 class="text-center mb-4">Registro Profesional</h1>
+        <form method="post" class="mx-auto" style="max-width: 500px;">
+            {% csrf_token %}
+            <div class="mb-4">
+                <label class="form-label">{{ form.registration_type.label }}</label>
+                {{ form.registration_type }}
+            </div>
+            <div class="mb-4 d-none" id="plan-section">
+                <label class="form-label">{{ form.plan.label }}</label>
+                {{ form.plan }}
+            </div>
+            <button type="submit" class="btn btn-dark">Enviar</button>
+        </form>
+    </div>
+</main>
+{% endblock %}
+{% block extra_js %}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const typeRadios = document.querySelectorAll('input[name="registration_type"]');
+        const planSection = document.getElementById('plan-section');
+        typeRadios.forEach(function(radio) {
+            radio.addEventListener('change', function() {
+                planSection.classList.remove('d-none');
+            });
+        });
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `ProfessionalRegistrationForm`
- create registration view and url
- show start button on plan page opening login modal or registration page
- include new template for registration

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687071bc5e708321b6d3b4b60d41eb29