### PR TITLE
Improve professional registration UX

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -18,10 +18,13 @@
   cursor: pointer;
 }
 
-.plan-card.active,
-.plan-card.featured {
+.plan-card.active {
   border-color: #198754;
   background-color: rgba(25, 135, 84, 0.1);
+}
+
+.plan-card.featured {
+  transform: scale(1.05);
 }
 
 
@@ -38,4 +41,25 @@
 }
 .plan-card ul li {
   margin-bottom: 0.5rem;
+}
+
+.tipo-card {
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+  padding: 1rem;
+  cursor: pointer;
+  text-align: center;
+  position: relative;
+}
+
+.tipo-card input[type="radio"] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.tipo-card.active {
+  border-color: #198754;
+  background-color: rgba(25, 135, 84, 0.1);
 }

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const clubFields = document.getElementById('club-fields');
   const coachFields = document.getElementById('coach-fields');
   const tipoRadios = document.querySelectorAll('input[name="tipo"]');
+  const tipoCards = document.querySelectorAll('.tipo-card');
   const planCards = document.querySelectorAll('.plan-card');
 
   function showStep(n) {
@@ -48,8 +49,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
   tipoRadios.forEach(radio => radio.addEventListener('change', toggleTipoFields));
 
+  tipoCards.forEach(card => {
+    const input = card.querySelector('input');
+    if (input.checked) {
+      card.classList.add('active');
+    }
+    card.addEventListener('click', () => {
+      input.checked = true;
+      tipoCards.forEach(c => c.classList.toggle('active', c === card));
+      toggleTipoFields();
+    });
+  });
+
   planCards.forEach(card => {
     const input = card.querySelector('input');
+    if (input.checked) {
+      card.classList.add('active');
+    }
     card.addEventListener('click', () => {
       input.checked = true;
       planCards.forEach(c => c.classList.toggle('active', c === card));

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -2,7 +2,10 @@
 {% load static %}
 {% block content %}
 <div class="container-fluid px-3 my-5 col-10">
-    <div class="mx-auto"  >
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        {% include 'partials/_back-btn.html' %}
+    </div>
+    <div class="mx-auto">
         <h1 class="text-center mb-2">Registro Profesional</h1>
         <p class="text-center text-muted mb-4">Completa los pasos y crea tu perfil profesional.</p>
 
@@ -20,12 +23,23 @@
         <div id="step1" class="step">
             <div class="mb-3">{{ form.tipo.label }}</div>
             <p class="text-muted">Indícanos qué tipo de profesional eres.</p>
+            <div class="d-flex justify-content-center flex-wrap gap-3">
             {% for radio in form.tipo %}
-            <div class="form-check">
-                {{ radio.tag }}
-                <label class="form-check-label" for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-            </div>
+                <label class="tipo-card">
+                    {{ radio.tag }}
+                    {% if radio.choice_value == 'entrenador' %}
+                        <img src="{% static 'img/iconos/coach.svg' %}" width="48" height="48" class="mb-2" alt="">
+                    {% elif radio.choice_value == 'club' %}
+                        <img src="{% static 'img/iconos/ring.svg' %}" width="48" height="48" class="mb-2" alt="">
+                    {% elif radio.choice_value == 'promotor' %}
+                        <img src="{% static 'img/iconos/guantes.svg' %}" width="48" height="48" class="mb-2" alt="">
+                    {% else %}
+                        <img src="{% static 'img/iconos/bike.svg' %}" width="48" height="48" class="mb-2" alt="">
+                    {% endif %}
+                    <div class="fw-medium">{{ radio.choice_label }}</div>
+                </label>
             {% endfor %}
+            </div>
             {% if form.tipo.errors %}
             <div class="invalid-feedback d-block">{{ form.tipo.errors.as_text|striptags }}</div>
             {% endif %}
@@ -38,40 +52,37 @@
              <h1 class="text-center mb-3">Nuestros Planes</h1>
         <p class="text-center text-muted mb-5">Elige la opción que mejor se adapte a tus necesidades y comienza a destacar en nuestro directorio.</p>
 
-        <div class="row row-cols-1 row-cols-md-3 g-4 mb-5">
-            <div class="col">
-                <div class="plan-card h-100">
-                    <h3 class="mb-2">Plan Gratuito</h3>
-                    <ul>
-                        <li>Presencia básica en el directorio</li>
-                        <li>Publicación de eventos</li>
-                        <li>Acceso a valoraciones</li>
-                    </ul>
-                    <div class="plan-card-price">0€ / mes</div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="plan-card featured h-100">
-                    <h3 class="mb-2">Plan Amateur</h3>
-                    <ul>
-                        <li>Todos los beneficios del plan gratuito</li>
-                        <li>Galería de fotos y vídeos</li>
-                        <li>Estadísticas básicas</li>
-                    </ul>
-                    <div class="plan-card-price">9€ / mes</div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="plan-card h-100">
-                    <h3 class="mb-2">Plan Pro</h3>
-                    <ul>
-                        <li>Promoción destacada en búsquedas</li>
-                        <li>Soporte prioritario</li>
-                        <li>Herramientas de marketing avanzadas</li>
-                    </ul>
-                    <div class="plan-card-price">19€ / mes</div>
-                </div>
-            </div>
+        <div class="d-flex justify-content-center flex-wrap gap-3 mb-5">
+            <label class="plan-card h-100">
+                <input type="radio" name="plan" value="gratis">
+                <h3 class="mb-2">Plan Gratuito</h3>
+                <ul>
+                    <li>Presencia básica en el directorio</li>
+                    <li>Publicación de eventos</li>
+                    <li>Acceso a valoraciones</li>
+                </ul>
+                <div class="plan-card-price">0€ / mes</div>
+            </label>
+            <label class="plan-card featured h-100">
+                <input type="radio" name="plan" value="amateur">
+                <h3 class="mb-2">Plan Amateur</h3>
+                <ul>
+                    <li>Todos los beneficios del plan gratuito</li>
+                    <li>Galería de fotos y vídeos</li>
+                    <li>Estadísticas básicas</li>
+                </ul>
+                <div class="plan-card-price">9€ / mes</div>
+            </label>
+            <label class="plan-card h-100">
+                <input type="radio" name="plan" value="pro">
+                <h3 class="mb-2">Plan Pro</h3>
+                <ul>
+                    <li>Promoción destacada en búsquedas</li>
+                    <li>Soporte prioritario</li>
+                    <li>Herramientas de marketing avanzadas</li>
+                </ul>
+                <div class="plan-card-price">19€ / mes</div>
+            </label>
         </div>
             {% if form.plan.errors %}
             <div class="invalid-feedback d-block">{{ form.plan.errors.as_text|striptags }}</div>


### PR DESCRIPTION
## Summary
- add back button to professional registration page
- restyle step 1 as selectable cards with icons
- restyle step 2 plan selector and fix selection highlight
- update JS to handle new card selections
- update CSS for new card components

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687121755a588321a35216e9c33d7310