### PR TITLE
Enable avatar click in new member modal

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -300,6 +300,8 @@ class MiembroForm(forms.ModelForm):
         if nacionalidad_field:
             other = [c for c in COUNTRY_CHOICES if c[0] != 'España']
             nacionalidad_field.choices = [('', 'País'), ('España', 'España')] + other
+            nacionalidad_field.label = 'País'
+            nacionalidad_field.widget.attrs['placeholder'] = 'País'
 
         # Set default labels for new fields
         if 'localidad' in self.fields:

--- a/static/js/avatar-dropzone.js
+++ b/static/js/avatar-dropzone.js
@@ -1,5 +1,6 @@
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.avatar-dropzone').forEach(zone => {
+function initAvatarDropzones(root = document) {
+  root.querySelectorAll('.avatar-dropzone').forEach(zone => {
+    if (zone.dataset.initialized) return;
     const input = zone.querySelector('input[type="file"]');
     const preview = zone.querySelector('.avatar-preview');
     const msg = preview.querySelector('.avatar-dropzone-msg');
@@ -42,5 +43,13 @@ document.addEventListener('DOMContentLoaded', () => {
         showFile(input.files[0]);
       }
     });
+
+    zone.dataset.initialized = 'true';
   });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initAvatarDropzones();
 });
+
+window.initAvatarDropzones = initAvatarDropzones;

--- a/static/js/member-modal.js
+++ b/static/js/member-modal.js
@@ -50,6 +50,9 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(html => {
           if (addEl) {
             addEl.querySelector('.modal-body').innerHTML = html;
+            if (window.initAvatarDropzones) {
+              window.initAvatarDropzones(addEl);
+            }
             const form = addEl.querySelector('form');
             form.addEventListener('submit', e => {
               e.preventDefault();


### PR DESCRIPTION
## Summary
- set nationality field label and placeholder to "País"
- support dynamic avatar dropzone initialization
- initialize dropzone when loading the new member modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68769b64cf8c8321bf89a6e385812ccc