### PR TITLE
Improve members dashboard UX

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -344,7 +344,7 @@ select option[value="España"] {
 }
 
 .search-field input {
-  padding-right: 3rem;
+  padding-right: 5rem;
   padding-left: 2.25rem;
 }
 
@@ -380,9 +380,13 @@ select option[value="España"] {
   top: 50%;
   transform: translateY(-50%);
   border: none;
-  background: none;
-  padding: 0;
-  color: #000;
+  background: #000;
+  color: #fff;
+  padding: 0.125rem 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
 }
 
 .search-field input:focus {
@@ -403,13 +407,13 @@ select option[value="España"] {
 .custom-check:checked::after {
   content: "";
   position: absolute;
-  top: 50%;
+  top: 45%;
   left: 50%;
-  width: 0.5rem;
+  width: 0.25rem;
   height: 0.5rem;
-  border-radius: 50%;
-  background: #000;
-  transform: translate(-50%, -50%);
+  border: solid #000;
+  border-width: 0 1px 1px 0;
+  transform: translate(-50%, -50%) rotate(45deg);
 }
 
 /* Range slider */

--- a/static/js/member-filter.js
+++ b/static/js/member-filter.js
@@ -5,4 +5,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('member-filter-form');
   if (!form) return;
   // No listeners: el usuario debe pulsar "Filtrar".
+
+  const clearBtn = document.getElementById('clear-filter-btn');
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      window.location.href = window.location.pathname;
+    });
+  }
 });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -688,14 +688,14 @@
           <form method="get" id="member-search-form" class="mb-3">
             <div class="search-field">
               <input type="text" name="q" class="form-control form-control-sm" placeholder="Buscar miembro" value="{{ request.GET.q }}">
-              <button type="submit" class="search-btn"><i class="bi bi-search"></i></button>
+              <button type="submit" class="search-btn"><i class="bi bi-search"></i> Buscar</button>
               <button type="button" class="clear-btn">&times;</button>
             </div>
           </form>
           <form method="get" id="member-filter-form" class="vstack gap-2">
             <select name="orden" class="form-select form-select-sm">
-              <option value="alpha" {% if request.GET.orden == 'alpha' %}selected{% endif %}>Alfabético A-Z</option>
-              <option value="alpha_desc" {% if request.GET.orden == 'alpha_desc' %}selected{% endif %}>Alfabético Z-A</option>
+              <option value="alpha" {% if request.GET.orden == 'alpha' %}selected{% endif %}>Nombre A-Z</option>
+              <option value="alpha_desc" {% if request.GET.orden == 'alpha_desc' %}selected{% endif %}>Nombre Z-A</option>
               <option value="oldest" {% if request.GET.orden == 'oldest' %}selected{% endif %}>Más antiguos primero</option>
               <option value="newest" {% if request.GET.orden == 'newest' %}selected{% endif %}>Más recientes primero</option>
             </select>
@@ -758,6 +758,7 @@
               </div>
               <div class="text-end">
                 <button type="submit" class="btn btn-dark btn-sm">Filtrar</button>
+                <button type="button" id="clear-filter-btn" class="btn btn-outline-dark btn-sm ms-2">Limpiar</button>
               </div>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- add a clear filters button in members dashboard
- show `Buscar` text next to the search icon and make button black
- change ordering labels to `Nombre A-Z` and `Nombre Z-A`
- display a check mark inside custom radio buttons
- implement clear filter button logic

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6879a29076a48321a1d9dab2536da02a