### PR TITLE
Pin featured photo first

### DIFF
--- a/apps/clubs/models/club.py
+++ b/apps/clubs/models/club.py
@@ -79,5 +79,8 @@ class ClubPhoto(models.Model):
         if self.image and hasattr(self.image, 'path'):
             resize_image(self.image.path)
 
+    class Meta:
+        ordering = ['-is_main', 'uploaded_at']
+
  
 

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -240,7 +240,7 @@
 }
 
 .gallery-item.main::after {
-  content: '★';
+  content: '\1F4CC';
   position: absolute;
   bottom: 5px;
   right: 5px;


### PR DESCRIPTION
## Summary
- order club photos so the featured image comes first
- show a push-pin icon on the highlighted photo

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68730e4f435483219914726e596505d8