### PR TITLE
Add support for custom schedule text

### DIFF
--- a/static/js/schedule-form.js
+++ b/static/js/schedule-form.js
@@ -25,4 +25,14 @@ document.addEventListener('DOMContentLoaded', () => {
     select.addEventListener('change', toggleFields);
     toggleFields();
   });
+
+  // Mostrar alerta si se exceden 20 caracteres en el campo "otro"
+  document.querySelectorAll('input[name="estado_otro"]').forEach(input => {
+    input.addEventListener('input', () => {
+      if (input.value.length > 20) {
+        alert('Máximo 20 caracteres');
+        input.value = input.value.slice(0, 20);
+      }
+    });
+  });
 });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -359,8 +359,10 @@
                     {% if bloque.estado == 'abierto' %}
                     {{ bloque.hora_inicio|time:'H:i' }} -
                     {{ bloque.hora_fin|time:'H:i' }}
-                    {% else %}
+                    {% elif bloque.estado == 'cerrado' %}
                     <span class="text-danger">Cerrado</span>
+                    {% else %}
+                    <span class="text-muted">{{ bloque.estado_otro }}</span>
                     {% endif %}
                   </span>
                   <span>


### PR DESCRIPTION
## Summary
- display custom text for schedule entries in dashboard
- alert when entering more than 20 chars in custom schedule field

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68732ef992b48321a5f12279745ce052