### PR TITLE
Add modals for new coach and competitor

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -209,10 +209,13 @@ def competidor_create(request, slug):
             competidor.club = club
             competidor.save()
             messages.success(request, 'Competidor añadido correctamente.')
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+                return HttpResponse(status=204)
             return redirect('club_dashboard', slug=club.slug)
     else:
         form = CompetidorForm()
-    return render(request, 'clubs/competidor_form.html', {'form': form, 'club': club})
+    template = 'clubs/_competidor_form.html' if request.headers.get('x-requested-with') == 'XMLHttpRequest' else 'clubs/competidor_form.html'
+    return render(request, template, {'form': form, 'club': club})
 
 
 @login_required
@@ -263,10 +266,13 @@ def entrenador_create(request, slug):
             entrenador.save()
             form.save_m2m()
             messages.success(request, 'Entrenador añadido correctamente.')
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+                return HttpResponse(status=204)
             return redirect('club_dashboard', slug=club.slug)
     else:
         form = EntrenadorForm()
-    return render(request, 'clubs/entrenador_form.html', {'form': form, 'club': club})
+    template = 'clubs/_entrenador_form.html' if request.headers.get('x-requested-with') == 'XMLHttpRequest' else 'clubs/entrenador_form.html'
+    return render(request, template, {'form': form, 'club': club})
 
 
 @login_required

--- a/static/js/coach-modal.js
+++ b/static/js/coach-modal.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const addEl = document.getElementById('addCoachModal');
+  const addModal = addEl ? new bootstrap.Modal(addEl) : null;
+  const btn = document.querySelector('.add-coach-btn');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      const slug = btn.dataset.clubSlug;
+      fetch(`/clubs/${slug}/entrenador/nuevo/`, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+      })
+        .then(res => res.text())
+        .then(html => {
+          if (addEl) {
+            addEl.querySelector('.modal-body').innerHTML = html;
+            if (window.initAvatarDropzones) {
+              window.initAvatarDropzones(addEl);
+            }
+            const form = addEl.querySelector('form');
+            form.addEventListener('submit', e => {
+              e.preventDefault();
+              const fd = new FormData(form);
+              fetch(form.action, {
+                method: 'POST',
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                body: fd
+              }).then(() => window.location.reload());
+            });
+            addModal.show();
+          }
+        });
+    });
+  }
+});

--- a/static/js/competitor-modal.js
+++ b/static/js/competitor-modal.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const addEl = document.getElementById('addCompetitorModal');
+  const addModal = addEl ? new bootstrap.Modal(addEl) : null;
+  const btn = document.querySelector('.add-competitor-btn');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      const slug = btn.dataset.clubSlug;
+      fetch(`/clubs/${slug}/competidor/nuevo/`, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+      })
+        .then(res => res.text())
+        .then(html => {
+          if (addEl) {
+            addEl.querySelector('.modal-body').innerHTML = html;
+            if (window.initAvatarDropzones) {
+              window.initAvatarDropzones(addEl);
+            }
+            const form = addEl.querySelector('form');
+            form.addEventListener('submit', e => {
+              e.preventDefault();
+              const fd = new FormData(form);
+              fetch(form.action, {
+                method: 'POST',
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                body: fd
+              }).then(() => window.location.reload());
+            });
+            addModal.show();
+          }
+        });
+    });
+  }
+});

--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -1,0 +1,77 @@
+<form method="post" enctype="multipart/form-data" class="profile-form">
+  {% csrf_token %}
+    <div class="form-field">
+      <div class="avatar-dropzone">
+        {{ form.avatar }}
+        <div class="avatar-preview{% if competidor and competidor.avatar %} has-image{% endif %}"{% if competidor and competidor.avatar %} style="background-image:url('{{ competidor.avatar.url }}')"{% endif %}>
+          <div class="avatar-dropzone-msg">
+            <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+            <span>Sube avatar</span>
+          </div>
+        </div>
+      </div>
+      <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
+      {% if form.avatar.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.avatar.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    <div class="form-field">
+      {{ form.nombre }}
+      <button type="button" class="clear-btn">×</button>
+      <label for="{{ form.nombre.id_for_label }}">{{ form.nombre.label }}</label>
+      {% if form.nombre.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.nombre.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    <div class="form-field">
+      {{ form.record }}
+      <button type="button" class="clear-btn">×</button>
+      <label for="{{ form.record.id_for_label }}">{{ form.record.label }}</label>
+      {% if form.record.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.record.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    <div class="form-field">
+      {{ form.modalidad }}
+      <label for="{{ form.modalidad.id_for_label }}">{{ form.modalidad.label }}</label>
+      {% if form.modalidad.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.modalidad.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    <div class="form-field">
+      {{ form.peso }}
+      <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
+      {% if form.peso.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.peso.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    <div class="form-field">
+      {{ form.sexo }}
+      <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
+      {% if form.sexo.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.sexo.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    <div class="form-field">
+      {{ form.palmares }}
+      <label for="{{ form.palmares.id_for_label }}">{{ form.palmares.label }}</label>
+      {% if form.palmares.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.palmares.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    <button type="submit" class="btn btn-dark">Guardar</button>
+</form>

--- a/templates/clubs/_entrenador_form.html
+++ b/templates/clubs/_entrenador_form.html
@@ -1,0 +1,47 @@
+<form method="post" enctype="multipart/form-data" class="profile-form">
+  {% csrf_token %}
+    <div class="form-field">
+      <div class="avatar-dropzone">
+        {{ form.avatar }}
+        <div class="avatar-preview{% if entrenador and entrenador.avatar %} has-image{% endif %}"{% if entrenador and entrenador.avatar %} style="background-image:url('{{ entrenador.avatar.url }}')"{% endif %}>
+          <div class="avatar-dropzone-msg">
+            <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+            <span>Sube avatar</span>
+          </div>
+        </div>
+      </div>
+      <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
+      {% if form.avatar.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.avatar.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    {% for field in form %}
+      {% if field.name != 'avatar' %}
+        {% if field.field.widget.input_type == 'checkbox' %}
+        <div class="form-field checkbox-field">
+          {{ field }}
+          <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+          {% if field.errors %}
+          <div class="invalid-feedback d-block">
+            {{ field.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+        {% else %}
+        <div class="form-field">
+          {{ field }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+          {% if field.errors %}
+          <div class="invalid-feedback d-block">
+            {{ field.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+    <button type="submit" class="btn btn-dark">Guardar</button>
+</form>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -522,12 +522,10 @@
         </table>
       </div>
     </div>
-    <div id="tab-coaches" class="profile-section"> 
-      <form action="{% url 'entrenador_create' club.slug %}" method="get">
-    <button   type="submit"  class="btn btn-outline-dark mb-3 d-inline-flex align-items-center justify-content-center gap-2 btn-sm"  >
+    <div id="tab-coaches" class="profile-section">
+      <button type="button" class="btn btn-outline-dark mb-3 d-inline-flex align-items-center justify-content-center gap-2 btn-sm add-coach-btn" data-club-slug="{{ club.slug }}">
         <i class="bi bi-plus-circle icon-large"></i> Añadir entrenador
       </button>
-    </form>
   
       <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 g-4">
         {% for coach in club.entrenadores.all %}
@@ -564,15 +562,10 @@
       </div>
     </div>
     <div id="tab-competitors" class="profile-section">
-      
-      <form action="{% url 'competidor_create' club.slug %}" method="get" class="mb-3">
-  <button
-    type="submit"
-    class="btn btn-sm btn-outline-dark d-inline-flex align-items-center justify-content-center gap-2 btn-sm"
-  >
+
+      <button type="button" class="btn btn-sm btn-outline-dark d-inline-flex align-items-center justify-content-center gap-2 btn-sm add-competitor-btn mb-3" data-club-slug="{{ club.slug }}">
     <i class="bi bi-plus-circle icon-large"></i> Añadir competidor
   </button>
-</form>
 
       <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 g-4">
         {% for comp in club.competidores.all %}
@@ -766,6 +759,32 @@
   </div>
 </div>
 
+<!-- Add Coach Modal -->
+<div class="modal fade" id="addCoachModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-xl">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Nuevo entrenador</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>
+
+<!-- Add Competitor Modal -->
+<div class="modal fade" id="addCompetitorModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-xl">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Nuevo competidor</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>
+
 {% endblock %} {% block extra_js %}
 <script src="{% static 'js/profile-tabs.js' %}"></script>
 <script src="{% static 'js/feature-select.js' %}"></script>
@@ -775,4 +794,6 @@
 <script src="{% static 'js/delete-confirm.js' %}"></script>
 <script src="{% static 'js/payment-history.js' %}"></script>
 <script src="{% static 'js/member-modal.js' %}"></script>
+<script src="{% static 'js/coach-modal.js' %}"></script>
+<script src="{% static 'js/competitor-modal.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add partial forms for coach and competitor
- support AJAX modal rendering in views
- add JS handlers for coach/competitor modals
- load modals and JS in the dashboard template

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68769d10a8f08321ad481b5d47f5fbfc