### PR TITLE
Fix login redirect to home

### DIFF
--- a/templates/partials/_login-form.html
+++ b/templates/partials/_login-form.html
@@ -1,7 +1,7 @@
  {% load socialaccount %}
  
             <form method="post" action="{% url 'login' %}" class="profile-form">
-                <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                <input type="hidden" name="next" value="{% url 'home' %}">
                 {% csrf_token %}
 
                 <div class="form-field">


### PR DESCRIPTION
## Summary
- always redirect to homepage after login

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68744006a9b4832186305b2deaf9dbda