### PR TITLE
Add confirmation modals for member edits

### DIFF
--- a/static/js/member-modal.js
+++ b/static/js/member-modal.js
@@ -2,9 +2,24 @@ document.addEventListener('DOMContentLoaded', () => {
   const profileEl = document.getElementById('memberProfileModal');
   const editEl = document.getElementById('editMemberModal');
   const addEl = document.getElementById('addMemberModal');
+  const confirmEl = document.getElementById('confirmEditModal');
   const profileModal = profileEl ? new bootstrap.Modal(profileEl) : null;
   const editModal = editEl ? new bootstrap.Modal(editEl) : null;
   const addModal = addEl ? new bootstrap.Modal(addEl) : null;
+  const confirmModal = confirmEl ? new bootstrap.Modal(confirmEl) : null;
+  let formToSubmit = null;
+
+  if (confirmEl) {
+    confirmEl.querySelector('.confirm-edit').addEventListener('click', () => {
+      if (!formToSubmit) return;
+      const fd = new FormData(formToSubmit);
+      fetch(formToSubmit.action, {
+        method: 'POST',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        body: fd
+      }).then(() => window.location.reload());
+    });
+  }
 
   document.querySelectorAll('.view-member-btn').forEach(btn => {
     btn.addEventListener('click', () => {
@@ -34,9 +49,14 @@ document.addEventListener('DOMContentLoaded', () => {
             const form = editEl.querySelector('form');
             form.addEventListener('submit', e => {
               e.preventDefault();
-              const fd = new FormData(form);
-              fetch(form.action, { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }, body: fd })
-                .then(() => window.location.reload());
+              formToSubmit = form;
+              if (confirmModal) {
+                confirmModal.show();
+              } else {
+                const fd = new FormData(form);
+                fetch(form.action, { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }, body: fd })
+                  .then(() => window.location.reload());
+              }
             });
             editModal.show();
           }

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -7,7 +7,7 @@
     <div class="profile-tab" data-target="tab-schedule">Horarios</div>
     <div class="profile-tab" data-target="tab-coaches">Entrenadores</div>
     <div class="profile-tab" data-target="tab-competitors">Competidores</div>
-    <div class="profile-tab" data-target="tab-members">Gestión de miembros</div>
+    <div class="profile-tab" data-target="tab-members">Gestión miembros</div>
     <div class="profile-tab" data-target="tab-bookings">Reservas</div>
   </div>
   <div class="profile-content">
@@ -664,7 +664,7 @@
                 <button type="button" class="btn btn-sm btn-link edit-member-btn text-dark" data-member-id="{{ m.id }}">
                   <i class="bi bi-pencil-square icon-large text-dark"></i>
                 </button>
-                <form method="post" action="{% url 'miembro_delete' m.id %}" class="d-inline">
+                <form method="post" action="{% url 'miembro_delete' m.id %}" class="d-inline delete-profile-form">
                   {% csrf_token %}
                   <button type="submit" class="btn btn-sm btn-link text-danger">
                     <i class="bi bi-dash-circle icon-large"></i>
@@ -696,7 +696,7 @@
 </div>
 <!-- Confirm Delete Modal -->
 <div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-xl">
+  <div class="modal-dialog modal-dialog-centered modal-sm">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Confirmar eliminación</h5>
@@ -708,6 +708,25 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
         <button type="button" class="btn btn-danger confirm-delete">Eliminar</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Confirm Edit Modal -->
+<div class="modal fade" id="confirmEditModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Confirmar cambios</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        ¿Seguro que deseas guardar los cambios?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-primary confirm-edit">Guardar</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- rename 'Gestión de miembros' tab to 'Gestión miembros'
- show delete confirmation when removing members
- shrink confirmation modals to small size and add edit confirmation modal
- require confirmation before submitting member edits

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6878490186e4832183b6e4f822931e30