### PR TITLE
Add modal for new members and reorganize form

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -310,16 +310,19 @@ def miembro_create(request, slug):
     if not has_club_permission(request.user, club):
         return HttpResponseForbidden()
     if request.method == 'POST':
-        form = MiembroForm(request.POST)
+        form = MiembroForm(request.POST, request.FILES)
         if form.is_valid():
             miembro = form.save(commit=False)
             miembro.club = club
             miembro.save()
             messages.success(request, 'Miembro añadido correctamente.')
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+                return HttpResponse(status=204)
             return redirect('club_dashboard', slug=club.slug)
     else:
         form = MiembroForm()
-    return render(request, 'clubs/miembro_form.html', {'form': form, 'club': club})
+    template = 'clubs/_miembro_form.html' if request.headers.get('x-requested-with') == 'XMLHttpRequest' else 'clubs/miembro_form.html'
+    return render(request, template, {'form': form, 'club': club})
 
 
 @login_required

--- a/static/js/member-modal.js
+++ b/static/js/member-modal.js
@@ -1,8 +1,10 @@
 document.addEventListener('DOMContentLoaded', () => {
   const profileEl = document.getElementById('memberProfileModal');
   const editEl = document.getElementById('editMemberModal');
+  const addEl = document.getElementById('addMemberModal');
   const profileModal = profileEl ? new bootstrap.Modal(profileEl) : null;
   const editModal = editEl ? new bootstrap.Modal(editEl) : null;
+  const addModal = addEl ? new bootstrap.Modal(addEl) : null;
 
   document.querySelectorAll('.view-member-btn').forEach(btn => {
     btn.addEventListener('click', () => {
@@ -38,4 +40,26 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
   });
+
+  const addBtn = document.querySelector('.add-member-btn');
+  if (addBtn) {
+    addBtn.addEventListener('click', () => {
+      const slug = addBtn.dataset.clubSlug;
+      fetch(`/clubs/${slug}/miembro/nuevo/`, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+        .then(res => res.text())
+        .then(html => {
+          if (addEl) {
+            addEl.querySelector('.modal-body').innerHTML = html;
+            const form = addEl.querySelector('form');
+            form.addEventListener('submit', e => {
+              e.preventDefault();
+              const fd = new FormData(form);
+              fetch(form.action, { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }, body: fd })
+                .then(() => window.location.reload());
+            });
+            addModal.show();
+          }
+        });
+    });
+  }
 });

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -17,19 +17,145 @@
     </div>
     {% endif %}
   </div>
-  {% for field in form %}
-    {% if field.name != 'avatar' %}
-    <div class="form-field">
-      {{ field }}
-      <button type="button" class="clear-btn">×</button>
-      <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-      {% if field.errors %}
-      <div class="invalid-feedback d-block">
-        {{ field.errors.as_text|striptags }}
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.nombre }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.nombre.id_for_label }}">{{ form.nombre.label }}</label>
+        {% if form.nombre.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.nombre.errors.as_text|striptags }}
+        </div>
+        {% endif %}
       </div>
-      {% endif %}
+    </div>
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.apellidos }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.apellidos.id_for_label }}">{{ form.apellidos.label }}</label>
+        {% if form.apellidos.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.apellidos.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.telefono }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
+        {% if form.telefono.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.telefono.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.email }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
+        {% if form.email.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.email.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-4">
+      <div class="form-field">
+        {{ form.fecha_nacimiento }}
+        <label for="{{ form.fecha_nacimiento.id_for_label }}">{{ form.fecha_nacimiento.label }}</label>
+        {% if form.fecha_nacimiento.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.fecha_nacimiento.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="form-field">
+        {{ form.sexo }}
+        <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
+        {% if form.sexo.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.sexo.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="form-field">
+        {{ form.nacionalidad }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.nacionalidad.id_for_label }}">{{ form.nacionalidad.label }}</label>
+        {% if form.nacionalidad.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.nacionalidad.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="form-field">
+    {{ form.direccion }}
+    <button type="button" class="clear-btn">×</button>
+    <label for="{{ form.direccion.id_for_label }}">{{ form.direccion.label }}</label>
+    {% if form.direccion.errors %}
+    <div class="invalid-feedback d-block">
+      {{ form.direccion.errors.as_text|striptags }}
     </div>
     {% endif %}
-  {% endfor %}
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.altura }}
+        <label for="{{ form.altura.id_for_label }}">{{ form.altura.label }}</label>
+        {% if form.altura.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.altura.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.peso }}
+        <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
+        {% if form.peso.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.peso.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="form-field">
+    {{ form.estado }}
+    <label for="{{ form.estado.id_for_label }}">{{ form.estado.label }}</label>
+    {% if form.estado.errors %}
+    <div class="invalid-feedback d-block">
+      {{ form.estado.errors.as_text|striptags }}
+    </div>
+    {% endif %}
+  </div>
+  <div class="form-field">
+    {{ form.notas }}
+    <label for="{{ form.notas.id_for_label }}">{{ form.notas.label }}</label>
+    {% if form.notas.errors %}
+    <div class="invalid-feedback d-block">
+      {{ form.notas.errors.as_text|striptags }}
+    </div>
+    {% endif %}
+  </div>
   <button type="submit" class="btn btn-dark">Guardar</button>
 </form>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -622,11 +622,9 @@
       </div>
     </div>
     <div id="tab-members" class="profile-section">
-      <form action="{% url 'miembro_create' club.slug %}" method="get" class="mb-3">
-        <button type="submit" class="btn btn-sm btn-outline-dark d-inline-flex align-items-center justify-content-center gap-2 btn-sm">
-          <i class="bi bi-plus-circle icon-large"></i> Añadir miembro
-        </button>
-      </form>
+      <button type="button" class="btn btn-sm btn-outline-dark d-inline-flex align-items-center justify-content-center gap-2 btn-sm add-member-btn" data-club-slug="{{ club.slug }}">
+        <i class="bi bi-plus-circle icon-large"></i> Añadir miembro
+      </button>
       <div class="table-responsive">
         <table class="table table-bordered text-center align-middle" style="min-width: 600px">
           <thead class="table-dark">
@@ -748,6 +746,19 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Editar miembro</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>
+
+<!-- Add Member Modal -->
+<div class="modal fade" id="addMemberModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Nuevo miembro</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body"></div>

--- a/templates/clubs/miembro_form.html
+++ b/templates/clubs/miembro_form.html
@@ -23,20 +23,146 @@
       </div>
       {% endif %}
     </div>
-    {% for field in form %}
-      {% if field.name != 'avatar' %}
-      <div class="form-field">
-        {{ field }}
-        <button type="button" class="clear-btn">×</button>
-        <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-        {% if field.errors %}
-        <div class="invalid-feedback d-block">
-          {{ field.errors.as_text|striptags }}
+    <div class="row">
+      <div class="col-md-6">
+        <div class="form-field">
+          {{ form.nombre }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ form.nombre.id_for_label }}">{{ form.nombre.label }}</label>
+          {% if form.nombre.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.nombre.errors.as_text|striptags }}
+          </div>
+          {% endif %}
         </div>
-        {% endif %}
+      </div>
+      <div class="col-md-6">
+        <div class="form-field">
+          {{ form.apellidos }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ form.apellidos.id_for_label }}">{{ form.apellidos.label }}</label>
+          {% if form.apellidos.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.apellidos.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-6">
+        <div class="form-field">
+          {{ form.telefono }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
+          {% if form.telefono.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.telefono.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="form-field">
+          {{ form.email }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
+          {% if form.email.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.email.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-4">
+        <div class="form-field">
+          {{ form.fecha_nacimiento }}
+          <label for="{{ form.fecha_nacimiento.id_for_label }}">{{ form.fecha_nacimiento.label }}</label>
+          {% if form.fecha_nacimiento.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.fecha_nacimiento.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="form-field">
+          {{ form.sexo }}
+          <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
+          {% if form.sexo.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.sexo.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="form-field">
+          {{ form.nacionalidad }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ form.nacionalidad.id_for_label }}">{{ form.nacionalidad.label }}</label>
+          {% if form.nacionalidad.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.nacionalidad.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    <div class="form-field">
+      {{ form.direccion }}
+      <button type="button" class="clear-btn">×</button>
+      <label for="{{ form.direccion.id_for_label }}">{{ form.direccion.label }}</label>
+      {% if form.direccion.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.direccion.errors.as_text|striptags }}
       </div>
       {% endif %}
-    {% endfor %}
+    </div>
+    <div class="row">
+      <div class="col-md-6">
+        <div class="form-field">
+          {{ form.altura }}
+          <label for="{{ form.altura.id_for_label }}">{{ form.altura.label }}</label>
+          {% if form.altura.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.altura.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="form-field">
+          {{ form.peso }}
+          <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
+          {% if form.peso.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.peso.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    <div class="form-field">
+      {{ form.estado }}
+      <label for="{{ form.estado.id_for_label }}">{{ form.estado.label }}</label>
+      {% if form.estado.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.estado.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    <div class="form-field">
+      {{ form.notas }}
+      <label for="{{ form.notas.id_for_label }}">{{ form.notas.label }}</label>
+      {% if form.notas.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.notas.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
     <button type="submit" class="btn btn-dark">Guardar</button>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- open member creation in a modal on the dashboard
- support AJAX form responses in `miembro_create`
- restructure member form fields for improved UX

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687615d4d248832188c0bec857f3a232