### PR TITLE
Remove plan cards from pro page

### DIFF
--- a/templates/core/pro.html
+++ b/templates/core/pro.html
@@ -15,50 +15,6 @@
             <button class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#loginModal">Empezar ahora</button>
             {% endif %}
         </div>
-        <div class="row row-cols-1 row-cols-md-3 g-4">
-            <div class="col">
-                <div class="card h-100 text-center shadow-sm">
-                    <div class="card-body d-flex flex-column justify-content-between">
-                        <div>
-                            <h3 class="card-title">Plan Gratuito</h3>
-                            <p class="card-text">Acceso básico al directorio y funciones esenciales.</p>
-                        </div>
-                        <div>
-                            <p class="display-6 fw-bold">€0</p>
-                            <a class="btn btn-outline-dark mt-2 disabled" href="#">Actual</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card h-100 text-center shadow-sm border-dark">
-                    <div class="card-body d-flex flex-column justify-content-between">
-                        <div>
-                            <h3 class="card-title">Plan Amateur</h3>
-                            <p class="card-text">Funciones ampliadas y visibilidad para tu club.</p>
-                        </div>
-                        <div>
-                            <p class="display-6 fw-bold">€9<span class="fs-6">/mes</span></p>
-                            <a class="btn btn-dark mt-2" href="#">Elegir</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card h-100 text-center shadow-sm">
-                    <div class="card-body d-flex flex-column justify-content-between">
-                        <div>
-                            <h3 class="card-title">Plan Pro</h3>
-                            <p class="card-text">Todas las ventajas para destacar y atraer más boxeadores.</p>
-                        </div>
-                        <div>
-                            <p class="display-6 fw-bold">€19<span class="fs-6">/mes</span></p>
-                            <a class="btn btn-dark mt-2" href="#">Elegir</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
     </div>
 </main>
 {% endblock %}


### PR DESCRIPTION
## Summary
- clean up Pro page to only show the registration link

## Testing
- `python manage.py test` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687081d9b43c83218a5de81921cdfd22