### PR TITLE
Modify member filters UI

### DIFF
--- a/static/js/member-table-filters.js
+++ b/static/js/member-table-filters.js
@@ -1,6 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const estadoItems = document.querySelectorAll('#estado-filter-menu .estado-option');
-  const pagoItems = document.querySelectorAll('#pago-filter-menu .pago-option');
+  const estadoForm = document.getElementById('estado-filter-menu');
+  const pagoForm = document.getElementById('pago-filter-menu');
+  const estadoBtn = document.getElementById('estado-filter-btn');
+  const pagoBtn = document.getElementById('pago-filter-btn');
   const rows = document.querySelectorAll('#tab-members tbody tr');
   const emptyRow = document.querySelector('#tab-members tbody .no-members-row');
 
@@ -27,21 +29,48 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  estadoItems.forEach(item => {
-    item.addEventListener('click', () => {
-      selectedEstado = item.dataset.value || '';
-      estadoItems.forEach(i => i.classList.remove('active'));
-      item.classList.add('active');
-      filterRows();
+  function restoreRadio(form, value) {
+    const radios = form.querySelectorAll('input[type="radio"]');
+    radios.forEach(r => {
+      r.checked = r.value === value;
     });
-  });
+  }
 
-  pagoItems.forEach(item => {
-    item.addEventListener('click', () => {
-      selectedPago = item.dataset.value || '';
-      pagoItems.forEach(i => i.classList.remove('active'));
-      item.classList.add('active');
+  if (estadoForm) {
+    const dd = bootstrap.Dropdown.getOrCreateInstance(estadoBtn);
+    estadoBtn.addEventListener('click', () => restoreRadio(estadoForm, selectedEstado));
+    estadoForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const checked = estadoForm.querySelector('input[name="estado-filter"]:checked');
+      selectedEstado = checked ? checked.value : '';
+      dd.hide();
       filterRows();
     });
-  });
+    const cancel = estadoForm.querySelector('.cancel-filter');
+    if (cancel) {
+      cancel.addEventListener('click', () => {
+        dd.hide();
+        restoreRadio(estadoForm, selectedEstado);
+      });
+    }
+  }
+
+  if (pagoForm) {
+    const dd = bootstrap.Dropdown.getOrCreateInstance(pagoBtn);
+    pagoBtn.addEventListener('click', () => restoreRadio(pagoForm, selectedPago));
+    pagoForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const checked = pagoForm.querySelector('input[name="pago-filter"]:checked');
+      selectedPago = checked ? checked.value : '';
+      dd.hide();
+      filterRows();
+    });
+    const cancel = pagoForm.querySelector('.cancel-filter');
+    if (cancel) {
+      cancel.addEventListener('click', () => {
+        dd.hide();
+        restoreRadio(pagoForm, selectedPago);
+      });
+    }
+  }
 });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -642,26 +642,44 @@
                 <div class="dropdown d-inline">
                   <span>Estado</span>
                   <button class="btn btn-link p-0 ms-1" type="button" id="estado-filter-btn" data-bs-toggle="dropdown" aria-expanded="false">
-                    <i class="bi bi-funnel-fill"></i>
+                    <i class="bi bi-funnel-fill text-white"></i>
                   </button>
-                  <ul class="dropdown-menu" aria-labelledby="estado-filter-btn" id="estado-filter-menu">
-                    <li><button class="dropdown-item estado-option" data-value="">Todos</button></li>
-                    <li><button class="dropdown-item estado-option" data-value="activo">Activo</button></li>
-                    <li><button class="dropdown-item estado-option" data-value="inactivo">Inactivo</button></li>
-                  </ul>
+                  <form class="dropdown-menu p-2" aria-labelledby="estado-filter-btn" id="estado-filter-menu">
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="estado-filter" id="estado-dd-activo" value="activo">
+                      <label class="form-check-label" for="estado-dd-activo">Activo</label>
+                    </div>
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="estado-filter" id="estado-dd-inactivo" value="inactivo">
+                      <label class="form-check-label" for="estado-dd-inactivo">Inactivo</label>
+                    </div>
+                    <div class="d-flex justify-content-end gap-2 mt-2">
+                      <button type="button" class="btn btn-outline-secondary btn-sm cancel-filter">Cancelar</button>
+                      <button type="submit" class="btn btn-dark btn-sm apply-filter">Filtrar</button>
+                    </div>
+                  </form>
                 </div>
               </th>
               <th>
                 <div class="dropdown d-inline">
                   <span>Pagos</span>
                   <button class="btn btn-link p-0 ms-1" type="button" id="pago-filter-btn" data-bs-toggle="dropdown" aria-expanded="false">
-                    <i class="bi bi-funnel-fill"></i>
+                    <i class="bi bi-funnel-fill text-white"></i>
                   </button>
-                  <ul class="dropdown-menu" aria-labelledby="pago-filter-btn" id="pago-filter-menu">
-                    <li><button class="dropdown-item pago-option" data-value="">Todos</button></li>
-                    <li><button class="dropdown-item pago-option" data-value="completo">Completo</button></li>
-                    <li><button class="dropdown-item pago-option" data-value="pendiente">Pendiente</button></li>
-                  </ul>
+                  <form class="dropdown-menu p-2" aria-labelledby="pago-filter-btn" id="pago-filter-menu">
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="pago-filter" id="pago-dd-completo" value="completo">
+                      <label class="form-check-label" for="pago-dd-completo">Completo</label>
+                    </div>
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="pago-filter" id="pago-dd-pendiente" value="pendiente">
+                      <label class="form-check-label" for="pago-dd-pendiente">Pendiente</label>
+                    </div>
+                    <div class="d-flex justify-content-end gap-2 mt-2">
+                      <button type="button" class="btn btn-outline-secondary btn-sm cancel-filter">Cancelar</button>
+                      <button type="submit" class="btn btn-dark btn-sm apply-filter">Filtrar</button>
+                    </div>
+                  </form>
                 </div>
               </th>
               <th></th>


### PR DESCRIPTION
## Summary
- style the table filter icons in white
- convert dropdown filter menus into forms with radio options
- add Cancelar and Filtrar buttons in each filter
- update member-table-filters.js to handle new dropdown behaviour

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a80d2eefc8321bf5fb698f07c55f1