### PR TITLE
Add payment management features

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -262,3 +262,33 @@ class MiembroForm(forms.ModelForm):
             )):
                 field.widget.attrs.setdefault('placeholder', ' ')
 
+
+class PagoForm(forms.ModelForm):
+    fecha = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}))
+    monto = forms.DecimalField(
+        max_digits=8,
+        decimal_places=2,
+        widget=forms.NumberInput(attrs={'step': '0.01'})
+    )
+
+    class Meta:
+        model = models.Pago
+        fields = ['fecha', 'monto']
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for name, field in self.fields.items():
+            css = field.widget.attrs.get('class', '')
+            field.widget.attrs['class'] = (css + ' form-control').strip()
+            if isinstance(field.widget, (
+                forms.TextInput,
+                forms.EmailInput,
+                forms.URLInput,
+                forms.NumberInput,
+                forms.PasswordInput,
+                forms.Textarea,
+                forms.DateInput,
+                forms.TimeInput,
+            )):
+                field.widget.attrs.setdefault('placeholder', ' ')
+

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -31,6 +31,9 @@ from apps.clubs.views.dashboard import (
     miembro_update,
     miembro_delete,
     miembro_pagos,
+    pago_create,
+    pago_update,
+    pago_delete,
 )
 
 urlpatterns = [
@@ -60,6 +63,9 @@ urlpatterns = [
     path('miembro/<int:pk>/editar/', miembro_update, name='miembro_update'),
     path('miembro/<int:pk>/eliminar/', miembro_delete, name='miembro_delete'),
     path('miembro/<int:pk>/pagos/', miembro_pagos, name='miembro_pagos'),
+    path('miembro/<int:miembro_id>/pago/nuevo/', pago_create, name='pago_create'),
+    path('pago/<int:pk>/editar/', pago_update, name='pago_update'),
+    path('pago/<int:pk>/eliminar/', pago_delete, name='pago_delete'),
 
     path('<slug:slug>/posts/nuevo/', post_create, name='clubpost_create'),
     path('posts/<int:pk>/editar/', post_update, name='clubpost_update'),

--- a/templates/clubs/_payment_history.html
+++ b/templates/clubs/_payment_history.html
@@ -1,8 +1,15 @@
+<form action="{% url 'pago_create' miembro.id %}" method="get" class="mb-3">
+  <button type="submit" class="btn btn-sm btn-outline-dark d-inline-flex align-items-center gap-2 btn-sm">
+    <i class="bi bi-plus-circle icon-large"></i> Añadir pago
+  </button>
+</form>
+
 <table class="table table-bordered text-center align-middle">
   <thead class="table-light">
     <tr>
       <th>Fecha</th>
       <th>Monto</th>
+      <th>Acciones</th>
     </tr>
   </thead>
   <tbody>
@@ -10,10 +17,17 @@
     <tr>
       <td>{{ p.fecha|date:"d/m/Y" }}</td>
       <td>{{ p.monto }}</td>
+      <td class="d-flex justify-content-center gap-2">
+        <a href="{% url 'pago_update' p.id %}" class="bi bi-pencil-square icon-large text-decoration-none d-flex align-items-center p-0"></a>
+        <form method="post" action="{% url 'pago_delete' p.id %}" class="m-0 p-0 delete-profile-form" onsubmit="return confirm('¿Seguro que deseas eliminar este pago?');">
+          {% csrf_token %}
+          <button type="submit" class="bi bi-dash-circle icon-large btn btn-link text-danger text-decoration-none p-0 m-0 d-flex align-items-center"></button>
+        </form>
+      </td>
     </tr>
     {% empty %}
     <tr>
-      <td colspan="2" class="text-muted">Sin pagos registrados.</td>
+      <td colspan="3" class="text-muted">Sin pagos registrados.</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/templates/clubs/pago_confirm_delete.html
+++ b/templates/clubs/pago_confirm_delete.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">Eliminar pago</h1>
+  <p>¿Seguro que deseas eliminar este pago?</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Eliminar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/clubs/payment_form.html
+++ b/templates/clubs/payment_form.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  {% include 'partials/_back-btn.html' %}
+  <h1 class="h5">{% if pago %}Editar{% else %}Nuevo{% endif %} pago</h1>
+  <form method="post" class="profile-form">
+    {% csrf_token %}
+    {% for field in form %}
+    <div class="form-field">
+      {{ field }}
+      <button type="button" class="clear-btn">×</button>
+      <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+      {% if field.errors %}
+      <div class="invalid-feedback d-block">
+        {{ field.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    {% endfor %}
+    <button type="submit" class="btn btn-dark">Guardar</button>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `PagoForm` for member payments
- support creating, editing and deleting payments in dashboard views
- wire up payment URLs
- create templates for payment form and delete confirmation
- extend payment history table with actions
- confirm payment deletion with a browser alert

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68751ced11b883219b538cf706ecaea6