### PR TITLE
Fix member search alignment and adjust grid columns

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -619,7 +619,7 @@
         <button type="button" class="btn btn-sm btn-outline-dark d-inline-flex align-items-center justify-content-center gap-2 btn-sm add-member-btn" data-club-slug="{{ club.slug }}">
           <i class="bi bi-plus-circle icon-large"></i> Añadir miembro
         </button>
-        <div class="member-search-wrapper ms-auto">
+        <div class="member-search-wrapper">
           <button type="button" id="member-search-toggle" class="btn btn-sm btn-outline-dark">
             <i class="bi bi-search"></i>
           </button>

--- a/templates/clubs/search_coaches.html
+++ b/templates/clubs/search_coaches.html
@@ -12,7 +12,7 @@
     </div>
 
     {% if coaches %}
-    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
+    <div class="row row-cols-1 row-cols-sm-3 row-cols-lg-4 g-4">
         {% for coach in coaches %}
         <div class="col">
             <div class="card h-100 border-0 shadow-sm">

--- a/templates/clubs/search_results.html
+++ b/templates/clubs/search_results.html
@@ -13,7 +13,7 @@
     </div>
 
     {% if clubs %}
-    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
+    <div class="row row-cols-1 row-cols-sm-3 row-cols-lg-4 g-4">
         {% for club in clubs %}
         <div class="col">
             <div class="card h-100 border-0 shadow-sm">


### PR DESCRIPTION
## Summary
- align the member search bar beside the "Añadir miembro" button
- display at least three columns in search results grids

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Django/Pillow)*

------
https://chatgpt.com/codex/tasks/task_e_6879c440d8ac83218c158c05b3a09de2