### PR TITLE
Fix filter usage in dashboard template

### DIFF
--- a/apps/core/templatetags/utils_filters.py
+++ b/apps/core/templatetags/utils_filters.py
@@ -90,3 +90,12 @@ def safe_url(file_field):
     except (ValueError, AttributeError):
         return ""
     return ""
+
+
+@register.filter
+def get_list(querydict, key):
+    """Return list of values for ``key`` in a ``QueryDict``."""
+    try:
+        return querydict.getlist(key)
+    except AttributeError:
+        return []

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -693,33 +693,33 @@
             <div>
               <span class="d-block small">Estado</span>
               <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" name="estado" id="estado-activo" value="activo" {% if 'activo' in request.GET.getlist('estado') %}checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="estado" id="estado-activo" value="activo" {% if 'activo' in request.GET|get_list:'estado' %}checked{% endif %}>
                 <label class="form-check-label" for="estado-activo">Activo</label>
               </div>
               <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" name="estado" id="estado-inactivo" value="inactivo" {% if 'inactivo' in request.GET.getlist('estado') %}checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="estado" id="estado-inactivo" value="inactivo" {% if 'inactivo' in request.GET|get_list:'estado' %}checked{% endif %}>
                 <label class="form-check-label" for="estado-inactivo">Inactivo</label>
               </div>
             </div>
             <div>
               <span class="d-block small">Pago</span>
               <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" name="pago" id="pago-completo" value="completo" {% if 'completo' in request.GET.getlist('pago') %}checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="pago" id="pago-completo" value="completo" {% if 'completo' in request.GET|get_list:'pago' %}checked{% endif %}>
                 <label class="form-check-label" for="pago-completo">Completo</label>
               </div>
               <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" name="pago" id="pago-pendiente" value="pendiente" {% if 'pendiente' in request.GET.getlist('pago') %}checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="pago" id="pago-pendiente" value="pendiente" {% if 'pendiente' in request.GET|get_list:'pago' %}checked{% endif %}>
                 <label class="form-check-label" for="pago-pendiente">Pendiente</label>
               </div>
             </div>
             <div>
               <span class="d-block small">Sexo</span>
               <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" name="sexo" id="sexo-M" value="M" {% if 'M' in request.GET.getlist('sexo') %}checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="sexo" id="sexo-M" value="M" {% if 'M' in request.GET|get_list:'sexo' %}checked{% endif %}>
                 <label class="form-check-label" for="sexo-M">Masculino</label>
               </div>
               <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" name="sexo" id="sexo-F" value="F" {% if 'F' in request.GET.getlist('sexo') %}checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="sexo" id="sexo-F" value="F" {% if 'F' in request.GET|get_list:'sexo' %}checked{% endif %}>
                 <label class="form-check-label" for="sexo-F">Femenino</label>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add `get_list` template filter for QueryDict values
- use new `get_list` filter instead of method calls in dashboard

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68785df2a6ec83219385274cbc2b2432