### PR TITLE
Add member modals

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -262,6 +262,15 @@ class MiembroForm(forms.ModelForm):
             )):
                 field.widget.attrs.setdefault('placeholder', ' ')
 
+        avatar_widget = self.fields.get('avatar')
+        if avatar_widget:
+            css = avatar_widget.widget.attrs.get('class', '')
+            avatar_widget.widget.attrs['class'] = (css + ' d-none').strip()
+
+        fecha_widget = self.fields.get('fecha_nacimiento')
+        if fecha_widget:
+            fecha_widget.widget.input_type = 'date'
+
 
 class PagoForm(forms.ModelForm):
     fecha = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}))

--- a/apps/clubs/migrations/0024_miembro_extra_fields.py
+++ b/apps/clubs/migrations/0024_miembro_extra_fields.py
@@ -1,0 +1,50 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0023_pago_model'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='miembro',
+            name='avatar',
+            field=models.ImageField(blank=True, null=True, upload_to='miembros/'),
+        ),
+        migrations.AddField(
+            model_name='miembro',
+            name='fecha_nacimiento',
+            field=models.DateField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='miembro',
+            name='direccion',
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name='miembro',
+            name='sexo',
+            field=models.CharField(blank=True, choices=[('M', 'Masculino'), ('F', 'Femenino')], max_length=1),
+        ),
+        migrations.AddField(
+            model_name='miembro',
+            name='peso',
+            field=models.DecimalField(blank=True, null=True, max_digits=5, decimal_places=2),
+        ),
+        migrations.AddField(
+            model_name='miembro',
+            name='altura',
+            field=models.DecimalField(blank=True, null=True, max_digits=5, decimal_places=2),
+        ),
+        migrations.AddField(
+            model_name='miembro',
+            name='nacionalidad',
+            field=models.CharField(blank=True, max_length=100),
+        ),
+        migrations.AddField(
+            model_name='miembro',
+            name='notas',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/apps/clubs/models/member.py
+++ b/apps/clubs/models/member.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 from .club import Club
+from apps.core.utils.image_utils import resize_image
 
 
 class Miembro(models.Model):
@@ -9,7 +10,20 @@ class Miembro(models.Model):
         ("inactivo", "Inactivo"),
     ]
 
+    SEXO_CHOICES = [
+        ("M", "Masculino"),
+        ("F", "Femenino"),
+    ]
+
     club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name="miembros")
+    avatar = models.ImageField(upload_to="miembros/", blank=True, null=True)
+    fecha_nacimiento = models.DateField(blank=True, null=True)
+    direccion = models.CharField(max_length=255, blank=True)
+    sexo = models.CharField(max_length=1, choices=SEXO_CHOICES, blank=True)
+    peso = models.DecimalField(max_digits=5, decimal_places=2, blank=True, null=True)
+    altura = models.DecimalField(max_digits=5, decimal_places=2, blank=True, null=True)
+    nacionalidad = models.CharField(max_length=100, blank=True)
+    notas = models.TextField(blank=True)
     nombre = models.CharField(max_length=100)
     apellidos = models.CharField(max_length=150)
     telefono = models.CharField(max_length=20, blank=True)
@@ -24,6 +38,11 @@ class Miembro(models.Model):
 
     def __str__(self):  # pragma: no cover - simple representation
         return f"{self.nombre} {self.apellidos}"
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        if self.avatar and hasattr(self.avatar, "path"):
+            resize_image(self.avatar.path)
 
     @property
     def pago_mes_actual(self):

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -29,6 +29,7 @@ from apps.clubs.views.dashboard import (
     entrenador_delete,
     miembro_create,
     miembro_update,
+    miembro_detail,
     miembro_delete,
     miembro_pagos,
     pago_create,
@@ -61,6 +62,7 @@ urlpatterns = [
 
     path('<slug:slug>/miembro/nuevo/', miembro_create, name='miembro_create'),
     path('miembro/<int:pk>/editar/', miembro_update, name='miembro_update'),
+    path('miembro/<int:pk>/detalle/', miembro_detail, name='miembro_detail'),
     path('miembro/<int:pk>/eliminar/', miembro_delete, name='miembro_delete'),
     path('miembro/<int:pk>/pagos/', miembro_pagos, name='miembro_pagos'),
     path('miembro/<int:miembro_id>/pago/nuevo/', pago_create, name='pago_create'),

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -328,18 +328,29 @@ def miembro_update(request, pk):
     if not has_club_permission(request.user, miembro.club):
         return HttpResponseForbidden()
     if request.method == 'POST':
-        form = MiembroForm(request.POST, instance=miembro)
+        form = MiembroForm(request.POST, request.FILES, instance=miembro)
         if form.is_valid():
             form.save()
             messages.success(request, 'Miembro actualizado correctamente.')
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+                return HttpResponse(status=204)
             return redirect('club_dashboard', slug=miembro.club.slug)
     else:
         form = MiembroForm(instance=miembro)
-    return render(request, 'clubs/miembro_form.html', {
+    template = 'clubs/_miembro_form.html' if request.headers.get('x-requested-with') == 'XMLHttpRequest' else 'clubs/miembro_form.html'
+    return render(request, template, {
         'form': form,
         'club': miembro.club,
         'miembro': miembro,
     })
+
+
+@login_required
+def miembro_detail(request, pk):
+    miembro = get_object_or_404(Miembro, pk=pk)
+    if not has_club_permission(request.user, miembro.club):
+        return HttpResponseForbidden()
+    return render(request, 'clubs/_miembro_detail.html', {'miembro': miembro})
 
 
 @login_required

--- a/static/js/member-modal.js
+++ b/static/js/member-modal.js
@@ -1,0 +1,41 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const profileEl = document.getElementById('memberProfileModal');
+  const editEl = document.getElementById('editMemberModal');
+  const profileModal = profileEl ? new bootstrap.Modal(profileEl) : null;
+  const editModal = editEl ? new bootstrap.Modal(editEl) : null;
+
+  document.querySelectorAll('.view-member-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.dataset.memberId;
+      fetch(`/clubs/miembro/${id}/detalle/`)
+        .then(res => res.text())
+        .then(html => {
+          if (profileEl) {
+            profileEl.querySelector('.modal-body').innerHTML = html;
+            profileModal.show();
+          }
+        });
+    });
+  });
+
+  document.querySelectorAll('.edit-member-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.dataset.memberId;
+      fetch(`/clubs/miembro/${id}/editar/`, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+        .then(res => res.text())
+        .then(html => {
+          if (editEl) {
+            editEl.querySelector('.modal-body').innerHTML = html;
+            const form = editEl.querySelector('form');
+            form.addEventListener('submit', e => {
+              e.preventDefault();
+              const fd = new FormData(form);
+              fetch(form.action, { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }, body: fd })
+                .then(() => window.location.reload());
+            });
+            editModal.show();
+          }
+        });
+    });
+  });
+});

--- a/templates/clubs/_miembro_detail.html
+++ b/templates/clubs/_miembro_detail.html
@@ -1,0 +1,19 @@
+<div class="text-center mb-3">
+  {% if miembro.avatar %}
+  <img src="{{ miembro.avatar.url }}" alt="{{ miembro }}" class="rounded-circle" style="width: 120px; height: 120px; object-fit: cover;">
+  {% else %}
+  <div class="rounded-circle bg-secondary d-inline-flex align-items-center justify-content-center text-white" style="width:120px;height:120px;">
+    {{ miembro.nombre|first|upper }}
+  </div>
+  {% endif %}
+</div>
+<ul class="list-unstyled">
+  <li><strong>Nombre:</strong> {{ miembro.nombre }} {{ miembro.apellidos }}</li>
+  <li><strong>Fecha de nacimiento:</strong> {{ miembro.fecha_nacimiento|default:"-" }}</li>
+  <li><strong>Dirección:</strong> {{ miembro.direccion|default:"-" }}</li>
+  <li><strong>Sexo:</strong> {{ miembro.get_sexo_display|default:"-" }}</li>
+  <li><strong>Peso (kg):</strong> {{ miembro.peso|default:"-" }}</li>
+  <li><strong>Altura (cm):</strong> {{ miembro.altura|default:"-" }}</li>
+  <li><strong>Nacionalidad:</strong> {{ miembro.nacionalidad|default:"-" }}</li>
+  <li><strong>Notas:</strong> {{ miembro.notas|default:"-" }}</li>
+</ul>

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -1,0 +1,35 @@
+<form method="post" enctype="multipart/form-data" class="profile-form">
+  {% csrf_token %}
+  <div class="form-field">
+    <div class="avatar-dropzone">
+      {{ form.avatar }}
+      <div class="avatar-preview{% if miembro and miembro.avatar %} has-image{% endif %}"{% if miembro and miembro.avatar %} style="background-image:url('{{ miembro.avatar.url }}')"{% endif %}>
+        <div class="avatar-dropzone-msg">
+          <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+          <span>Sube avatar</span>
+        </div>
+      </div>
+    </div>
+    <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
+    {% if form.avatar.errors %}
+    <div class="invalid-feedback d-block">
+      {{ form.avatar.errors.as_text|striptags }}
+    </div>
+    {% endif %}
+  </div>
+  {% for field in form %}
+    {% if field.name != 'avatar' %}
+    <div class="form-field">
+      {{ field }}
+      <button type="button" class="clear-btn">×</button>
+      <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+      {% if field.errors %}
+      <div class="invalid-feedback d-block">
+        {{ field.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    {% endif %}
+  {% endfor %}
+  <button type="submit" class="btn btn-dark">Guardar</button>
+</form>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -631,7 +631,7 @@
         <table class="table table-bordered text-center align-middle" style="min-width: 600px">
           <thead class="table-dark">
             <tr>
-              <th>Nombre</th>
+              <th>Miembro</th>
               <th>Teléfono</th>
               <th>Email</th>
               <th>Inscrito</th>
@@ -643,7 +643,12 @@
           <tbody>
             {% for m in members %}
             <tr>
-              <td>{{ m.nombre }} {{ m.apellidos }}</td>
+              <td>
+                {{ m.nombre }} {{ m.apellidos }}
+                <button type="button" class="btn btn-sm btn-link view-member-btn" data-member-id="{{ m.id }}">
+                  <i class="bi bi-eye icon-large"></i>
+                </button>
+              </td>
               <td>{{ m.telefono }}</td>
               <td>{{ m.email }}</td>
               <td>{{ m.fecha_inscripcion|date:"d/m/Y" }}</td>
@@ -659,7 +664,9 @@
                 </button>
               </td>
               <td>
-                <a href="{% url 'miembro_update' m.id %}" class="btn btn-sm btn-link"><i class="bi bi-pencil-square icon-large"></i></a>
+                <button type="button" class="btn btn-sm btn-link edit-member-btn" data-member-id="{{ m.id }}">
+                  <i class="bi bi-pencil-square icon-large"></i>
+                </button>
                 <form method="post" action="{% url 'miembro_delete' m.id %}" class="d-inline">
                   {% csrf_token %}
                   <button type="submit" class="btn btn-sm btn-link text-danger">
@@ -722,6 +729,32 @@
   </div>
 </div>
 
+<!-- Member Profile Modal -->
+<div class="modal fade" id="memberProfileModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Perfil de Miembro</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>
+
+<!-- Edit Member Modal -->
+<div class="modal fade" id="editMemberModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Editar miembro</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>
+
 {% endblock %} {% block extra_js %}
 <script src="{% static 'js/profile-tabs.js' %}"></script>
 <script src="{% static 'js/feature-select.js' %}"></script>
@@ -730,4 +763,5 @@
 <script src="{% static 'js/gallery-manager.js' %}"></script>
 <script src="{% static 'js/delete-confirm.js' %}"></script>
 <script src="{% static 'js/payment-history.js' %}"></script>
+<script src="{% static 'js/member-modal.js' %}"></script>
 {% endblock %}

--- a/templates/clubs/miembro_form.html
+++ b/templates/clubs/miembro_form.html
@@ -3,21 +3,43 @@
 <div class="container py-4">
   {% include 'partials/_back-btn.html' %}
   <h1 class="h5">{% if miembro %}Editar{% else %}Nuevo{% endif %} miembro</h1>
-  <form method="post" class="profile-form">
+  <form method="post" enctype="multipart/form-data" class="profile-form">
     {% csrf_token %}
-    {% for field in form %}
     <div class="form-field">
-      {{ field }}
-      <button type="button" class="clear-btn">×</button>
-      <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-      {% if field.errors %}
+      <div class="avatar-dropzone">
+        {{ form.avatar }}
+        <div class="avatar-preview{% if miembro and miembro.avatar %} has-image{% endif %}"{% if miembro and miembro.avatar %} style="background-image:url('{{ miembro.avatar.url }}')"{% endif %}>
+          <div class="avatar-dropzone-msg">
+            <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+            <span>Sube avatar</span>
+          </div>
+        </div>
+      </div>
+      <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
+      {% if form.avatar.errors %}
       <div class="invalid-feedback d-block">
-        {{ field.errors.as_text|striptags }}
+        {{ form.avatar.errors.as_text|striptags }}
       </div>
       {% endif %}
     </div>
+    {% for field in form %}
+      {% if field.name != 'avatar' %}
+      <div class="form-field">
+        {{ field }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+        {% if field.errors %}
+        <div class="invalid-feedback d-block">
+          {{ field.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+      {% endif %}
     {% endfor %}
     <button type="submit" class="btn btn-dark">Guardar</button>
   </form>
 </div>
+{% endblock %}
+{% block extra_js %}
+<script src="{% static 'js/avatar-dropzone.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extend `Miembro` model with personal data fields
- handle avatar upload and birth date widgets in form
- change members table to show profile/edit modals
- add modal templates and JS loader
- wire up new views and urls

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68761158d1b48321bb6460035fa41e68