### PR TITLE
Add payment history modal for members

### DIFF
--- a/apps/clubs/migrations/0023_pago_model.py
+++ b/apps/clubs/migrations/0023_pago_model.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0022_miembro_model'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Pago',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('fecha', models.DateField()),
+                ('monto', models.DecimalField(decimal_places=2, max_digits=8)),
+                ('miembro', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='pagos', to='clubs.miembro')),
+            ],
+            options={
+                'verbose_name': 'Pago',
+                'verbose_name_plural': 'Pagos',
+                'ordering': ['-fecha'],
+            },
+        ),
+    ]

--- a/apps/clubs/models/__init__.py
+++ b/apps/clubs/models/__init__.py
@@ -9,3 +9,4 @@ from .entrenador import Entrenador, EntrenadorPhoto, TrainingLevel
 from .post import ClubPost
 from .booking import Booking
 from .member import Miembro
+from .payment import Pago

--- a/apps/clubs/models/payment.py
+++ b/apps/clubs/models/payment.py
@@ -1,0 +1,16 @@
+from django.db import models
+from .member import Miembro
+
+
+class Pago(models.Model):
+    miembro = models.ForeignKey(Miembro, on_delete=models.CASCADE, related_name="pagos")
+    fecha = models.DateField()
+    monto = models.DecimalField(max_digits=8, decimal_places=2)
+
+    class Meta:
+        verbose_name = "Pago"
+        verbose_name_plural = "Pagos"
+        ordering = ["-fecha"]
+
+    def __str__(self):  # pragma: no cover - simple representation
+        return f"{self.miembro} - {self.fecha} - {self.monto}"

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -30,6 +30,7 @@ from apps.clubs.views.dashboard import (
     miembro_create,
     miembro_update,
     miembro_delete,
+    miembro_pagos,
 )
 
 urlpatterns = [
@@ -58,6 +59,7 @@ urlpatterns = [
     path('<slug:slug>/miembro/nuevo/', miembro_create, name='miembro_create'),
     path('miembro/<int:pk>/editar/', miembro_update, name='miembro_update'),
     path('miembro/<int:pk>/eliminar/', miembro_delete, name='miembro_delete'),
+    path('miembro/<int:pk>/pagos/', miembro_pagos, name='miembro_pagos'),
 
     path('<slug:slug>/posts/nuevo/', post_create, name='clubpost_create'),
     path('posts/<int:pk>/editar/', post_update, name='clubpost_update'),

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -15,6 +15,7 @@ from ..models import (
     Competidor,
     Entrenador,
     Miembro,
+    Pago,
 )
 from ..forms import (
     ClubForm,
@@ -352,4 +353,16 @@ def miembro_delete(request, pk):
         return redirect('club_dashboard', slug=slug)
     return render(request, 'clubs/miembro_confirm_delete.html', {
         'miembro': miembro,
+    })
+
+
+@login_required
+def miembro_pagos(request, pk):
+    miembro = get_object_or_404(Miembro, pk=pk)
+    if not has_club_permission(request.user, miembro.club):
+        return HttpResponseForbidden()
+    pagos = miembro.pagos.all()
+    return render(request, 'clubs/_payment_history.html', {
+        'miembro': miembro,
+        'pagos': pagos,
     })

--- a/static/js/payment-history.js
+++ b/static/js/payment-history.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('paymentHistoryModal');
+  if (!modalEl) return;
+  const modal = new bootstrap.Modal(modalEl);
+  modalEl.querySelector('.modal-body').innerHTML = '';
+
+  document.querySelectorAll('.view-payments-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const memberId = btn.dataset.memberId;
+      fetch(`/clubs/miembro/${memberId}/pagos/`)
+        .then(res => res.text())
+        .then(html => {
+          modalEl.querySelector('.modal-body').innerHTML = html;
+          modal.show();
+        });
+    });
+  });
+});

--- a/templates/clubs/_payment_history.html
+++ b/templates/clubs/_payment_history.html
@@ -1,0 +1,20 @@
+<table class="table table-bordered text-center align-middle">
+  <thead class="table-light">
+    <tr>
+      <th>Fecha</th>
+      <th>Monto</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for p in pagos %}
+    <tr>
+      <td>{{ p.fecha|date:"d/m/Y" }}</td>
+      <td>{{ p.monto }}</td>
+    </tr>
+    {% empty %}
+    <tr>
+      <td colspan="2" class="text-muted">Sin pagos registrados.</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -636,6 +636,7 @@
               <th>Email</th>
               <th>Inscrito</th>
               <th>Estado</th>
+              <th>Pagos</th>
               <th></th>
             </tr>
           </thead>
@@ -648,6 +649,11 @@
               <td>{{ m.fecha_inscripcion|date:"d/m/Y" }}</td>
               <td>{{ m.get_estado_display }}</td>
               <td>
+                <button type="button" class="btn btn-sm btn-outline-secondary view-payments-btn" data-member-id="{{ m.id }}">
+                  Ver Historial
+                </button>
+              </td>
+              <td>
                 <a href="{% url 'miembro_update' m.id %}" class="btn btn-sm btn-link"><i class="bi bi-pencil-square icon-large"></i></a>
                 <form method="post" action="{% url 'miembro_delete' m.id %}" class="d-inline">
                   {% csrf_token %}
@@ -659,7 +665,7 @@
             </tr>
             {% empty %}
             <tr>
-              <td colspan="6" class="text-muted">No hay miembros.</td>
+              <td colspan="7" class="text-muted">No hay miembros.</td>
             </tr>
             {% endfor %}
           </tbody>
@@ -698,6 +704,19 @@
   </div>
 </div>
 
+<!-- Payment History Modal -->
+<div class="modal fade" id="paymentHistoryModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Historial de Pagos</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>
+
 {% endblock %} {% block extra_js %}
 <script src="{% static 'js/profile-tabs.js' %}"></script>
 <script src="{% static 'js/feature-select.js' %}"></script>
@@ -705,4 +724,5 @@
 <script src="{% static 'js/schedule-form.js' %}"></script>
 <script src="{% static 'js/gallery-manager.js' %}"></script>
 <script src="{% static 'js/delete-confirm.js' %}"></script>
+<script src="{% static 'js/payment-history.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `Pago` model and migration
- display payment history button in member management table
- fetch payment history via new view and show in modal
- include JS handler for modal

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6875155323248321a5f7953ca1e363d3