### PR TITLE
Improve member search and filters

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -323,3 +323,17 @@ select option[value="España"] {
   border-bottom: 1px solid #ccc;
 }
 
+.member-search-wrapper {
+  display: none;
+  align-items: center;
+}
+.member-search-wrapper.show {
+  display: inline-flex;
+}
+.member-search-input {
+  width: 0;
+  transition: width 0.3s ease;
+}
+.member-search-wrapper.show .member-search-input {
+  width: 160px;
+}

--- a/static/js/member-search.js
+++ b/static/js/member-search.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleBtn = document.getElementById('member-search-toggle');
+  const wrapper = document.getElementById('member-search-wrapper');
+  const input = document.getElementById('member-search-input');
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', () => {
+      if (wrapper) {
+        wrapper.classList.toggle('show');
+        if (wrapper.classList.contains('show')) {
+          input.focus();
+        } else {
+          input.value = '';
+        }
+      }
+    });
+  }
+  if (input) {
+    const listId = input.getAttribute('list');
+    input.addEventListener('input', () => {
+      if (input.value.trim().length > 0) {
+        input.setAttribute('list', listId);
+      } else {
+        input.removeAttribute('list');
+      }
+    });
+  }
+});

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -618,6 +618,18 @@
       <button type="button" class="btn btn-sm btn-outline-dark d-inline-flex align-items-center justify-content-center gap-2 btn-sm add-member-btn mb-3" data-club-slug="{{ club.slug }}">
         <i class="bi bi-plus-circle icon-large"></i> Añadir miembro
       </button>
+      <form method="get" id="member-search-form" class="d-inline-flex align-items-center gap-2 ms-2 mb-3">
+        <button type="button" id="member-search-toggle" class="btn btn-outline-dark"><i class="bi bi-search"></i></button>
+        <div id="member-search-wrapper" class="member-search-wrapper ms-2">
+          <input type="text" name="q" id="member-search-input" list="member-list" class="form-control form-control-sm member-search-input" placeholder="Buscar miembro" value="{{ request.GET.q }}">
+          <button type="submit" class="btn btn-dark btn-sm ms-1">Buscar</button>
+        </div>
+        <datalist id="member-list">
+          {% for mem in club.miembros.all %}
+          <option value="{{ mem.nombre }} {{ mem.apellidos }}"></option>
+          {% endfor %}
+        </datalist>
+      </form>
       <div class="row g-3">
         <div class="col-lg-9">
           <div class="table-responsive">
@@ -685,18 +697,11 @@
         </div>
         <div class="col-lg-3">
           <form method="get" id="member-filter-form" class="vstack gap-2">
-            <input type="text" name="q" list="member-list" class="form-control form-control-sm" placeholder="Buscar miembro" value="{{ request.GET.q }}">
-            <datalist id="member-list">
-              {% for mem in club.miembros.all %}
-              <option value="{{ mem.nombre }} {{ mem.apellidos }}"></option>
-              {% endfor %}
-            </datalist>
             <select name="orden" class="form-select form-select-sm">
-              <option value="">Ordenar</option>
-              <option value="alpha" {% if request.GET.orden == 'alpha' %}selected{% endif %}>A-Z</option>
-              <option value="alpha_desc" {% if request.GET.orden == 'alpha_desc' %}selected{% endif %}>Z-A</option>
+              <option value="alpha" {% if request.GET.orden == 'alpha' %}selected{% endif %}>Alfabético A-Z</option>
+              <option value="alpha_desc" {% if request.GET.orden == 'alpha_desc' %}selected{% endif %}>Alfabético Z-A</option>
               <option value="oldest" {% if request.GET.orden == 'oldest' %}selected{% endif %}>Más antiguos primero</option>
-              <option value="newest" {% if request.GET.orden == 'newest' %}selected{% endif %}>Más nuevos primero</option>
+              <option value="newest" {% if request.GET.orden == 'newest' %}selected{% endif %}>Más recientes primero</option>
             </select>
             <div>
               <span class="d-block small fw-bold">Estado</span>
@@ -731,6 +736,7 @@
                 <label class="form-check-label" for="sexo-F">Femenino</label>
               </div>
             </div>
+              <span class="d-block small fw-bold">Peso</span>
               <div class="row g-2">
                 <div class="col">
                   <input type="number" step="0.01" name="peso_min" class="form-control form-control-sm" placeholder="Peso mín" value="{{ request.GET.peso_min }}">
@@ -739,6 +745,7 @@
                   <input type="number" step="0.01" name="peso_max" class="form-control form-control-sm" placeholder="Peso máx" value="{{ request.GET.peso_max }}">
                 </div>
               </div>
+              <span class="d-block small fw-bold">Altura</span>
               <div class="row g-2">
                 <div class="col">
                   <input type="number" step="0.01" name="altura_min" class="form-control form-control-sm" placeholder="Altura mín" value="{{ request.GET.altura_min }}">
@@ -895,4 +902,5 @@
 <script src="{% static 'js/coach-modal.js' %}"></script>
 <script src="{% static 'js/competitor-modal.js' %}"></script>
 <script src="{% static 'js/member-filter.js' %}"></script>
+<script src="{% static 'js/member-search.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add expanding search bar for members on dashboard
- adjust member filter dropdown labels
- add labels for weight and height filters
- style search bar and add JS for interactive behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL' and 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68786745551c8321bcc8223675a4e90f