### PR TITLE
Adjust add member modal

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -252,7 +252,7 @@ class EntrenadorForm(forms.ModelForm):
 
 class MiembroForm(forms.ModelForm):
     nacionalidad = forms.ChoiceField(
-        choices=[('', 'País')] + COUNTRY_CHOICES,
+        choices=[('', 'pais')] + COUNTRY_CHOICES,
         required=False,
     )
 
@@ -299,7 +299,7 @@ class MiembroForm(forms.ModelForm):
         nacionalidad_field = self.fields.get('nacionalidad')
         if nacionalidad_field:
             other = [c for c in COUNTRY_CHOICES if c[0] != 'España']
-            nacionalidad_field.choices = [('', 'País'), ('España', 'España')] + other
+            nacionalidad_field.choices = [('', 'pais'), ('España', 'España')] + other
 
         # Set default labels for new fields
         if 'localidad' in self.fields:

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -311,3 +311,18 @@ select option[value="España"] {
   border-bottom: 1px solid #ccc;
 }
 
+/* Add Member Modal custom sizing */
+#addMemberModalDialog {
+  max-width: 70%;
+}
+
+#addMemberModal .profile-form input,
+#addMemberModal .profile-form select,
+#addMemberModal .profile-form textarea {
+  width: auto;
+}
+
+#addMemberModal .profile-form select[name="estado"] {
+  width: auto;
+}
+

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -755,7 +755,7 @@
 
 <!-- Add Member Modal -->
 <div class="modal fade" id="addMemberModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-xl">
+  <div id="addMemberModalDialog" class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Nuevo miembro</h5>


### PR DESCRIPTION
## Summary
- shrink the add member modal width
- show "pais" placeholder for nationality
- make inputs in the add member modal autosize including a small state field

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68768bea0d0c8321aae411a7e66dbbad