### PR TITLE
Update gallery UI

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -193,8 +193,25 @@
   display: none;
 }
 
-.gallery-grid.select-mode .photo-checkbox {
+.gallery-item:hover .photo-checkbox,
+.gallery-item .photo-checkbox:checked {
   display: block;
+}
+
+.gallery-hover-actions {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  display: none;
+  gap: 0.25rem;
+}
+
+.gallery-item:hover .gallery-hover-actions {
+  display: flex;
+}
+
+.drag-handle {
+  cursor: move;
 }
 
 .gallery-item.main::after {

--- a/static/js/gallery-manager.js
+++ b/static/js/gallery-manager.js
@@ -8,40 +8,41 @@ document.addEventListener('DOMContentLoaded', () => {
       if (input.files.length) {
         text.textContent = `${input.files.length} archivo(s) seleccionado(s)`;
       } else {
-        text.textContent = 'Arrastra imágenes aquí o haz clic para seleccionar';
+        text.textContent = 'Haz clic para seleccionar imágenes';
       }
     };
     zone.addEventListener('click', () => input.click());
-    zone.addEventListener('dragover', e => {
-      e.preventDefault();
-      zone.classList.add('dragover');
-    });
-    zone.addEventListener('dragleave', () => zone.classList.remove('dragover'));
-    zone.addEventListener('drop', e => {
-      e.preventDefault();
-      zone.classList.remove('dragover');
-      input.files = e.dataTransfer.files;
-      showCount();
-    });
     input.addEventListener('change', showCount);
   });
 
-  const selectBtn = document.getElementById('toggle-select');
-  const selectAllBtn = document.getElementById('select-all');
   const gallery = document.getElementById('gallery-grid');
   const deleteForm = document.getElementById('bulk-delete-form');
   const deleteIds = document.getElementById('delete-ids');
 
-  selectBtn && selectBtn.addEventListener('click', () => {
-    gallery.classList.toggle('select-mode');
-    if (selectAllBtn) selectAllBtn.classList.toggle('d-none');
-  });
+  let dragged = null;
+  if (gallery) {
+    gallery.addEventListener('dragstart', e => {
+      const item = e.target.closest('.gallery-item');
+      if (item) {
+        dragged = item;
+      }
+    });
 
-  selectAllBtn && selectAllBtn.addEventListener('click', () => {
-    const boxes = gallery.querySelectorAll('.photo-checkbox');
-    const allChecked = Array.from(boxes).every(cb => cb.checked);
-    boxes.forEach(cb => { cb.checked = !allChecked; });
-  });
+    gallery.addEventListener('dragover', e => {
+      e.preventDefault();
+      const target = e.target.closest('.gallery-item');
+      if (dragged && target && target !== dragged) {
+        const rect = target.getBoundingClientRect();
+        const next = (e.clientY - rect.top) / (rect.bottom - rect.top) > 0.5;
+        gallery.insertBefore(dragged, next ? target.nextSibling : target);
+      }
+    });
+
+    gallery.addEventListener('drop', e => {
+      e.preventDefault();
+      dragged = null;
+    });
+  }
 
   deleteForm && deleteForm.addEventListener('submit', e => {
     const ids = [...gallery.querySelectorAll('.photo-checkbox:checked')].map(cb => cb.value);

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -213,26 +213,12 @@
           />
           <div class="photo-dropzone-msg">
             <i class="bi bi-cloud-upload mb-2 fs-2"></i>
-            <span>Arrastra imágenes aquí o haz clic para seleccionar</span>
+            <span>Haz clic para seleccionar imágenes</span>
           </div>
         </div>
         <button type="submit" class="btn btn-dark btn-sm">Subir</button>
       </form>
       <div class="d-flex justify-content-end gap-2 mb-2">
-        <button
-          id="toggle-select"
-          type="button"
-          class="btn btn-sm btn-outline-secondary"
-        >
-          Seleccionar
-        </button>
-        <button
-          id="select-all"
-          type="button"
-          class="btn btn-sm btn-outline-secondary d-none"
-        >
-          Seleccionar todo
-        </button>
         <form
           id="bulk-delete-form"
           method="post"
@@ -247,6 +233,8 @@
         {% for photo in club.photos.all %}
         <div
           class="gallery-item position-relative{% if photo.is_main %} main{% endif %}"
+          draggable="true"
+          data-id="{{ photo.id }}"
         >
           <img
             src="{{ photo.image.url }}"
@@ -258,16 +246,33 @@
             class="photo-checkbox"
             value="{{ photo.id }}"
           />
-          <form
-            method="post"
-            action="{% url 'clubphoto_set_main' photo.id %}"
-            class="set-main-form"
-          >
-            {% csrf_token %}
-            <button type="submit" class="btn btn-light btn-sm">
-              Principal
-            </button>
-          </form>
+          <div class="gallery-hover-actions">
+            <span class="drag-handle bi bi-arrows-move"></span>
+            <div class="dropdown">
+              <button
+                class="btn btn-light btn-sm dropdown-toggle"
+                type="button"
+                data-bs-toggle="dropdown"
+                aria-expanded="false"
+              >
+                Opciones
+              </button>
+              <ul class="dropdown-menu">
+                <li>
+                  <form method="post" action="{% url 'clubphoto_set_main' photo.id %}">
+                    {% csrf_token %}
+                    <button type="submit" class="dropdown-item">Destacar</button>
+                  </form>
+                </li>
+                <li>
+                  <form method="post" action="{% url 'clubphoto_delete' photo.id %}">
+                    {% csrf_token %}
+                    <button type="submit" class="dropdown-item text-danger">Eliminar</button>
+                  </form>
+                </li>
+              </ul>
+            </div>
+          </div>
         </div>
         {% empty %}
         <p>No hay fotos.</p>


### PR DESCRIPTION
## Summary
- tweak gallery dropzone text
- remove bulk select buttons from dashboard
- show checkbox and options on hover
- enable drag-and-drop reordering
- disable drag/drop upload handling

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6872ee3b264c832189c1da5f77664434