### PR TITLE
Improve search field UX on member dashboard

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -342,7 +342,6 @@ select option[value="España"] {
 
 .member-search-form.open {
   width: 220px;
-  border: 1px solid #ced4da;
 }
 
 .member-search-form input {
@@ -352,12 +351,19 @@ select option[value="España"] {
   padding: 0 0.5rem;
   opacity: 0;
   width: 0;
-  transition: opacity 0.3s ease;
+  border-bottom: 1px solid transparent;
+  transition: opacity 0.3s ease, border-bottom-color 0.3s ease;
 }
 
 .member-search-form.open input {
   opacity: 1;
   width: auto;
+  border-bottom-color: #ced4da;
+}
+
+.member-search-form input:focus {
+  outline: none;
+  box-shadow: none;
 }
 
 .member-search-form .search-icon {

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -622,8 +622,8 @@
         </button>
         <div class="member-search">
           <form method="get" id="member-search-form" class="member-search-form">
-            <input type="text" name="q" id="member-search-input" placeholder="Buscar miembro" value="{{ request.GET.q }}" autocomplete="off">
             <button type="submit" class="search-icon"><i class="bi bi-search"></i></button>
+            <input type="text" name="q" id="member-search-input" placeholder="Buscar miembro" value="{{ request.GET.q }}" autocomplete="off">
             <button type="button" class="close-icon">&times;</button>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- expand the search field from the left button
- show only a bottom border and remove focus outlines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687a88290f10832183e8c7cf61deef55