### PR TITLE
Improve pro registration UX

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -25,3 +25,17 @@
 }
 
 
+.plan-card-price {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 1rem;
+}
+.plan-card ul {
+  margin-top: 1rem;
+  text-align: left;
+  padding-left: 0;
+  list-style: none;
+}
+.plan-card ul li {
+  margin-bottom: 0.5rem;
+}

--- a/static/css/registro_pro.css
+++ b/static/css/registro_pro.css
@@ -1,0 +1,32 @@
+.progress-steps {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+  list-style: none;
+  padding: 0;
+}
+.progress-steps .step-item {
+  flex: 1;
+  text-align: center;
+  font-weight: 600;
+  color: #6c757d;
+}
+.progress-steps .step-item.active {
+  color: #000;
+}
+.progress-steps .step-item::before {
+  content: attr(data-step);
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  margin-bottom: .5rem;
+  transition: background-color .3s, color .3s;
+}
+.progress-steps .step-item.active::before {
+  background-color: currentColor;
+  color: #fff;
+}

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const steps = ['step1', 'step2', 'step3'].map(id => document.getElementById(id));
+  const progress = ['step-label-1', 'step-label-2', 'step-label-3'].map(id => document.getElementById(id));
   const currentInput = document.getElementById('current-step');
   let current = parseInt(currentInput.value, 10) || 1;
   const clubFields = document.getElementById('club-fields');
@@ -11,6 +12,10 @@ document.addEventListener('DOMContentLoaded', () => {
     steps.forEach((step, idx) => {
       if (!step) return;
       step.classList.toggle('d-none', idx !== n - 1);
+    });
+    progress.forEach((item, idx) => {
+      if (!item) return;
+      item.classList.toggle('active', idx === n - 1);
     });
     current = n;
     currentInput.value = current;

--- a/templates/core/pro.html
+++ b/templates/core/pro.html
@@ -7,8 +7,46 @@
         <div class="d-flex justify-content-between align-items-center mb-3">
             {% include 'partials/_back-btn.html' %}
         </div>
-        <h1 class="text-center mb-4">Nuestros Planes</h1>
-        <div class="text-center mb-4">
+        <h1 class="text-center mb-3">Nuestros Planes</h1>
+        <p class="text-center text-muted mb-5">Elige la opción que mejor se adapte a tus necesidades y comienza a destacar en nuestro directorio.</p>
+
+        <div class="row row-cols-1 row-cols-md-3 g-4 mb-5">
+            <div class="col">
+                <div class="plan-card h-100">
+                    <h3 class="mb-2">Plan Gratuito</h3>
+                    <ul>
+                        <li>Presencia básica en el directorio</li>
+                        <li>Publicación de eventos</li>
+                        <li>Acceso a valoraciones</li>
+                    </ul>
+                    <div class="plan-card-price">0€ / mes</div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="plan-card featured h-100">
+                    <h3 class="mb-2">Plan Amateur</h3>
+                    <ul>
+                        <li>Todos los beneficios del plan gratuito</li>
+                        <li>Galería de fotos y vídeos</li>
+                        <li>Estadísticas básicas</li>
+                    </ul>
+                    <div class="plan-card-price">9€ / mes</div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="plan-card h-100">
+                    <h3 class="mb-2">Plan Pro</h3>
+                    <ul>
+                        <li>Promoción destacada en búsquedas</li>
+                        <li>Soporte prioritario</li>
+                        <li>Herramientas de marketing avanzadas</li>
+                    </ul>
+                    <div class="plan-card-price">19€ / mes</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="text-center">
             {% if user.is_authenticated %}
             <a href="{% url 'registro_profesional' %}" class="btn btn-dark">Empezar ahora</a>
             {% else %}

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -2,14 +2,24 @@
 {% load static %}
 {% block content %}
 <div class="container py-5">
-    <h1 class="text-center mb-4">Registro Profesional</h1>
-    <form method="post" class="profile-form">
-        {% csrf_token %}
-        {{ form.non_field_errors }}
-        <input type="hidden" name="current_step" id="current-step" value="{{ start_step }}">
+    <div class="mx-auto" style="max-width:600px;">
+        <h1 class="text-center mb-2">Registro Profesional</h1>
+        <p class="text-center text-muted mb-4">Completa los pasos y crea tu perfil profesional.</p>
+
+        <ul class="progress-steps mb-4">
+            <li class="step-item active" data-step="1" id="step-label-1">Perfil</li>
+            <li class="step-item" data-step="2" id="step-label-2">Plan</li>
+            <li class="step-item" data-step="3" id="step-label-3">Datos</li>
+        </ul>
+
+        <form method="post" class="profile-form">
+            {% csrf_token %}
+            {{ form.non_field_errors }}
+            <input type="hidden" name="current_step" id="current-step" value="{{ start_step }}">
 
         <div id="step1" class="step">
             <div class="mb-3">{{ form.tipo.label }}</div>
+            <p class="text-muted">Indícanos qué tipo de profesional eres.</p>
             {% for radio in form.tipo %}
             <div class="form-check">
                 {{ radio.tag }}
@@ -24,6 +34,7 @@
 
         <div id="step2" class="step d-none">
             <div class="mb-3">{{ form.plan.label }}</div>
+            <p class="text-muted">Selecciona el plan que prefieras.</p>
             <div class="row">
             {% for radio in form.plan %}
                 <div class="col-md-4 mb-3">
@@ -42,6 +53,7 @@
         </div>
 
         <div id="step3" class="step d-none">
+            <p class="text-muted">Rellena la información de tu perfil.</p>
             <div id="club-fields" class="d-none">
                 {% include 'core/_profile_fields.html' with form=club_form %}
             </div>
@@ -51,7 +63,8 @@
             <button type="button" class="btn btn-outline-dark me-2" id="prev3">Anterior</button>
             <button type="submit" class="btn btn-dark">Finalizar</button>
         </div>
-    </form>
+        </form>
+    </div>
 </div>
 {% endblock %}
 {% block extra_js %}


### PR DESCRIPTION
## Summary
- add plan descriptions to professional subscription page
- enhance professional registration form with progress steps and helper text
- style plan cards and progress indicators
- highlight active step in registration script

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68708c883df8832182ca8816b5300fc2