### PR TITLE
Mostrar club en header del dashboard

### DIFF
--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -22,6 +22,14 @@
                         </svg>
                     </button>
                 </li>
+                {% if request.resolver_match.url_name == 'club_dashboard' %}
+                <li class="nav-item d-flex align-items-center ms-2">
+                    <span class="me-1 text-dark">{{ club.name }}</span>
+                    <a href="{% url 'club_profile' club.slug %}" class="text-dark">
+                        <i class="bi bi-eye"></i>
+                    </a>
+                </li>
+                {% endif %}
                 {% endif %}
                 {% if user.is_authenticated %}
                     <li class="nav-item">


### PR DESCRIPTION
## Summary
- show club name and profile link when viewing the club dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==5.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_68744485b3748321acfe9d2c48038871