### PR TITLE
Fix badge colors in member dashboard

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -633,7 +633,7 @@
           </thead>
           <tbody>
             {% for m in members %}
-            <tr class="{% if m.estado == 'activo' %}table-success{% else %}table-danger{% endif %}">
+            <tr>
               <td>
                 {{ m.nombre }} {{ m.apellidos }}
                 <button type="button" class="btn btn-sm btn-link view-member-btn text-dark" data-member-id="{{ m.id }}">
@@ -647,7 +647,7 @@
                 {% if m.estado == 'activo' %}
                 <span class="badge bg-success">Activo</span>
                 {% else %}
-                <span class="badge bg-danger">Inactivo</span>
+                <span class="badge bg-warning text-dark">Inactivo</span>
                 {% endif %}
               </td>
               <td>


### PR DESCRIPTION
## Summary
- tweak table row styling in club member dashboard
- show yellow badge for inactive members

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6876b141522c8321a506fd09517317bb