### PR TITLE
Improve member modal UX

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -252,6 +252,7 @@ class EntrenadorForm(forms.ModelForm):
 
 class MiembroForm(forms.ModelForm):
     nacionalidad = forms.ChoiceField(
+        label='País',
         choices=[('', 'pais')] + COUNTRY_CHOICES,
         required=False,
     )

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -313,7 +313,7 @@ select option[value="España"] {
 
 /* Add Member Modal custom sizing */
 #addMemberModalDialog {
-  max-width: 70%;
+  max-width: 66.6667%;
 }
 
 #addMemberModal .profile-form input,

--- a/static/js/avatar-dropzone.js
+++ b/static/js/avatar-dropzone.js
@@ -1,5 +1,5 @@
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.avatar-dropzone').forEach(zone => {
+function initAvatarDropzones(context = document) {
+  context.querySelectorAll('.avatar-dropzone').forEach(zone => {
     const input = zone.querySelector('input[type="file"]');
     const preview = zone.querySelector('.avatar-preview');
     const msg = preview.querySelector('.avatar-dropzone-msg');
@@ -43,4 +43,10 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initAvatarDropzones();
 });
+
+window.initAvatarDropzones = initAvatarDropzones;

--- a/static/js/member-modal.js
+++ b/static/js/member-modal.js
@@ -28,6 +28,9 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(html => {
           if (editEl) {
             editEl.querySelector('.modal-body').innerHTML = html;
+            if (window.initAvatarDropzones) {
+              window.initAvatarDropzones(editEl);
+            }
             const form = editEl.querySelector('form');
             form.addEventListener('submit', e => {
               e.preventDefault();
@@ -50,6 +53,9 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(html => {
           if (addEl) {
             addEl.querySelector('.modal-body').innerHTML = html;
+            if (window.initAvatarDropzones) {
+              window.initAvatarDropzones(addEl);
+            }
             const form = addEl.querySelector('form');
             form.addEventListener('submit', e => {
               e.preventDefault();


### PR DESCRIPTION
## Summary
- open file dialog for avatar in dynamically loaded forms
- label nationality field as "País" and keep placeholder
- narrow add-member modal to 8 columns

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68769624e1e08321831f05b0e4b57ec4