### PR TITLE
Add member search and sorting options

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -90,11 +90,21 @@ def dashboard(request, slug):
         elif 'pendiente' in pagos and 'completo' not in pagos:
             members = members.filter(has_payment=False)
 
+    search_q = request.GET.get('q', '').strip()
+    if search_q:
+        members = members.filter(
+            Q(nombre__icontains=search_q) | Q(apellidos__icontains=search_q)
+        )
+
     orden = request.GET.get('orden')
     if orden == 'alpha':
         members = members.order_by('nombre', 'apellidos')
-    elif orden == 'antiguedad':
+    elif orden == 'alpha_desc':
+        members = members.order_by('-nombre', '-apellidos')
+    elif orden == 'oldest':
         members = members.order_by('fecha_inscripcion')
+    elif orden == 'newest':
+        members = members.order_by('-fecha_inscripcion')
 
     bookings = Booking.objects.filter(
         Q(evento__club=club)

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -206,3 +206,8 @@ p {
         transform: translateX(0);
     }
 }
+
+/* Estilo para checkboxes en negro y blanco */
+input[type="checkbox"] {
+    accent-color: #000;
+}

--- a/static/js/member-filter.js
+++ b/static/js/member-filter.js
@@ -1,9 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
+  // Previously the form submitted automatically on input change.
+  // Se deshabilita el auto envío para que el filtrado solo ocurra
+  // al presionar el botón correspondiente.
   const form = document.getElementById('member-filter-form');
   if (!form) return;
-  form.querySelectorAll('input, select').forEach(el => {
-    el.addEventListener('change', () => {
-      form.submit();
-    });
-  });
+  // No listeners: el usuario debe pulsar "Filtrar".
 });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -685,10 +685,18 @@
         </div>
         <div class="col-lg-3">
           <form method="get" id="member-filter-form" class="vstack gap-2">
+            <input type="text" name="q" list="member-list" class="form-control form-control-sm" placeholder="Buscar miembro" value="{{ request.GET.q }}">
+            <datalist id="member-list">
+              {% for mem in club.miembros.all %}
+              <option value="{{ mem.nombre }} {{ mem.apellidos }}"></option>
+              {% endfor %}
+            </datalist>
             <select name="orden" class="form-select form-select-sm">
               <option value="">Ordenar</option>
               <option value="alpha" {% if request.GET.orden == 'alpha' %}selected{% endif %}>A-Z</option>
-              <option value="antiguedad" {% if request.GET.orden == 'antiguedad' %}selected{% endif %}>Antigüedad</option>
+              <option value="alpha_desc" {% if request.GET.orden == 'alpha_desc' %}selected{% endif %}>Z-A</option>
+              <option value="oldest" {% if request.GET.orden == 'oldest' %}selected{% endif %}>Más antiguos primero</option>
+              <option value="newest" {% if request.GET.orden == 'newest' %}selected{% endif %}>Más nuevos primero</option>
             </select>
             <div>
               <span class="d-block small fw-bold">Estado</span>


### PR DESCRIPTION
## Summary
- allow searching members in dashboard using datalist suggestions
- add ordering options for members (A-Z, Z-A, oldest, newest)
- disable auto filtering until pressing the filter button
- style checkboxes black and white

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6878632e69a883219ccb3d819709f22b