### PR TITLE
Implement gallery hover and selection styles

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -192,11 +192,13 @@
   position: absolute;
   top: 5px;
   left: 5px;
+  z-index: 3;
   display: none;
 }
 
 .gallery-item:hover .photo-checkbox,
-.gallery-item .photo-checkbox:checked {
+.gallery-item .photo-checkbox:checked,
+.gallery-grid.selection-mode .photo-checkbox {
   display: block;
 }
 
@@ -206,10 +208,31 @@
   display: none;
   align-items: center;
   justify-content: center;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.gallery-hover-actions > * {
+  pointer-events: auto;
 }
 
 .gallery-item:hover .gallery-hover-actions {
   display: flex;
+}
+
+/* Darken image on hover */
+.gallery-item:hover img {
+  filter: brightness(0.7);
+}
+
+/* Darken image when selected */
+.gallery-item.selected img {
+  filter: brightness(0.7);
+}
+
+/* Darken all images when any is selected */
+.gallery-grid.selection-mode .gallery-item img {
+  filter: brightness(0.7);
 }
 
 .gallery-hover-actions .dropdown {

--- a/static/js/gallery-manager.js
+++ b/static/js/gallery-manager.js
@@ -36,8 +36,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const deleteBtn = deleteForm && deleteForm.querySelector('button[type="submit"]');
 
   const updateActionStyles = () => {
-    const hasSelected =
-      gallery && gallery.querySelectorAll('.photo-checkbox:checked').length > 0;
+    const checked = gallery
+      ? gallery.querySelectorAll('.photo-checkbox:checked')
+      : [];
+    const hasSelected = checked.length > 0;
     if (deselectAllBtn) {
       deselectAllBtn.classList.toggle('text-secondary', !hasSelected);
       deselectAllBtn.classList.toggle('text-black', hasSelected);
@@ -45,6 +47,13 @@ document.addEventListener('DOMContentLoaded', () => {
     if (deleteBtn) {
       deleteBtn.classList.toggle('text-secondary', !hasSelected);
       deleteBtn.classList.toggle('text-danger', hasSelected);
+    }
+    if (gallery) {
+      gallery.classList.toggle('selection-mode', hasSelected);
+      gallery.querySelectorAll('.gallery-item').forEach(item => {
+        const cb = item.querySelector('.photo-checkbox');
+        item.classList.toggle('selected', cb && cb.checked);
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- allow clicking hover checkbox by layering components
- darken gallery thumbnails on hover and when selected
- dim entire gallery grid when any item is checked
- show all checkboxes when gallery enters selection mode

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6873202bf91083219acbbe6efd5a8252