### PR TITLE
Add custom "otro" schedule state

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -175,11 +175,12 @@ class ClubPhotoForm(forms.ModelForm):
 class HorarioForm(forms.ModelForm):
     class Meta:
         model = models.Horario
-        fields = ['dia', 'hora_inicio', 'hora_fin', 'estado']
+        fields = ['dia', 'hora_inicio', 'hora_fin', 'estado', 'estado_otro']
         widgets = {
             'hora_inicio': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
             'hora_fin': forms.TimeInput(format='%H:%M', attrs={'type': 'time'}),
             'estado': forms.Select(attrs={'class': 'form-select form-select-sm'}),
+            'estado_otro': forms.TextInput(attrs={'class': 'form-control form-control-sm', 'maxlength': '30'}),
         }
 
 

--- a/apps/clubs/migrations/0021_horario_otro.py
+++ b/apps/clubs/migrations/0021_horario_otro.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0020_clubphoto_is_main'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='horario',
+            name='estado',
+            field=models.CharField(choices=[('abierto', 'Abierto'), ('cerrado', 'Cerrado'), ('otro', 'Otro')], default='abierto', max_length=10),
+        ),
+        migrations.AddField(
+            model_name='horario',
+            name='estado_otro',
+            field=models.CharField(blank=True, max_length=30),
+        ),
+    ]

--- a/apps/clubs/models/horario.py
+++ b/apps/clubs/models/horario.py
@@ -16,6 +16,7 @@ class Horario(models.Model):
     class Estado(models.TextChoices):
         ABIERTO = 'abierto', _('Abierto')
         CERRADO = 'cerrado', _('Cerrado')
+        OTRO = 'otro', _('Otro')
 
     club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='horarios')
     dia = models.CharField(max_length=10, choices=DiasSemana.choices)
@@ -26,6 +27,7 @@ class Horario(models.Model):
         choices=Estado.choices,
         default=Estado.ABIERTO,
     )
+    estado_otro = models.CharField(max_length=30, blank=True)
 
     class Meta:
         ordering = ['dia', 'hora_inicio']

--- a/static/js/schedule-form.js
+++ b/static/js/schedule-form.js
@@ -4,15 +4,22 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!row) return;
     const startCol = row.querySelector('input[name="hora_inicio"]').closest('.col');
     const endCol = row.querySelector('input[name="hora_fin"]').closest('.col');
+    const customCol = row.querySelector('input[name="estado_otro"]').closest('.col');
     function toggleFields() {
       const abierto = select.value === 'abierto';
+      const otro = select.value === 'otro';
       startCol.style.display = abierto ? '' : 'none';
       endCol.style.display = abierto ? '' : 'none';
+      if (customCol) customCol.style.display = otro ? '' : 'none';
       if (!abierto) {
         const startInput = startCol.querySelector('input[name="hora_inicio"]');
         const endInput = endCol.querySelector('input[name="hora_fin"]');
         if (!startInput.value) startInput.value = '00:00';
         if (!endInput.value) endInput.value = '00:00';
+      }
+      if (!otro && customCol) {
+        const customInput = customCol.querySelector('input[name="estado_otro"]');
+        if (customInput) customInput.value = '';
       }
     }
     select.addEventListener('change', toggleFields);

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -314,8 +314,10 @@
                                                                      data-end="{{ h.hora_fin|time:'H:i' }}">
                                                                     {{ h.hora_inicio|time:"H:i" }} - {{ h.hora_fin|time:"H:i" }}
                                                                 </div>
-                                                            {% else %}
+                                                            {% elif h.estado == 'cerrado' %}
                                                                 <div class="border-bottom py-1 small text-danger">Cerrado</div>
+                                                            {% else %}
+                                                                <div class="border-bottom py-1 small text-muted">{{ h.estado_otro }}</div>
                                                             {% endif %}
                                                         {% endif %}
                                                     {% empty %}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -463,7 +463,11 @@
                           >
                             Cerrado
                           </option>
+                          <option value="otro" {% if bloque.estado == 'otro' %}selected{% endif %}>Otro</option>
                         </select>
+                      </div>
+                      <div class="col" style="display: none">
+                        <input type="text" name="estado_otro" value="{{ bloque.estado_otro }}" class="form-control form-control-sm" maxlength="30" placeholder="Especificar" />
                       </div>
                       <div class="col-auto">
                         <button type="submit" class="btn btn-sm btn-dark">
@@ -519,7 +523,11 @@
                           >
                             <option value="abierto">Abierto</option>
                             <option value="cerrado">Cerrado</option>
+                            <option value="otro">Otro</option>
                           </select>
+                        </div>
+                        <div class="col" style="display: none">
+                          <input type="text" name="estado_otro" class="form-control form-control-sm" maxlength="30" placeholder="Especificar" />
                         </div>
                         <div class="col-auto">
                           <button type="submit" class="btn btn-sm btn-dark">


### PR DESCRIPTION
## Summary
- extend `Horario` model with "otro" status
- allow entering custom text for schedule state
- display and edit custom state in dashboard and profile
- update schedule JS to show/hide custom input
- add migration for new model changes

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6873257b2a6c8321bba82ec68ff293d1