### PR TITLE
Update member modal layout and dropdown

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -252,7 +252,7 @@ class EntrenadorForm(forms.ModelForm):
 
 class MiembroForm(forms.ModelForm):
     nacionalidad = forms.ChoiceField(
-        choices=[('', 'Seleccione país')] + COUNTRY_CHOICES,
+        choices=[('', 'País')] + COUNTRY_CHOICES,
         required=False,
     )
 
@@ -294,11 +294,12 @@ class MiembroForm(forms.ModelForm):
 
         sexo_field = self.fields.get('sexo')
         if sexo_field:
-            sexo_field.choices = [('', 'Seleccione sexo')] + list(models.Miembro.SEXO_CHOICES)
+            sexo_field.choices = [('', 'Sexo')] + list(models.Miembro.SEXO_CHOICES)
 
         nacionalidad_field = self.fields.get('nacionalidad')
         if nacionalidad_field:
-            nacionalidad_field.choices = [('', 'Seleccione país')] + COUNTRY_CHOICES
+            other = [c for c in COUNTRY_CHOICES if c[0] != 'España']
+            nacionalidad_field.choices = [('', 'País'), ('España', 'España')] + other
 
         # Set default labels for new fields
         if 'localidad' in self.fields:

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -303,6 +303,11 @@
 }
 
 .icon-large{
-  font-size:17px; 
+  font-size:17px;
+}
+
+/* Divider after Spain in nationality dropdown */
+select option[value="España"] {
+  border-bottom: 1px solid #ccc;
 }
 

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -59,7 +59,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-4">
       <div class="form-field">
         {{ form.telefono }}
         <button type="button" class="clear-btn">×</button>
@@ -73,7 +73,7 @@
         {% endif %}
       </div>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-8">
       <div class="form-field">
         {{ form.email }}
         <button type="button" class="clear-btn">×</button>
@@ -89,7 +89,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-3">
       <div class="form-field">
         {{ form.fecha_nacimiento }}
         <label for="{{ form.fecha_nacimiento.id_for_label }}"
@@ -102,7 +102,7 @@
         {% endif %}
       </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
       <div class="form-field">
         {{ form.sexo }}
         <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
@@ -113,7 +113,7 @@
         {% endif %}
       </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
       <div class="form-field">
         {{ form.nacionalidad }}
         <button type="button" class="clear-btn">×</button>

--- a/templates/clubs/miembro_form.html
+++ b/templates/clubs/miembro_form.html
@@ -50,7 +50,7 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-md-6">
+      <div class="col-md-4">
         <div class="form-field">
           {{ form.telefono }}
           <button type="button" class="clear-btn">×</button>
@@ -62,7 +62,7 @@
           {% endif %}
         </div>
       </div>
-      <div class="col-md-6">
+      <div class="col-md-8">
         <div class="form-field">
           {{ form.email }}
           <button type="button" class="clear-btn">×</button>
@@ -76,7 +76,7 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-md-4">
+      <div class="col-md-3">
         <div class="form-field">
           {{ form.fecha_nacimiento }}
           <label for="{{ form.fecha_nacimiento.id_for_label }}">{{ form.fecha_nacimiento.label }}</label>
@@ -87,7 +87,7 @@
           {% endif %}
         </div>
       </div>
-      <div class="col-md-4">
+      <div class="col-md-3">
         <div class="form-field">
           {{ form.sexo }}
           <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
@@ -98,7 +98,7 @@
           {% endif %}
         </div>
       </div>
-      <div class="col-md-4">
+      <div class="col-md-3">
         <div class="form-field">
           {{ form.nacionalidad }}
           <button type="button" class="clear-btn">×</button>


### PR DESCRIPTION
## Summary
- tweak placeholders and Spain order in new member form
- adjust column widths for phone, birth date, gender and nationality
- highlight Spain with a bottom border in nationality dropdown

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687688b6db208321aa2d3ca6179c5118