### PR TITLE
Update payment modal interactions

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -404,6 +404,8 @@ def pago_update(request, pk):
         if form.is_valid():
             form.save()
             messages.success(request, 'Pago actualizado correctamente.')
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+                return HttpResponse(status=204)
             return redirect('club_dashboard', slug=pago.miembro.club.slug)
     else:
         form = PagoForm(instance=pago)

--- a/static/js/payment-history.js
+++ b/static/js/payment-history.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!modalEl) return;
   const modal = new bootstrap.Modal(modalEl);
   modalEl.querySelector('.modal-body').innerHTML = '';
+  let createAction = '';
 
   function loadHistory(memberId) {
     fetch(`/clubs/miembro/${memberId}/pagos/`)
@@ -10,6 +11,8 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(html => {
         modalEl.querySelector('.modal-body').innerHTML = html;
         initForm(memberId);
+        initEdit(memberId);
+        initDelete(memberId);
       });
   }
 
@@ -17,8 +20,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const toggleBtn = modalEl.querySelector('#add-payment-btn');
     const form = modalEl.querySelector('#payment-form');
     if (!toggleBtn || !form) return;
+    createAction = form.action;
     toggleBtn.addEventListener('click', () => {
       form.classList.toggle('d-none');
+      form.action = createAction;
+      form.reset();
+      const cancelBtn = form.querySelector('.cancel-edit');
+      if (cancelBtn) cancelBtn.remove();
     });
     form.addEventListener('submit', e => {
       e.preventDefault();
@@ -28,6 +36,57 @@ document.addEventListener('DOMContentLoaded', () => {
         headers: { 'X-Requested-With': 'XMLHttpRequest' },
         body: formData
       }).then(() => loadHistory(memberId));
+    });
+  }
+
+  function initEdit(memberId) {
+    const form = modalEl.querySelector('#payment-form');
+    if (!form) return;
+    modalEl.querySelectorAll('.edit-payment-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        form.classList.remove('d-none');
+        form.action = btn.dataset.url;
+        form.querySelector('input[name="fecha"]').value = btn.dataset.fecha;
+        form.querySelector('input[name="monto"]').value = btn.dataset.monto;
+        if (!form.querySelector('.cancel-edit')) {
+          const cancel = document.createElement('button');
+          cancel.type = 'button';
+          cancel.textContent = 'Cancelar';
+          cancel.className = 'btn btn-secondary btn-sm ms-2 cancel-edit';
+          form.querySelector('.col-auto').appendChild(cancel);
+          cancel.addEventListener('click', () => {
+            form.action = createAction;
+            form.reset();
+            cancel.remove();
+          });
+        }
+      });
+    });
+  }
+
+  function initDelete(memberId) {
+    modalEl.querySelectorAll('.delete-payment-form').forEach(form => {
+      form.addEventListener('submit', e => {
+        e.preventDefault();
+        const alert = document.createElement('div');
+        alert.className = 'alert alert-warning d-flex justify-content-between align-items-center';
+        alert.innerHTML = '<span>¿Seguro que deseas eliminar este pago?</span>' +
+          '<div><button type="button" class="btn btn-danger btn-sm me-2 confirm">Eliminar</button>' +
+          '<button type="button" class="btn btn-secondary btn-sm cancel">Cancelar</button></div>';
+        modalEl.querySelector('.modal-body').prepend(alert);
+        alert.querySelector('.cancel').addEventListener('click', () => alert.remove());
+        alert.querySelector('.confirm').addEventListener('click', () => {
+          const formData = new FormData(form);
+          fetch(form.action, {
+            method: 'POST',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            body: formData
+          }).then(() => {
+            alert.remove();
+            loadHistory(memberId);
+          });
+        });
+      });
     });
   }
 

--- a/templates/clubs/_payment_history.html
+++ b/templates/clubs/_payment_history.html
@@ -28,8 +28,8 @@
       <td>{{ p.fecha|date:"d/m/Y" }}</td>
       <td>{{ p.monto }}</td>
       <td class="d-flex justify-content-center gap-2">
-        <a href="{% url 'pago_update' p.id %}" class="bi bi-pencil-square icon-large text-decoration-none d-flex align-items-center p-0"></a>
-        <form method="post" action="{% url 'pago_delete' p.id %}" class="m-0 p-0 delete-profile-form">
+        <button type="button" class="bi bi-pencil-square icon-large btn btn-link p-0 edit-payment-btn" data-url="{% url 'pago_update' p.id %}" data-fecha="{{ p.fecha|date:'Y-m-d' }}" data-monto="{{ p.monto }}"></button>
+        <form method="post" action="{% url 'pago_delete' p.id %}" class="m-0 p-0 delete-payment-form">
           {% csrf_token %}
           <button type="submit" class="bi bi-dash-circle icon-large btn btn-link text-danger text-decoration-none p-0 m-0 d-flex align-items-center"></button>
         </form>


### PR DESCRIPTION
## Summary
- enable AJAX updates for payments
- allow editing payments inside the history modal
- add inline confirmation to delete payments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for django)*

------
https://chatgpt.com/codex/tasks/task_e_68760ad8a3f48321954b4fb9b61e3fd5