### PR TITLE
Add realtime dashboard member filters

### DIFF
--- a/static/js/member-filter.js
+++ b/static/js/member-filter.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('member-filter-form');
+  if (!form) return;
+  form.querySelectorAll('input, select').forEach(el => {
+    el.addEventListener('change', () => {
+      form.submit();
+    });
+  });
+});

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -684,32 +684,61 @@
           </div>
         </div>
         <div class="col-lg-3">
-          <form method="get" class="vstack gap-2">
+          <form method="get" id="member-filter-form" class="vstack gap-2">
             <select name="orden" class="form-select form-select-sm">
               <option value="">Ordenar</option>
               <option value="alpha" {% if request.GET.orden == 'alpha' %}selected{% endif %}>A-Z</option>
               <option value="antiguedad" {% if request.GET.orden == 'antiguedad' %}selected{% endif %}>Antigüedad</option>
             </select>
-            <select name="estado" class="form-select form-select-sm">
-              <option value="">Estado</option>
-              <option value="activo" {% if request.GET.estado == 'activo' %}selected{% endif %}>Activo</option>
-              <option value="inactivo" {% if request.GET.estado == 'inactivo' %}selected{% endif %}>Inactivo</option>
-            </select>
-            <select name="pago" class="form-select form-select-sm">
-              <option value="">Pago</option>
-              <option value="completo" {% if request.GET.pago == 'completo' %}selected{% endif %}>Completo</option>
-              <option value="pendiente" {% if request.GET.pago == 'pendiente' %}selected{% endif %}>Pendiente</option>
-            </select>
-            <select name="sexo" class="form-select form-select-sm">
-              <option value="">Sexo</option>
-              <option value="M" {% if request.GET.sexo == 'M' %}selected{% endif %}>Masculino</option>
-              <option value="F" {% if request.GET.sexo == 'F' %}selected{% endif %}>Femenino</option>
-            </select>
-            <input type="number" step="0.01" name="peso_min" class="form-control form-control-sm" placeholder="Peso mín" value="{{ request.GET.peso_min }}">
-            <input type="number" step="0.01" name="peso_max" class="form-control form-control-sm" placeholder="Peso máx" value="{{ request.GET.peso_max }}">
-            <input type="number" step="0.01" name="altura_min" class="form-control form-control-sm" placeholder="Altura mín" value="{{ request.GET.altura_min }}">
-            <input type="number" step="0.01" name="altura_max" class="form-control form-control-sm" placeholder="Altura máx" value="{{ request.GET.altura_max }}">
-            <button type="submit" class="btn btn-primary btn-sm">Filtrar</button>
+            <div>
+              <span class="d-block small">Estado</span>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="estado" id="estado-activo" value="activo" {% if 'activo' in selected_estados %}checked{% endif %}>
+                <label class="form-check-label" for="estado-activo">Activo</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="estado" id="estado-inactivo" value="inactivo" {% if 'inactivo' in selected_estados %}checked{% endif %}>
+                <label class="form-check-label" for="estado-inactivo">Inactivo</label>
+              </div>
+            </div>
+            <div>
+              <span class="d-block small">Pago</span>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="pago" id="pago-completo" value="completo" {% if 'completo' in selected_pagos %}checked{% endif %}>
+                <label class="form-check-label" for="pago-completo">Completo</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="pago" id="pago-pendiente" value="pendiente" {% if 'pendiente' in selected_pagos %}checked{% endif %}>
+                <label class="form-check-label" for="pago-pendiente">Pendiente</label>
+              </div>
+            </div>
+            <div>
+              <span class="d-block small">Sexo</span>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="sexo" id="sexo-M" value="M" {% if 'M' in selected_sexos %}checked{% endif %}>
+                <label class="form-check-label" for="sexo-M">Masculino</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="sexo" id="sexo-F" value="F" {% if 'F' in selected_sexos %}checked{% endif %}>
+                <label class="form-check-label" for="sexo-F">Femenino</label>
+              </div>
+            </div>
+            <div class="row g-2">
+              <div class="col">
+                <input type="number" step="0.01" name="peso_min" class="form-control form-control-sm" placeholder="Peso mín" value="{{ request.GET.peso_min }}">
+              </div>
+              <div class="col">
+                <input type="number" step="0.01" name="peso_max" class="form-control form-control-sm" placeholder="Peso máx" value="{{ request.GET.peso_max }}">
+              </div>
+            </div>
+            <div class="row g-2">
+              <div class="col">
+                <input type="number" step="0.01" name="altura_min" class="form-control form-control-sm" placeholder="Altura mín" value="{{ request.GET.altura_min }}">
+              </div>
+              <div class="col">
+                <input type="number" step="0.01" name="altura_max" class="form-control form-control-sm" placeholder="Altura máx" value="{{ request.GET.altura_max }}">
+              </div>
+            </div>
           </form>
         </div>
       </div>
@@ -854,4 +883,5 @@
 <script src="{% static 'js/member-modal.js' %}"></script>
 <script src="{% static 'js/coach-modal.js' %}"></script>
 <script src="{% static 'js/competitor-modal.js' %}"></script>
+<script src="{% static 'js/member-filter.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support multi-select member filters in dashboard
- display filter groups as checkboxes and group numeric ranges
- auto-submit member filter form via new JS helper
- fix template error by passing selected filters from view

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68785b4cce2c832189ba15cb5f742e38