### PR TITLE
Fix member modal save

### DIFF
--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -1,4 +1,4 @@
-<form method="post" enctype="multipart/form-data" class="profile-form">
+<form method="post" enctype="multipart/form-data" class="profile-form" action="{% if miembro %}{% url 'miembro_update' miembro.id %}{% else %}{% url 'miembro_create' club.slug %}{% endif %}">
   {% csrf_token %}
   <div class="form-field text-center">
     <div class="avatar-dropzone mx-auto">

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -636,22 +636,28 @@
             <tr>
               <td>
                 {{ m.nombre }} {{ m.apellidos }}
-                <button type="button" class="btn btn-sm btn-link view-member-btn" data-member-id="{{ m.id }}">
-                  <i class="bi bi-eye icon-large"></i>
+                <button type="button" class="btn btn-sm btn-link view-member-btn text-dark" data-member-id="{{ m.id }}">
+                  <i class="bi bi-eye icon-large text-dark"></i>
                 </button>
               </td>
               <td>{{ m.telefono }}</td>
               <td>{{ m.email }}</td>
               <td>{{ m.fecha_inscripcion|date:"d/m/Y" }}</td>
-              <td>{{ m.get_estado_display }}</td>
+              <td>
+                {% if m.estado == 'activo' %}
+                <span class="badge bg-success">Activo</span>
+                {% else %}
+                <span class="badge bg-danger">Inactivo</span>
+                {% endif %}
+              </td>
               <td>
                 {% if m.pago_mes_actual == 'completo' %}
                 <span class="badge bg-success">Completo</span>
                 {% else %}
                 <span class="badge bg-warning text-dark">Pendiente</span>
                 {% endif %}
-                <button type="button" class="btn btn-sm btn-link view-payments-btn" data-member-id="{{ m.id }}">
-                  <i class="bi bi-eye icon-large"></i>
+                <button type="button" class="btn btn-sm btn-link view-payments-btn text-dark" data-member-id="{{ m.id }}">
+                  <i class="bi bi-eye icon-large text-dark"></i>
                 </button>
               </td>
               <td>


### PR DESCRIPTION
## Summary
- ensure member form posts to the correct create/update URL
- dark eye icons and color-coded status badges for members

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL', 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6876a3821e2c8321829c07a5b7026d50