### PR TITLE
Add payment form modal

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -277,6 +277,7 @@ class PagoForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields['monto'].label = 'Cantidad'
         for name, field in self.fields.items():
             css = field.widget.attrs.get('class', '')
             field.widget.attrs['class'] = (css + ' form-control').strip()

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -1,7 +1,7 @@
 from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
-from django.http import HttpResponseForbidden
+from django.http import HttpResponseForbidden, HttpResponse
 from django.db.models import Q
 from collections import defaultdict
 
@@ -363,9 +363,11 @@ def miembro_pagos(request, pk):
     if not has_club_permission(request.user, miembro.club):
         return HttpResponseForbidden()
     pagos = miembro.pagos.all()
+    form = PagoForm()
     return render(request, 'clubs/_payment_history.html', {
         'miembro': miembro,
         'pagos': pagos,
+        'form': form,
     })
 
 
@@ -381,6 +383,8 @@ def pago_create(request, miembro_id):
             pago.miembro = miembro
             pago.save()
             messages.success(request, 'Pago añadido correctamente.')
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+                return HttpResponse(status=204)
             return redirect('club_dashboard', slug=miembro.club.slug)
     else:
         form = PagoForm()
@@ -419,5 +423,7 @@ def pago_delete(request, pk):
         slug = pago.miembro.club.slug
         pago.delete()
         messages.success(request, 'Pago eliminado correctamente.')
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+            return HttpResponse(status=204)
         return redirect('club_dashboard', slug=slug)
     return render(request, 'clubs/pago_confirm_delete.html', {'pago': pago})

--- a/static/js/delete-confirm.js
+++ b/static/js/delete-confirm.js
@@ -4,12 +4,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const modal = new bootstrap.Modal(modalEl);
   let formToSubmit = null;
 
-  document.querySelectorAll('.delete-profile-form').forEach(form => {
-    form.addEventListener('submit', (e) => {
-      e.preventDefault();
-      formToSubmit = form;
-      modal.show();
-    });
+  document.body.addEventListener('submit', (e) => {
+    const form = e.target.closest('.delete-profile-form');
+    if (!form) return;
+    e.preventDefault();
+    formToSubmit = form;
+    modal.show();
   });
 
   modalEl.querySelector('.confirm-delete').addEventListener('click', () => {

--- a/static/js/payment-history.js
+++ b/static/js/payment-history.js
@@ -4,15 +4,38 @@ document.addEventListener('DOMContentLoaded', () => {
   const modal = new bootstrap.Modal(modalEl);
   modalEl.querySelector('.modal-body').innerHTML = '';
 
+  function loadHistory(memberId) {
+    fetch(`/clubs/miembro/${memberId}/pagos/`)
+      .then(res => res.text())
+      .then(html => {
+        modalEl.querySelector('.modal-body').innerHTML = html;
+        initForm(memberId);
+      });
+  }
+
+  function initForm(memberId) {
+    const toggleBtn = modalEl.querySelector('#add-payment-btn');
+    const form = modalEl.querySelector('#payment-form');
+    if (!toggleBtn || !form) return;
+    toggleBtn.addEventListener('click', () => {
+      form.classList.toggle('d-none');
+    });
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const formData = new FormData(form);
+      fetch(form.action, {
+        method: 'POST',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        body: formData
+      }).then(() => loadHistory(memberId));
+    });
+  }
+
   document.querySelectorAll('.view-payments-btn').forEach(btn => {
     btn.addEventListener('click', () => {
       const memberId = btn.dataset.memberId;
-      fetch(`/clubs/miembro/${memberId}/pagos/`)
-        .then(res => res.text())
-        .then(html => {
-          modalEl.querySelector('.modal-body').innerHTML = html;
-          modal.show();
-        });
+      loadHistory(memberId);
+      modal.show();
     });
   });
 });

--- a/templates/clubs/_payment_history.html
+++ b/templates/clubs/_payment_history.html
@@ -1,14 +1,24 @@
-<form action="{% url 'pago_create' miembro.id %}" method="get" class="mb-3">
-  <button type="submit" class="btn btn-sm btn-outline-dark d-inline-flex align-items-center gap-2 btn-sm">
-    <i class="bi bi-plus-circle icon-large"></i> Añadir pago
-  </button>
+<button id="add-payment-btn" class="btn btn-sm btn-outline-dark d-inline-flex align-items-center gap-2 mb-3">
+  <i class="bi bi-plus-circle icon-large"></i> Añadir pago
+</button>
+<form id="payment-form" action="{% url 'pago_create' miembro.id %}" method="post" class="row g-2 align-items-end mb-3 d-none">
+  {% csrf_token %}
+  <div class="col">
+    {{ form.fecha }}
+  </div>
+  <div class="col">
+    {{ form.monto }}
+  </div>
+  <div class="col-auto">
+    <button type="submit" class="btn btn-dark btn-sm">Guardar</button>
+  </div>
 </form>
 
 <table class="table table-bordered text-center align-middle">
   <thead class="table-light">
     <tr>
       <th>Fecha</th>
-      <th>Monto</th>
+      <th>Cantidad</th>
       <th>Acciones</th>
     </tr>
   </thead>


### PR DESCRIPTION
## Summary
- embed payment form into payment history modal
- update labels and headers from `Monto` to `Cantidad`
- support AJAX payment creation and deletion
- ensure delete confirmation works with dynamically loaded content

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6876065f6c84832197ea9b13b0045fe5