### PR TITLE
Apply dark hover effect on gallery images

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -187,6 +187,9 @@
   height: 100%;
   object-fit: cover;
 }
+.gallery-item:hover img {
+  filter: brightness(0.6);
+}
 
 .gallery-item .photo-checkbox {
   position: absolute;


### PR DESCRIPTION
## Summary
- add CSS rule to darken gallery images on hover

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not install dependencies)*
- `python manage.py test apps.users.tests` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68731ab3e3f48321bff5310ccd3be857