### PR TITLE
Add button-based photo upload

### DIFF
--- a/static/js/gallery-manager.js
+++ b/static/js/gallery-manager.js
@@ -15,11 +15,39 @@ document.addEventListener('DOMContentLoaded', () => {
     input.addEventListener('change', showCount);
   });
 
+  const uploadForm = document.getElementById('upload-form');
+  const uploadInput = document.getElementById('id_gallery_image');
+  const uploadBtn = document.getElementById('add-photos-btn');
+
+  if (uploadForm && uploadInput && uploadBtn) {
+    uploadBtn.addEventListener('click', () => uploadInput.click());
+    uploadInput.addEventListener('change', () => {
+      if (uploadInput.files.length) {
+        uploadForm.submit();
+      }
+    });
+  }
+
   const gallery = document.getElementById('gallery-grid');
   const deleteForm = document.getElementById('bulk-delete-form');
   const deleteIds = document.getElementById('delete-ids');
+  const deleteBtn = document.getElementById('bulk-delete-btn');
   const selectAllBtn = document.getElementById('select-all');
   const deselectAllBtn = document.getElementById('deselect-all');
+
+  const updateActions = () => {
+    if (!gallery) return;
+    const any = gallery.querySelectorAll('.photo-checkbox:checked').length > 0;
+    if (any) {
+      deselectAllBtn && deselectAllBtn.classList.replace('text-secondary', 'text-dark');
+      deleteBtn && deleteBtn.classList.replace('text-secondary', 'text-dark');
+      deleteBtn && (deleteBtn.disabled = false);
+    } else {
+      deselectAllBtn && deselectAllBtn.classList.replace('text-dark', 'text-secondary');
+      deleteBtn && deleteBtn.classList.replace('text-dark', 'text-secondary');
+      deleteBtn && (deleteBtn.disabled = true);
+    }
+  };
 
   let dragged = null;
   if (gallery) {
@@ -52,6 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
       .forEach(cb => {
         cb.checked = true;
       });
+    updateActions();
   });
 
   deselectAllBtn && deselectAllBtn.addEventListener('click', () => {
@@ -60,6 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
       .forEach(cb => {
         cb.checked = false;
       });
+    updateActions();
   });
 
   deleteForm && deleteForm.addEventListener('submit', e => {
@@ -70,4 +100,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     deleteIds.value = ids.join(',');
   });
+
+  gallery && gallery.querySelectorAll('.photo-checkbox').forEach(cb => {
+    cb.addEventListener('change', updateActions);
+  });
+
+  updateActions();
 });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -195,43 +195,63 @@
       </form>
     </div>
     <div id="tab-gallery" class="profile-section">
-      <form
-        id="upload-form"
-        method="post"
-        enctype="multipart/form-data"
-        action="{% url 'clubphoto_upload' club.slug %}"
-        class="mb-3 text-end"
-      >
-        {% csrf_token %}
-        <input
-          type="file"
-          name="image"
-          id="id_gallery_image"
-          multiple
-          class="form-control mb-2"
-        />
-        <button type="submit" class="btn btn-dark btn-sm">Añadir fotos</button>
-      </form>
-      <div class="d-flex justify-content-end gap-2 mb-2">
-        <button type="button" id="select-all" class="btn btn-sm btn-secondary">
-          Seleccionar todas
-        </button>
-        <button
-          type="button"
-          id="deselect-all"
-          class="btn btn-sm btn-secondary"
-        >
-          Desmarcar todas
-        </button>
+      <div class="d-flex justify-content-between align-items-center mb-2">
         <form
-          id="bulk-delete-form"
+          id="upload-form"
           method="post"
-          action="{% url 'clubphoto_bulk_delete' club.slug %}"
+          enctype="multipart/form-data"
+          action="{% url 'clubphoto_upload' club.slug %}"
+          class="m-0"
         >
           {% csrf_token %}
-          <input type="hidden" name="ids" id="delete-ids" />
-          <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+          <input
+            type="file"
+            name="image"
+            id="id_gallery_image"
+            multiple
+            class="d-none"
+          />
+          <button
+            type="button"
+            id="add-photos-btn"
+            class="btn btn-dark btn-sm"
+          >
+            Añadir fotos
+          </button>
         </form>
+        <div class="d-flex gap-3">
+          <button
+            type="button"
+            id="select-all"
+            class="btn btn-link p-0 fw-medium text-dark"
+          >
+            Seleccionar todas
+          </button>
+          <button
+            type="button"
+            id="deselect-all"
+            class="btn btn-link p-0 fw-medium text-secondary"
+          >
+            Desmarcar todas
+          </button>
+          <form
+            id="bulk-delete-form"
+            method="post"
+            action="{% url 'clubphoto_bulk_delete' club.slug %}"
+            class="m-0"
+          >
+            {% csrf_token %}
+            <input type="hidden" name="ids" id="delete-ids" />
+            <button
+              type="submit"
+              id="bulk-delete-btn"
+              class="btn btn-link p-0 fw-medium text-secondary"
+              disabled
+            >
+              Eliminar
+            </button>
+          </form>
+        </div>
       </div>
       <div id="gallery-grid" class="gallery-grid">
         {% for photo in club.photos.all %}


### PR DESCRIPTION
## Summary
- hide gallery file input on the dashboard
- trigger file chooser and submit when clicking "Añadir fotos"
- move add photo button left and convert action buttons to text links
- dynamically enable/disable bulk actions

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6872fb0cd7208321ab6efd2658be54c6