### PR TITLE
Maintain floating labels on modal dropdowns

### DIFF
--- a/static/js/coach-modal.js
+++ b/static/js/coach-modal.js
@@ -15,6 +15,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (window.initAvatarDropzones) {
               window.initAvatarDropzones(addEl);
             }
+            if (window.initSelectLabels) {
+              window.initSelectLabels(addEl);
+            }
             const form = addEl.querySelector('form');
             form.addEventListener('submit', e => {
               e.preventDefault();

--- a/static/js/competitor-modal.js
+++ b/static/js/competitor-modal.js
@@ -15,6 +15,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (window.initAvatarDropzones) {
               window.initAvatarDropzones(addEl);
             }
+            if (window.initSelectLabels) {
+              window.initSelectLabels(addEl);
+            }
             const form = addEl.querySelector('form');
             form.addEventListener('submit', e => {
               e.preventDefault();

--- a/static/js/member-modal.js
+++ b/static/js/member-modal.js
@@ -28,6 +28,9 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(html => {
           if (editEl) {
             editEl.querySelector('.modal-body').innerHTML = html;
+            if (window.initSelectLabels) {
+              window.initSelectLabels(editEl);
+            }
             const form = editEl.querySelector('form');
             form.addEventListener('submit', e => {
               e.preventDefault();
@@ -52,6 +55,9 @@ document.addEventListener('DOMContentLoaded', () => {
             addEl.querySelector('.modal-body').innerHTML = html;
             if (window.initAvatarDropzones) {
               window.initAvatarDropzones(addEl);
+            }
+            if (window.initSelectLabels) {
+              window.initSelectLabels(addEl);
             }
             const form = addEl.querySelector('form');
             form.addEventListener('submit', e => {

--- a/static/js/select-label.js
+++ b/static/js/select-label.js
@@ -1,24 +1,26 @@
+function initSelectLabels(root = document) {
+  root.querySelectorAll('.form-field select').forEach(select => {
+    if (select.dataset.initSelectLabels) return;
 
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.form-field select').forEach((select) => {
+    const placeholder = select.querySelector('option[value=""]');
+    if (placeholder) {
+      placeholder.hidden = true;
+    }
+
     const update = () => {
       select.classList.toggle('has-value', select.value !== '');
     };
 
-    ['change', 'blur'].forEach((evt) => {
-      select.addEventListener(evt, update);
-    });
-
-  document.querySelectorAll('.form-field select').forEach(select => {
-    const update = () => {
-      if (select.value) {
-        select.classList.add('has-value');
-      } else {
-        select.classList.remove('has-value');
-      }
-    };
     select.addEventListener('change', update);
+    select.addEventListener('blur', update);
+
     update();
+    select.dataset.initSelectLabels = 'true';
   });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSelectLabels();
 });
 
+window.initSelectLabels = initSelectLabels;


### PR DESCRIPTION
## Summary
- ensure dropdown placeholder options stay hidden
- initialize floating labels after Ajax loads
- update modal scripts to re-run select floating logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68783e26e8a08321bb0e760bff445c24