### PR TITLE
Improve member search UX

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -430,7 +430,7 @@ select option[value="España"] {
 .range-slider .slider-wrapper {
   position: relative;
   height: 1px;
-  background: #000;
+  background: #eee;
 }
 
 .range-slider input[type=range] {

--- a/static/js/member-search.js
+++ b/static/js/member-search.js
@@ -1,27 +1,34 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const toggleBtn = document.getElementById('member-search-toggle');
-  const wrapper = document.getElementById('member-search-wrapper');
-  const input = document.getElementById('member-search-input');
-  if (toggleBtn) {
-    toggleBtn.addEventListener('click', () => {
-      if (wrapper) {
-        wrapper.classList.toggle('show');
-        if (wrapper.classList.contains('show')) {
-          input.focus();
-        } else {
-          input.value = '';
-        }
+  const input = document.querySelector('#member-search-form input[name="q"]');
+  if (!input) return;
+  const rows = Array.from(document.querySelectorAll('#tab-members tbody tr'));
+  const emptyRow = document.querySelector('#tab-members tbody .no-members-row');
+
+  const filter = () => {
+    const query = input.value.toLowerCase().trim();
+    let shown = 0;
+    rows.forEach(row => {
+      if (row.classList.contains('no-members-row')) return;
+      const text = row.innerText.toLowerCase();
+      if (!query || text.includes(query)) {
+        row.style.display = '';
+        shown++;
+      } else {
+        row.style.display = 'none';
       }
     });
-  }
-  if (input) {
-    const listId = input.getAttribute('list');
-    input.addEventListener('input', () => {
-      if (input.value.trim().length > 0) {
-        input.setAttribute('list', listId);
-      } else {
-        input.removeAttribute('list');
-      }
+    if (emptyRow) {
+      emptyRow.style.display = shown ? 'none' : '';
+    }
+  };
+
+  input.addEventListener('input', filter);
+
+  const clearBtn = document.querySelector('#member-search-form .clear-btn');
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      input.value = '';
+      filter();
     });
   }
 });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -618,9 +618,15 @@
       <button type="button" class="btn btn-sm btn-outline-dark d-inline-flex align-items-center justify-content-center gap-2 btn-sm add-member-btn mb-3" data-club-slug="{{ club.slug }}">
         <i class="bi bi-plus-circle icon-large"></i> Añadir miembro
       </button>
-      {# Buscador de miembros oculto para simplificar la interfaz #}
       <div class="row g-3">
         <div class="col-lg-9">
+          <form method="get" id="member-search-form" class="mb-3 text-end">
+            <div class="search-field">
+              <input type="text" name="q" class="form-control form-control-sm" placeholder="Buscar miembro" value="{{ request.GET.q }}">
+              <button type="submit" class="search-btn"><i class="bi bi-search"></i> Buscar</button>
+              <button type="button" class="clear-btn">&times;</button>
+            </div>
+          </form>
           <div class="table-responsive">
             <table class="table table-bordered text-center align-middle" style="min-width: 600px">
           <thead class="table-dark">
@@ -685,13 +691,6 @@
           </div>
         </div>
         <div class="col-3">
-          <form method="get" id="member-search-form" class="mb-3">
-            <div class="search-field">
-              <input type="text" name="q" class="form-control form-control-sm" placeholder="Buscar miembro" value="{{ request.GET.q }}">
-              <button type="submit" class="search-btn"><i class="bi bi-search"></i> Buscar</button>
-              <button type="button" class="clear-btn">&times;</button>
-            </div>
-          </form>
           <form method="get" id="member-filter-form" class="vstack gap-2">
             <select name="orden" class="form-select form-select-sm">
               <option value="alpha" {% if request.GET.orden == 'alpha' %}selected{% endif %}>Nombre A-Z</option>


### PR DESCRIPTION
## Summary
- move search bar above the members table
- support live filtering of member list
- tweak slider background color so the unselected range is light grey

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6879beafc32883219cc0ab069edc82c4