### PR TITLE
Add location fields and modal adjustments

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -204,6 +204,9 @@ class CompetidorForm(forms.ModelForm):
             )):
                 field.widget.attrs.setdefault('placeholder', ' ')
 
+
+
+
         avatar_widget = self.fields.get('avatar')
         if avatar_widget:
             css = avatar_widget.widget.attrs.get('class', '')
@@ -233,6 +236,12 @@ class EntrenadorForm(forms.ModelForm):
                 forms.TimeInput,
             )):
                 field.widget.attrs.setdefault('placeholder', ' ')
+
+        # Custom labels with units
+        if 'peso' in self.fields:
+            self.fields['peso'].label = 'Peso (kg)'
+        if 'altura' in self.fields:
+            self.fields['altura'].label = 'Altura (cm)'
 
         avatar_widget = self.fields.get('avatar')
         if avatar_widget:
@@ -270,6 +279,12 @@ class MiembroForm(forms.ModelForm):
         fecha_widget = self.fields.get('fecha_nacimiento')
         if fecha_widget:
             fecha_widget.widget.input_type = 'date'
+
+        # Set default labels for new fields
+        if 'localidad' in self.fields:
+            self.fields['localidad'].label = 'Localidad'
+        if 'codigo_postal' in self.fields:
+            self.fields['codigo_postal'].label = 'Código postal'
 
 
 class PagoForm(forms.ModelForm):

--- a/apps/clubs/migrations/0025_miembro_location.py
+++ b/apps/clubs/migrations/0025_miembro_location.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0024_miembro_extra_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='miembro',
+            name='localidad',
+            field=models.CharField(max_length=100, blank=True),
+        ),
+        migrations.AddField(
+            model_name='miembro',
+            name='codigo_postal',
+            field=models.CharField(max_length=10, blank=True),
+        ),
+    ]

--- a/apps/clubs/models/member.py
+++ b/apps/clubs/models/member.py
@@ -19,6 +19,8 @@ class Miembro(models.Model):
     avatar = models.ImageField(upload_to="miembros/", blank=True, null=True)
     fecha_nacimiento = models.DateField(blank=True, null=True)
     direccion = models.CharField(max_length=255, blank=True)
+    localidad = models.CharField(max_length=100, blank=True)
+    codigo_postal = models.CharField(max_length=10, blank=True)
     sexo = models.CharField(max_length=1, choices=SEXO_CHOICES, blank=True)
     peso = models.DecimalField(max_digits=5, decimal_places=2, blank=True, null=True)
     altura = models.DecimalField(max_digits=5, decimal_places=2, blank=True, null=True)

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -125,6 +125,7 @@
   width: 200px;
   height: 200px;
   position: relative;
+  margin: 0 auto;
 }
 .avatar-dropzone input[type="file"] {
   display: none;
@@ -133,7 +134,7 @@
   width: 100%;
   height: 100%;
   border: 2px dashed #666;
-  border-radius: 0;
+  border-radius: 50%;
   background-size: cover;
   background-position: center;
   cursor: pointer;
@@ -142,6 +143,7 @@
   justify-content: center;
   color: #666;
   transition: background-color 0.2s, border-color 0.2s;
+  overflow: hidden;
 }
 .avatar-dropzone .avatar-dropzone-msg {
   text-align: center;

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -1,7 +1,7 @@
 <form method="post" enctype="multipart/form-data" class="profile-form">
   {% csrf_token %}
-  <div class="form-field">
-    <div class="avatar-dropzone">
+  <div class="form-field text-center">
+    <div class="avatar-dropzone mx-auto">
       {{ form.avatar }}
       <div class="avatar-preview{% if miembro and miembro.avatar %} has-image{% endif %}"{% if miembro and miembro.avatar %} style="background-image:url('{{ miembro.avatar.url }}')"{% endif %}>
         <div class="avatar-dropzone-msg">
@@ -105,15 +105,43 @@
       </div>
     </div>
   </div>
-  <div class="form-field">
-    {{ form.direccion }}
-    <button type="button" class="clear-btn">×</button>
-    <label for="{{ form.direccion.id_for_label }}">{{ form.direccion.label }}</label>
-    {% if form.direccion.errors %}
-    <div class="invalid-feedback d-block">
-      {{ form.direccion.errors.as_text|striptags }}
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.direccion }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.direccion.id_for_label }}">{{ form.direccion.label }}</label>
+        {% if form.direccion.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.direccion.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
     </div>
-    {% endif %}
+    <div class="col-md-3">
+      <div class="form-field">
+        {{ form.localidad }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.localidad.id_for_label }}">{{ form.localidad.label }}</label>
+        {% if form.localidad.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.localidad.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="form-field">
+        {{ form.codigo_postal }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.codigo_postal.id_for_label }}">{{ form.codigo_postal.label }}</label>
+        {% if form.codigo_postal.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.codigo_postal.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
   </div>
   <div class="row">
     <div class="col-md-6">

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -742,13 +742,13 @@
 
 <!-- Edit Member Modal -->
 <div class="modal fade" id="editMemberModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Editar miembro</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-      <div class="modal-body"></div>
+      <div class="modal-body p-5"></div>
     </div>
   </div>
 </div>

--- a/templates/clubs/miembro_form.html
+++ b/templates/clubs/miembro_form.html
@@ -4,10 +4,10 @@
 <div class="container py-4">
   {% include 'partials/_back-btn.html' %}
   <h1 class="h5">{% if miembro %}Editar{% else %}Nuevo{% endif %} miembro</h1>
-  <form method="post" enctype="multipart/form-data" class="profile-form">
-    {% csrf_token %}
-    <div class="form-field">
-      <div class="avatar-dropzone">
+    <form method="post" enctype="multipart/form-data" class="profile-form">
+      {% csrf_token %}
+      <div class="form-field text-center">
+        <div class="avatar-dropzone mx-auto">
         {{ form.avatar }}
         <div class="avatar-preview{% if miembro and miembro.avatar %} has-image{% endif %}"{% if miembro and miembro.avatar %} style="background-image:url('{{ miembro.avatar.url }}')"{% endif %}>
           <div class="avatar-dropzone-msg">
@@ -111,16 +111,44 @@
         </div>
       </div>
     </div>
-    <div class="form-field">
-      {{ form.direccion }}
-      <button type="button" class="clear-btn">×</button>
-      <label for="{{ form.direccion.id_for_label }}">{{ form.direccion.label }}</label>
-      {% if form.direccion.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.direccion.errors.as_text|striptags }}
+      <div class="row">
+        <div class="col-md-6">
+          <div class="form-field">
+            {{ form.direccion }}
+            <button type="button" class="clear-btn">×</button>
+            <label for="{{ form.direccion.id_for_label }}">{{ form.direccion.label }}</label>
+            {% if form.direccion.errors %}
+            <div class="invalid-feedback d-block">
+              {{ form.direccion.errors.as_text|striptags }}
+            </div>
+            {% endif %}
+          </div>
+        </div>
+        <div class="col-md-3">
+          <div class="form-field">
+            {{ form.localidad }}
+            <button type="button" class="clear-btn">×</button>
+            <label for="{{ form.localidad.id_for_label }}">{{ form.localidad.label }}</label>
+            {% if form.localidad.errors %}
+            <div class="invalid-feedback d-block">
+              {{ form.localidad.errors.as_text|striptags }}
+            </div>
+            {% endif %}
+          </div>
+        </div>
+        <div class="col-md-3">
+          <div class="form-field">
+            {{ form.codigo_postal }}
+            <button type="button" class="clear-btn">×</button>
+            <label for="{{ form.codigo_postal.id_for_label }}">{{ form.codigo_postal.label }}</label>
+            {% if form.codigo_postal.errors %}
+            <div class="invalid-feedback d-block">
+              {{ form.codigo_postal.errors.as_text|striptags }}
+            </div>
+            {% endif %}
+          </div>
+        </div>
       </div>
-      {% endif %}
-    </div>
     <div class="row">
       <div class="col-md-6">
         <div class="form-field">


### PR DESCRIPTION
## Summary
- add new fields `localidad` and `codigo_postal` to the member model
- display those fields alongside `direccion` in member forms
- adjust labels for weight and height with units
- center avatar dropzone and make it circular
- enlarge edit member modal
- add migration for new fields

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68767dac4d148321840c713b89269c41