### PR TITLE
Add dynamic pro registration form

### DIFF
--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -23,20 +23,9 @@ class PlanForm(forms.Form):
         widget=forms.RadioSelect
     )
 
-class BaseInfoForm(forms.Form):
-    nombre = forms.CharField(label='Nombre', max_length=100)
-    email = forms.EmailField(label='Correo')
-    telefono = forms.CharField(label='Teléfono', required=False)
-    descripcion = forms.CharField(label='Descripción', widget=forms.Textarea, required=False)
-
-
 class RegistroProfesionalForm(forms.Form):
-    """Formulario unificado para el registro profesional multipaso."""
+    """Formulario multipaso para seleccionar tipo de usuario y plan."""
 
     tipo = TipoUsuarioForm.base_fields['tipo']
     plan = PlanForm.base_fields['plan']
-    nombre = BaseInfoForm.base_fields['nombre']
-    email = BaseInfoForm.base_fields['email']
-    telefono = BaseInfoForm.base_fields['telefono']
-    descripcion = BaseInfoForm.base_fields['descripcion']
 

--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -1,11 +1,7 @@
 # apps/core/views.py
 from django.shortcuts import render, redirect
-from ..forms import (
-    TipoUsuarioForm,
-    PlanForm,
-    BaseInfoForm,
-    RegistroProfesionalForm,
-)
+from ..forms import TipoUsuarioForm, PlanForm, RegistroProfesionalForm
+from apps.clubs.forms import ClubForm, EntrenadorForm
 
 
 def home(request):
@@ -23,23 +19,41 @@ def pro(request):
 
 
 def registro_profesional(request):
-    """Registro profesional mostrado como formulario multipaso mediante JS."""
+    """Registro profesional mostrado como formulario multipaso."""
     if not request.user.is_authenticated:
         return redirect('login')
 
     start_step = 1
-    if request.method == 'POST':
+    club_form = ClubForm(prefix="club")
+    coach_form = EntrenadorForm(prefix="coach")
+
+    if request.method == "POST":
         form = RegistroProfesionalForm(request.POST)
+        tipo = request.POST.get("tipo")
+
+        if tipo == "club":
+            club_form = ClubForm(request.POST, request.FILES, prefix="club")
+        elif tipo == "entrenador":
+            coach_form = EntrenadorForm(request.POST, request.FILES, prefix="coach")
+
         if form.is_valid():
-            return render(request, 'core/registro_pro_success.html')
-        start_step = request.POST.get('current_step', 1)
+            if tipo == "club" and club_form.is_valid():
+                return render(request, "core/registro_pro_success.html")
+            if tipo == "entrenador" and coach_form.is_valid():
+                return render(request, "core/registro_pro_success.html")
+        start_step = request.POST.get("current_step", 1)
     else:
         form = RegistroProfesionalForm()
 
     return render(
         request,
-        'core/registro_pro.html',
-        {'form': form, 'start_step': start_step},
+        "core/registro_pro.html",
+        {
+            "form": form,
+            "start_step": start_step,
+            "club_form": club_form,
+            "coach_form": coach_form,
+        },
     )
 
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2,4 +2,26 @@
   margin:10% 0 50px 0;
 }
 
+.plan-card {
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+  padding: 1rem;
+  cursor: pointer;
+  text-align: center;
+  position: relative;
+}
+
+.plan-card input[type="radio"] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.plan-card.active,
+.plan-card.featured {
+  border-color: #198754;
+  background-color: rgba(25, 135, 84, 0.1);
+}
+
 

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -2,6 +2,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const steps = ['step1', 'step2', 'step3'].map(id => document.getElementById(id));
   const currentInput = document.getElementById('current-step');
   let current = parseInt(currentInput.value, 10) || 1;
+  const clubFields = document.getElementById('club-fields');
+  const coachFields = document.getElementById('coach-fields');
+  const tipoRadios = document.querySelectorAll('input[name="tipo"]');
+  const planCards = document.querySelectorAll('.plan-card');
 
   function showStep(n) {
     steps.forEach((step, idx) => {
@@ -21,6 +25,33 @@ document.addEventListener('DOMContentLoaded', () => {
   if (next2) next2.addEventListener('click', () => showStep(3));
   if (prev2) prev2.addEventListener('click', () => showStep(1));
   if (prev3) prev3.addEventListener('click', () => showStep(2));
+
+  function toggleTipoFields() {
+    const checked = document.querySelector('input[name="tipo"]:checked');
+    if (!checked) return;
+    if (checked.value === 'club') {
+      clubFields && clubFields.classList.remove('d-none');
+      coachFields && coachFields.classList.add('d-none');
+    } else if (checked.value === 'entrenador') {
+      coachFields && coachFields.classList.remove('d-none');
+      clubFields && clubFields.classList.add('d-none');
+    } else {
+      clubFields && clubFields.classList.add('d-none');
+      coachFields && coachFields.classList.add('d-none');
+    }
+  }
+
+  tipoRadios.forEach(radio => radio.addEventListener('change', toggleTipoFields));
+
+  planCards.forEach(card => {
+    const input = card.querySelector('input');
+    card.addEventListener('click', () => {
+      input.checked = true;
+      planCards.forEach(c => c.classList.toggle('active', c === card));
+    });
+  });
+
+  toggleTipoFields();
 
   showStep(current);
 });

--- a/templates/core/_profile_fields.html
+++ b/templates/core/_profile_fields.html
@@ -1,0 +1,36 @@
+{% for field in form %}
+  {% if field.field.widget.input_type == 'file' %}
+  <div class="form-field">
+    <div class="avatar-dropzone mx-auto">
+      {{ field }}
+      <div class="avatar-preview">
+        <div class="avatar-dropzone-msg">
+          <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+          <span>Sube {{ field.label|lower }}</span>
+        </div>
+      </div>
+    </div>
+    <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+    {% if field.errors %}
+    <div class="invalid-feedback d-block">{{ field.errors.as_text|striptags }}</div>
+    {% endif %}
+  </div>
+  {% elif field.field.widget.input_type == 'checkbox' %}
+  <div class="form-field checkbox-field">
+    {{ field }}
+    <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+    {% if field.errors %}
+    <div class="invalid-feedback d-block">{{ field.errors.as_text|striptags }}</div>
+    {% endif %}
+  </div>
+  {% else %}
+  <div class="form-field">
+    {{ field }}
+    <button type="button" class="clear-btn">×</button>
+    <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+    {% if field.errors %}
+    <div class="invalid-feedback d-block">{{ field.errors.as_text|striptags }}</div>
+    {% endif %}
+  </div>
+  {% endif %}
+{% endfor %}

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -24,12 +24,16 @@
 
         <div id="step2" class="step d-none">
             <div class="mb-3">{{ form.plan.label }}</div>
+            <div class="row">
             {% for radio in form.plan %}
-            <div class="form-check">
-                {{ radio.tag }}
-                <label class="form-check-label" for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-            </div>
+                <div class="col-md-4 mb-3">
+                    <label class="plan-card {% if radio.choice_value == 'amateur' %}featured{% endif %}">
+                        {{ radio.tag }}
+                        <div class="h5 mb-0">{{ radio.choice_label }}</div>
+                    </label>
+                </div>
             {% endfor %}
+            </div>
             {% if form.plan.errors %}
             <div class="invalid-feedback d-block">{{ form.plan.errors.as_text|striptags }}</div>
             {% endif %}
@@ -38,18 +42,12 @@
         </div>
 
         <div id="step3" class="step d-none">
-            {% for field in form %}
-                {% if field.name != 'tipo' and field.name != 'plan' %}  
-                <div class="form-field">
-                    {{ field }}
-                    <button type="button" class="clear-btn">×</button>
-                    <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-                    {% if field.errors %}
-                    <div class="invalid-feedback d-block">{{ field.errors.as_text|striptags }}</div>
-                    {% endif %}
-                </div>
-                {% endif %}
-            {% endfor %}
+            <div id="club-fields" class="d-none">
+                {% include 'core/_profile_fields.html' with form=club_form %}
+            </div>
+            <div id="coach-fields" class="d-none">
+                {% include 'core/_profile_fields.html' with form=coach_form %}
+            </div>
             <button type="button" class="btn btn-outline-dark me-2" id="prev3">Anterior</button>
             <button type="submit" class="btn btn-dark">Finalizar</button>
         </div>


### PR DESCRIPTION
## Summary
- update multi-step pro registration to load club or coach fields
- show plan options as cards with Amateur highlighted
- toggle form sections via javascript
- style plan cards

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6870854e72608321a177e85d24018df5