### PR TITLE
Implement basic Pro section with registration

### DIFF
--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -1,0 +1,41 @@
+from django import forms
+
+class TipoUsuarioForm(forms.Form):
+    tipo = forms.ChoiceField(
+        label='Selecciona que eres',
+        choices=[
+            ('entrenador', 'Entrenador'),
+            ('club', 'Club'),
+            ('manager', 'Manager'),
+            ('servicio', 'Servicio'),
+        ],
+        widget=forms.RadioSelect
+    )
+
+class PlanForm(forms.Form):
+    plan = forms.ChoiceField(
+        label='Selecciona el tipo de Plan',
+        choices=[
+            ('gratis', 'Plan Gratuito'),
+            ('amateur', 'Plan Amateur'),
+            ('pro', 'Plan Pro'),
+        ],
+        widget=forms.RadioSelect
+    )
+
+class BaseInfoForm(forms.Form):
+    nombre = forms.CharField(label='Nombre', max_length=100)
+    email = forms.EmailField(label='Correo')
+    telefono = forms.CharField(label='Teléfono', required=False)
+    descripcion = forms.CharField(label='Descripción', widget=forms.Textarea, required=False)
+
+
+class RegistroProForm(forms.Form):
+    """Formulario combinado para el registro profesional."""
+    tipo = TipoUsuarioForm.base_fields['tipo']
+    plan = PlanForm.base_fields['plan']
+    nombre = BaseInfoForm.base_fields['nombre']
+    email = BaseInfoForm.base_fields['email']
+    telefono = BaseInfoForm.base_fields['telefono']
+    descripcion = BaseInfoForm.base_fields['descripcion']
+

--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -1,11 +1,12 @@
 # apps/core/urls.py
 from django.urls import path 
-from .views import home, ayuda, planes, terminos, privacidad, cookies
+from .views import home, ayuda, pro, registro_profesional, terminos, privacidad, cookies
 
 urlpatterns = [
     path('', home, name='home'),
     path('ayuda/', ayuda, name='ayuda'),
-    path('planes/', planes, name='planes'),
+    path('pro/', pro, name='pro'),
+    path('pro/registro/', registro_profesional, name='registro_profesional'),
     path('terminos/', terminos, name='terminos'),
     path('privacidad/', privacidad, name='privacidad'),
     path('cookies/', cookies, name='cookies'),

--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -1,5 +1,6 @@
 # apps/core/views.py
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from ..forms import RegistroProForm
 
 
 def home(request):
@@ -12,8 +13,23 @@ def home(request):
 def ayuda(request): 
     return render(request, 'core/ayuda.html')
 
-def planes(request): 
-    return render(request, 'core/planes.html')
+def pro(request):
+    return render(request, 'core/pro.html')
+
+
+def registro_profesional(request):
+    """Registro profesional en un único formulario controlado por JavaScript."""
+    if not request.user.is_authenticated:
+        return redirect('login')
+
+    if request.method == 'POST':
+        form = RegistroProForm(request.POST)
+        if form.is_valid():
+            return render(request, 'core/registro_pro_success.html')
+    else:
+        form = RegistroProForm()
+
+    return render(request, 'core/registro_pro.html', {'form': form})
 
 
 def terminos(request):

--- a/static/js/registro-pro.js
+++ b/static/js/registro-pro.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const steps = document.querySelectorAll('#registro-pro-form .step');
+  let current = 0;
+
+  function update() {
+    steps.forEach((step, i) => {
+      step.style.display = i === current ? '' : 'none';
+    });
+  }
+
+  document.querySelectorAll('#registro-pro-form .next-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (current < steps.length - 1) {
+        current += 1;
+        update();
+      }
+    });
+  });
+
+  document.querySelectorAll('#registro-pro-form .back-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (current > 0) {
+        current -= 1;
+        update();
+      }
+    });
+  });
+
+  update();
+});

--- a/templates/core/pro.html
+++ b/templates/core/pro.html
@@ -7,7 +7,14 @@
         <div class="d-flex justify-content-between align-items-center mb-3">
             {% include 'partials/_back-btn.html' %}
         </div>
-        <h1 class="text-center mb-5">Nuestros Planes</h1>
+        <h1 class="text-center mb-4">Nuestros Planes</h1>
+        <div class="text-center mb-4">
+            {% if user.is_authenticated %}
+            <a href="{% url 'registro_profesional' %}" class="btn btn-dark">Empezar ahora</a>
+            {% else %}
+            <button class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#loginModal">Empezar ahora</button>
+            {% endif %}
+        </div>
         <div class="row row-cols-1 row-cols-md-3 g-4">
             <div class="col">
                 <div class="card h-100 text-center shadow-sm">

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block content %}
+<div class="container py-5">
+    <h1 class="text-center mb-4">Registro Profesional</h1>
+    <form method="post" id="registro-pro-form" class="profile-form">
+        {% csrf_token %}
+        <div class="step" data-step="1">
+            {{ form.tipo.label_tag }}
+            {{ form.tipo }}
+            <button type="button" class="btn btn-dark mt-3 next-btn">Siguiente</button>
+        </div>
+        <div class="step" data-step="2" style="display:none;">
+            {{ form.plan.label_tag }}
+            {{ form.plan }}
+            <div class="mt-3">
+                <button type="button" class="btn btn-secondary back-btn me-2">Atrás</button>
+                <button type="button" class="btn btn-dark next-btn">Siguiente</button>
+            </div>
+        </div>
+        <div class="step" data-step="3" style="display:none;">
+            {{ form.nombre.label_tag }}
+            {{ form.nombre }}
+            {{ form.email.label_tag }}
+            {{ form.email }}
+            {{ form.telefono.label_tag }}
+            {{ form.telefono }}
+            {{ form.descripcion.label_tag }}
+            {{ form.descripcion }}
+            <div class="mt-3">
+                <button type="button" class="btn btn-secondary back-btn me-2">Atrás</button>
+                <button type="submit" class="btn btn-dark">Finalizar</button>
+            </div>
+        </div>
+    </form>
+</div>
+{% endblock %}
+{% block extra_js %}
+<script src="{% static 'js/registro-pro.js' %}"></script>
+{% endblock %}

--- a/templates/core/registro_pro_success.html
+++ b/templates/core/registro_pro_success.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-5 text-center">
+    <h1 class="mb-4">Registro completado</h1>
+    <p>Gracias por registrarte como profesional.</p>
+</div>
+{% endblock %}

--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -12,7 +12,7 @@
             <!-- Enlaces principales -->
             <div class="col-md-10 d-flex justify-content-md-end justify-content-center text-center gap-3 flex-md-row flex-column">
                 <a class="text-dark fw-bold text-decoration-none" href="{% url 'ayuda' %}">Ayuda</a>
-                <a class="text-dark fw-bold text-decoration-none" href="/planes">Planes</a>
+                <a class="text-dark fw-bold text-decoration-none" href="/pro">Pro</a>
                 <a class="text-dark fw-bold text-decoration-none" href="/blog">Blog</a>
                 <a class="text-dark fw-bold text-decoration-none d-flex justify-content-center " href="#">
                     <img src="{% static 'img/instagram-icon.svg' %}" alt="Instagram">


### PR DESCRIPTION
## Summary
- rename `/planes` route to `/pro`
- add forms for professional onboarding
- add multi-step registration views
- update footer link
- add "Empezar ahora" button on Pro page

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6870788170908321b06c55c634af258d