### PR TITLE
Add realtime dashboard member filters

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -54,13 +54,13 @@ def dashboard(request, slug):
     members = club.miembros.all()
 
     # Filtros para los miembros
-    estado = request.GET.get('estado')
-    if estado in ['activo', 'inactivo']:
-        members = members.filter(estado=estado)
+    estados = [e for e in request.GET.getlist('estado') if e in ['activo', 'inactivo']]
+    if estados:
+        members = members.filter(estado__in=estados)
 
-    sexo = request.GET.get('sexo')
-    if sexo in ['M', 'F']:
-        members = members.filter(sexo=sexo)
+    sexos = [s for s in request.GET.getlist('sexo') if s in ['M', 'F']]
+    if sexos:
+        members = members.filter(sexo__in=sexos)
 
     peso_min = request.GET.get('peso_min')
     if peso_min:
@@ -76,8 +76,8 @@ def dashboard(request, slug):
     if altura_max:
         members = members.filter(altura__lte=altura_max)
 
-    pago = request.GET.get('pago')
-    if pago in ['completo', 'pendiente']:
+    pagos = [p for p in request.GET.getlist('pago') if p in ['completo', 'pendiente']]
+    if pagos:
         today = timezone.now().date()
         payment_qs = Pago.objects.filter(
             miembro=OuterRef('pk'),
@@ -85,7 +85,10 @@ def dashboard(request, slug):
             fecha__month=today.month,
         )
         members = members.annotate(has_payment=Exists(payment_qs))
-        members = members.filter(has_payment=(pago == 'completo'))
+        if 'completo' in pagos and 'pendiente' not in pagos:
+            members = members.filter(has_payment=True)
+        elif 'pendiente' in pagos and 'completo' not in pagos:
+            members = members.filter(has_payment=False)
 
     orden = request.GET.get('orden')
     if orden == 'alpha':

--- a/static/js/member-filter.js
+++ b/static/js/member-filter.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('member-filter-form');
+  if (!form) return;
+  form.querySelectorAll('input, select').forEach(el => {
+    el.addEventListener('change', () => {
+      form.submit();
+    });
+  });
+});

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -684,32 +684,61 @@
           </div>
         </div>
         <div class="col-lg-3">
-          <form method="get" class="vstack gap-2">
+          <form method="get" id="member-filter-form" class="vstack gap-2">
             <select name="orden" class="form-select form-select-sm">
               <option value="">Ordenar</option>
               <option value="alpha" {% if request.GET.orden == 'alpha' %}selected{% endif %}>A-Z</option>
               <option value="antiguedad" {% if request.GET.orden == 'antiguedad' %}selected{% endif %}>Antigüedad</option>
             </select>
-            <select name="estado" class="form-select form-select-sm">
-              <option value="">Estado</option>
-              <option value="activo" {% if request.GET.estado == 'activo' %}selected{% endif %}>Activo</option>
-              <option value="inactivo" {% if request.GET.estado == 'inactivo' %}selected{% endif %}>Inactivo</option>
-            </select>
-            <select name="pago" class="form-select form-select-sm">
-              <option value="">Pago</option>
-              <option value="completo" {% if request.GET.pago == 'completo' %}selected{% endif %}>Completo</option>
-              <option value="pendiente" {% if request.GET.pago == 'pendiente' %}selected{% endif %}>Pendiente</option>
-            </select>
-            <select name="sexo" class="form-select form-select-sm">
-              <option value="">Sexo</option>
-              <option value="M" {% if request.GET.sexo == 'M' %}selected{% endif %}>Masculino</option>
-              <option value="F" {% if request.GET.sexo == 'F' %}selected{% endif %}>Femenino</option>
-            </select>
-            <input type="number" step="0.01" name="peso_min" class="form-control form-control-sm" placeholder="Peso mín" value="{{ request.GET.peso_min }}">
-            <input type="number" step="0.01" name="peso_max" class="form-control form-control-sm" placeholder="Peso máx" value="{{ request.GET.peso_max }}">
-            <input type="number" step="0.01" name="altura_min" class="form-control form-control-sm" placeholder="Altura mín" value="{{ request.GET.altura_min }}">
-            <input type="number" step="0.01" name="altura_max" class="form-control form-control-sm" placeholder="Altura máx" value="{{ request.GET.altura_max }}">
-            <button type="submit" class="btn btn-primary btn-sm">Filtrar</button>
+            <div>
+              <span class="d-block small">Estado</span>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="estado" id="estado-activo" value="activo" {% if 'activo' in request.GET.getlist('estado') %}checked{% endif %}>
+                <label class="form-check-label" for="estado-activo">Activo</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="estado" id="estado-inactivo" value="inactivo" {% if 'inactivo' in request.GET.getlist('estado') %}checked{% endif %}>
+                <label class="form-check-label" for="estado-inactivo">Inactivo</label>
+              </div>
+            </div>
+            <div>
+              <span class="d-block small">Pago</span>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="pago" id="pago-completo" value="completo" {% if 'completo' in request.GET.getlist('pago') %}checked{% endif %}>
+                <label class="form-check-label" for="pago-completo">Completo</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="pago" id="pago-pendiente" value="pendiente" {% if 'pendiente' in request.GET.getlist('pago') %}checked{% endif %}>
+                <label class="form-check-label" for="pago-pendiente">Pendiente</label>
+              </div>
+            </div>
+            <div>
+              <span class="d-block small">Sexo</span>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="sexo" id="sexo-M" value="M" {% if 'M' in request.GET.getlist('sexo') %}checked{% endif %}>
+                <label class="form-check-label" for="sexo-M">Masculino</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="sexo" id="sexo-F" value="F" {% if 'F' in request.GET.getlist('sexo') %}checked{% endif %}>
+                <label class="form-check-label" for="sexo-F">Femenino</label>
+              </div>
+            </div>
+            <div class="row g-2">
+              <div class="col">
+                <input type="number" step="0.01" name="peso_min" class="form-control form-control-sm" placeholder="Peso mín" value="{{ request.GET.peso_min }}">
+              </div>
+              <div class="col">
+                <input type="number" step="0.01" name="peso_max" class="form-control form-control-sm" placeholder="Peso máx" value="{{ request.GET.peso_max }}">
+              </div>
+            </div>
+            <div class="row g-2">
+              <div class="col">
+                <input type="number" step="0.01" name="altura_min" class="form-control form-control-sm" placeholder="Altura mín" value="{{ request.GET.altura_min }}">
+              </div>
+              <div class="col">
+                <input type="number" step="0.01" name="altura_max" class="form-control form-control-sm" placeholder="Altura máx" value="{{ request.GET.altura_max }}">
+              </div>
+            </div>
           </form>
         </div>
       </div>
@@ -854,4 +883,5 @@
 <script src="{% static 'js/member-modal.js' %}"></script>
 <script src="{% static 'js/coach-modal.js' %}"></script>
 <script src="{% static 'js/competitor-modal.js' %}"></script>
+<script src="{% static 'js/member-filter.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support multi-select member filters in dashboard
- display filter groups as checkboxes and group numeric ranges
- auto-submit member filter form via new JS helper

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68785b4cce2c832189ba15cb5f742e38