### PR TITLE
Pin featured photo first

### DIFF
--- a/apps/clubs/models/club.py
+++ b/apps/clubs/models/club.py
@@ -79,5 +79,8 @@ class ClubPhoto(models.Model):
         if self.image and hasattr(self.image, 'path'):
             resize_image(self.image.path)
 
+    class Meta:
+        ordering = ['-is_main', 'uploaded_at']
+
  
 

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -239,12 +239,11 @@
   display: block;
 }
 
-.gallery-item.main::after {
-  content: '★';
+.gallery-item .main-pin {
   position: absolute;
   bottom: 5px;
   right: 5px;
-  color: #ffc107;
+  color: #fff;
   font-size: 1.2rem;
 }
 

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -299,6 +299,9 @@
               </ul>
             </div>
           </div>
+          {% if photo.is_main %}
+          <span class="bi bi-pin-angle-fill main-pin"></span>
+          {% endif %}
         </div>
         {% empty %}
         <p>No hay fotos.</p>


### PR DESCRIPTION
## Summary
- order club photos so the featured image comes first
- show a push-pin icon on the highlighted photo
- use white Bootstrap pin icon instead of emoji

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68730e4f435483219914726e596505d8