### PR TITLE
Fix login modal form submission

### DIFF
--- a/templates/partials/_login-form.html
+++ b/templates/partials/_login-form.html
@@ -1,6 +1,7 @@
  {% load socialaccount %}
  
-            <form method="post" class="profile-form">
+            <form method="post" action="{% url 'login' %}" class="profile-form">
+                <input type="hidden" name="next" value="{{ request.get_full_path }}">
                 {% csrf_token %}
 
                 <div class="form-field">

--- a/templates/partials/_login_modal.html
+++ b/templates/partials/_login_modal.html
@@ -6,7 +6,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-            {% include 'partials/_login-form.html' %}
+            {% include 'partials/_login-form.html' with form=login_form %}
 
       </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure login modal uses the shared login form instance
- POST login modal to the proper login URL and preserve the next page

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68711e69d5a08321821a0e72830c99e2