### PR TITLE
Add button-based photo upload

### DIFF
--- a/static/js/gallery-manager.js
+++ b/static/js/gallery-manager.js
@@ -15,6 +15,19 @@ document.addEventListener('DOMContentLoaded', () => {
     input.addEventListener('change', showCount);
   });
 
+  const uploadForm = document.getElementById('upload-form');
+  const uploadInput = document.getElementById('id_gallery_image');
+  const uploadBtn = document.getElementById('add-photos-btn');
+
+  if (uploadForm && uploadInput && uploadBtn) {
+    uploadBtn.addEventListener('click', () => uploadInput.click());
+    uploadInput.addEventListener('change', () => {
+      if (uploadInput.files.length) {
+        uploadForm.submit();
+      }
+    });
+  }
+
   const gallery = document.getElementById('gallery-grid');
   const deleteForm = document.getElementById('bulk-delete-form');
   const deleteIds = document.getElementById('delete-ids');

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -208,9 +208,15 @@
           name="image"
           id="id_gallery_image"
           multiple
-          class="form-control mb-2"
+          class="d-none"
         />
-        <button type="submit" class="btn btn-dark btn-sm">Añadir fotos</button>
+        <button
+          type="button"
+          id="add-photos-btn"
+          class="btn btn-dark btn-sm"
+        >
+          Añadir fotos
+        </button>
       </form>
       <div class="d-flex justify-content-end gap-2 mb-2">
         <button type="button" id="select-all" class="btn btn-sm btn-secondary">


### PR DESCRIPTION
## Summary
- hide gallery file input on the dashboard
- trigger file chooser and submit when clicking "Añadir fotos"

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6872fb0cd7208321ab6efd2658be54c6