### PR TITLE
Improve member filters and search UX

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -102,9 +102,9 @@ def dashboard(request, slug):
     elif orden == 'alpha_desc':
         members = members.order_by('-nombre', '-apellidos')
     elif orden == 'oldest':
-        members = members.order_by('fecha_inscripcion')
+        members = members.order_by('fecha_inscripcion', 'id')
     elif orden == 'newest':
-        members = members.order_by('-fecha_inscripcion')
+        members = members.order_by('-fecha_inscripcion', '-id')
 
     bookings = Booking.objects.filter(
         Q(evento__club=club)

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -337,3 +337,37 @@ select option[value="España"] {
 .member-search-wrapper.show .member-search-input {
   width: 160px;
 }
+
+/* Generic search field with clear button and icon */
+.search-field {
+  position: relative;
+}
+
+.search-field input {
+  padding-right: 3rem;
+}
+
+.search-field .search-icon {
+  position: absolute;
+  right: 2.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: #6c757d;
+}
+
+.search-field .clear-btn {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1rem;
+  display: none;
+}
+
+.search-field input:not(:placeholder-shown) + .clear-btn {
+  display: block;
+}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -620,9 +620,11 @@
       </button>
       <form method="get" id="member-search-form" class="d-inline-flex align-items-center gap-2 ms-2 mb-3">
         <button type="button" id="member-search-toggle" class="btn btn-outline-dark"><i class="bi bi-search"></i></button>
-        <div id="member-search-wrapper" class="member-search-wrapper ms-2">
+        <div id="member-search-wrapper" class="member-search-wrapper ms-2 form-field search-field">
           <input type="text" name="q" id="member-search-input" list="member-list" class="form-control form-control-sm member-search-input" placeholder="Buscar miembro" value="{{ request.GET.q }}">
-          <button type="submit" class="btn btn-dark btn-sm ms-1">Buscar</button>
+          <button type="button" class="clear-btn">&times;</button>
+          <i class="bi bi-search search-icon"></i>
+          <button type="submit" class="btn btn-outline-dark btn-sm search-submit"><i class="bi bi-search"></i></button>
         </div>
         <datalist id="member-list">
           {% for mem in club.miembros.all %}
@@ -695,10 +697,14 @@
             </table>
           </div>
         </div>
-        <div class="col-lg-3">
-          <form method="get" id="member-search-form" class="d-flex gap-2 mb-3">
-            <input type="text" name="q" class="form-control form-control-sm" placeholder="Buscar miembro" value="{{ request.GET.q }}">
-            <button type="submit" class="btn btn-dark btn-sm">Buscar</button>
+        <div class="col-lg-2">
+          <form method="get" id="member-search-form" class="mb-3">
+            <div class="input-group input-group-sm form-field search-field">
+              <input type="text" name="q" class="form-control" placeholder="Buscar miembro" value="{{ request.GET.q }}">
+              <button type="button" class="clear-btn">&times;</button>
+              <i class="bi bi-search search-icon"></i>
+              <button type="submit" class="btn btn-outline-dark"><i class="bi bi-search"></i></button>
+            </div>
           </form>
           <form method="get" id="member-filter-form" class="vstack gap-2">
             <select name="orden" class="form-select form-select-sm">


### PR DESCRIPTION
## Summary
- tweak member order logic in dashboard view
- combine search button and input with clear option
- slim dashboard filter column and polish search field styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Django and PIL)*

------
https://chatgpt.com/codex/tasks/task_e_68786d63cc088321a37edada40161fd6