### PR TITLE
Add confirmation prompt inside edit member modal

### DIFF
--- a/static/js/member-modal.js
+++ b/static/js/member-modal.js
@@ -2,12 +2,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const profileEl = document.getElementById('memberProfileModal');
   const editEl = document.getElementById('editMemberModal');
   const addEl = document.getElementById('addMemberModal');
-  const confirmEl = document.getElementById('confirmEditModal');
   const profileModal = profileEl ? new bootstrap.Modal(profileEl) : null;
   const editModal = editEl ? new bootstrap.Modal(editEl) : null;
   const addModal = addEl ? new bootstrap.Modal(addEl) : null;
-  const confirmModal = confirmEl ? new bootstrap.Modal(confirmEl) : null;
   let formToSubmit = null;
+  let confirmContainer = null;
 
   function bindMemberRow(row) {
     const viewBtn = row.querySelector('.view-member-btn');
@@ -40,14 +39,37 @@ document.addEventListener('DOMContentLoaded', () => {
               form.addEventListener('submit', e => {
                 e.preventDefault();
                 formToSubmit = form;
-                if (confirmModal) {
-                  confirmModal.show();
+                confirmContainer = form.querySelector('.confirm-edit-container');
+                if (confirmContainer) {
+                  confirmContainer.classList.remove('d-none');
                 } else {
                   const fd = new FormData(form);
                   fetch(form.action, { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }, body: fd })
                     .then(() => window.location.reload());
                 }
               });
+
+              confirmContainer = form.querySelector('.confirm-edit-container');
+              if (confirmContainer) {
+                const confirmBtn = confirmContainer.querySelector('.confirm-edit-btn');
+                const cancelBtn = confirmContainer.querySelector('.cancel-confirm');
+                if (confirmBtn) {
+                  confirmBtn.addEventListener('click', () => {
+                    if (!formToSubmit) return;
+                    const fd = new FormData(formToSubmit);
+                    fetch(formToSubmit.action, {
+                      method: 'POST',
+                      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                      body: fd
+                    }).then(() => window.location.reload());
+                  });
+                }
+                if (cancelBtn) {
+                  cancelBtn.addEventListener('click', () => {
+                    confirmContainer.classList.add('d-none');
+                  });
+                }
+              }
               editModal.show();
             }
           });
@@ -67,17 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  if (confirmEl) {
-    confirmEl.querySelector('.confirm-edit').addEventListener('click', () => {
-      if (!formToSubmit) return;
-      const fd = new FormData(formToSubmit);
-      fetch(formToSubmit.action, {
-        method: 'POST',
-        headers: { 'X-Requested-With': 'XMLHttpRequest' },
-        body: fd
-      }).then(() => window.location.reload());
-    });
-  }
+
 
   document.querySelectorAll('#tab-members tbody tr').forEach(tr => bindMemberRow(tr));
 

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -209,5 +209,12 @@
     </div>
     {% endif %}
   </div>
-  <button type="submit" class="btn btn-dark">Guardar</button>
+  <button type="submit" class="btn btn-dark save-btn">Guardar</button>
+  <div class="confirm-edit-container alert alert-warning mt-3 d-none" role="alert">
+    ¿Seguro que deseas guardar los cambios?
+    <div class="mt-2 d-flex justify-content-end gap-2">
+      <button type="button" class="btn btn-secondary btn-sm cancel-confirm">Cancelar</button>
+      <button type="button" class="btn btn-primary btn-sm confirm-edit-btn">Guardar</button>
+    </div>
+  </div>
 </form>

--- a/templates/clubs/miembro_form.html
+++ b/templates/clubs/miembro_form.html
@@ -191,7 +191,14 @@
       </div>
       {% endif %}
     </div>
-    <button type="submit" class="btn btn-dark">Guardar</button>
+    <button type="submit" class="btn btn-dark save-btn">Guardar</button>
+    <div class="confirm-edit-container alert alert-warning mt-3 d-none" role="alert">
+      ¿Seguro que deseas guardar los cambios?
+      <div class="mt-2 d-flex justify-content-end gap-2">
+        <button type="button" class="btn btn-secondary btn-sm cancel-confirm">Cancelar</button>
+        <button type="button" class="btn btn-primary btn-sm confirm-edit-btn">Guardar</button>
+      </div>
+    </div>
   </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show confirmation prompt directly inside the member form
- update JS to toggle new confirmation container

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68785199bfb48321891e8bd6ea5d2c21