### PR TITLE
Add toggleable search field

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -324,18 +324,18 @@ select option[value="España"] {
 }
 
 .member-search-wrapper {
-  display: none;
-  align-items: center;
-}
-.member-search-wrapper.show {
   display: inline-flex;
+  align-items: center;
 }
 .member-search-input {
   width: 0;
   transition: width 0.3s ease;
+  overflow: hidden;
+  opacity: 0;
 }
 .member-search-wrapper.show .member-search-input {
   width: 160px;
+  opacity: 1;
 }
 
 /* Generic search field with clear button and icon */

--- a/static/js/member-search.js
+++ b/static/js/member-search.js
@@ -1,6 +1,15 @@
 document.addEventListener('DOMContentLoaded', () => {
   const input = document.querySelector('#member-search-form input[name="q"]');
-  if (!input) return;
+  const wrapper = document.querySelector('.member-search-wrapper');
+  const toggleBtn = document.getElementById('member-search-toggle');
+  if (!input || !wrapper || !toggleBtn) return;
+
+  toggleBtn.addEventListener('click', () => {
+    wrapper.classList.toggle('show');
+    if (wrapper.classList.contains('show')) {
+      input.focus();
+    }
+  });
   const rows = Array.from(document.querySelectorAll('#tab-members tbody tr'));
   const emptyRow = document.querySelector('#tab-members tbody .no-members-row');
 

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -615,18 +615,25 @@
       </div>
     </div>
     <div id="tab-members" class="profile-section">
-      <button type="button" class="btn btn-sm btn-outline-dark d-inline-flex align-items-center justify-content-center gap-2 btn-sm add-member-btn mb-3" data-club-slug="{{ club.slug }}">
-        <i class="bi bi-plus-circle icon-large"></i> Añadir miembro
-      </button>
-      <div class="row g-3">
-        <div class="col-lg-9">
-          <form method="get" id="member-search-form" class="mb-3 text-end">
+      <div class="d-flex align-items-center gap-2 mb-3">
+        <button type="button" class="btn btn-sm btn-outline-dark d-inline-flex align-items-center justify-content-center gap-2 btn-sm add-member-btn" data-club-slug="{{ club.slug }}">
+          <i class="bi bi-plus-circle icon-large"></i> Añadir miembro
+        </button>
+        <div class="member-search-wrapper ms-auto">
+          <button type="button" id="member-search-toggle" class="btn btn-sm btn-outline-dark">
+            <i class="bi bi-search"></i>
+          </button>
+          <form method="get" id="member-search-form" class="ms-2">
             <div class="search-field">
-              <input type="text" name="q" class="form-control form-control-sm" placeholder="Buscar miembro" value="{{ request.GET.q }}">
+              <input type="text" name="q" class="form-control form-control-sm member-search-input" placeholder="Buscar miembro" value="{{ request.GET.q }}">
               <button type="submit" class="search-btn"><i class="bi bi-search"></i> Buscar</button>
               <button type="button" class="clear-btn">&times;</button>
             </div>
           </form>
+        </div>
+      </div>
+      <div class="row g-3">
+        <div class="col-lg-9">
           <div class="table-responsive">
             <table class="table table-bordered text-center align-middle" style="min-width: 600px">
           <thead class="table-dark">


### PR DESCRIPTION
## Summary
- refine member search styles
- let the search icon toggle visibility of the member search input
- update dashboard markup for collapsible search

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6879c1dab6208321b82f5df20e439d35