### PR TITLE
Fix sticky add button for schedules

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -299,3 +299,11 @@
   z-index: 2;
 
 }
+
+/* Keep schedule add buttons visible at the top */
+.schedule-add-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: #fff;
+}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -328,7 +328,7 @@
               {% for dia, nombre in dias_semana %}
               <td>
                 <!-- Botón añadir -->
-                <div class="mb-3">
+                <div class="mb-3 schedule-add-sticky">
                   <a
                     data-bs-toggle="collapse"
                     href="#add-{{ dia }}"


### PR DESCRIPTION
## Summary
- make the schedule add button sticky to the top of the schedule table
- add CSS to support sticky button on the dashboard schedule tab

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68744ba476988321ad456c94b1e784c2