### PR TITLE
Fix inactive badge and adjust member table

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -376,6 +376,9 @@ select option[value="España"] {
   justify-content: center;
   cursor: pointer;
 }
+.member-search-form .search-icon i {
+  font-size: 1.25rem;
+}
 
 .member-search-form .close-icon {
   display: none;

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -659,7 +659,7 @@
               <th>Teléfono</th>
               <th>Email</th>
               <th>Inscrito</th>
-              <th>
+              <th class="text-nowrap" style="width:1%">
                 <div class="dropdown d-inline">
                   <span>Estado</span>
                   <button class="btn btn-link p-0 ms-1" type="button" id="estado-filter-btn" data-bs-toggle="dropdown" aria-expanded="false">
@@ -681,7 +681,7 @@
                   </form>
                 </div>
               </th>
-              <th>
+              <th class="text-nowrap" style="width:1%">
                 <div class="dropdown d-inline">
                   <span>Pagos</span>
                   <button class="btn btn-link p-0 ms-1" type="button" id="pago-filter-btn" data-bs-toggle="dropdown" aria-expanded="false">
@@ -718,14 +718,14 @@
               <td>{{ m.telefono }}</td>
               <td>{{ m.email }}</td>
               <td>{{ m.fecha_inscripcion|date:"d/m/Y" }}</td>
-              <td>
+              <td class="text-nowrap">
                 {% if m.estado == 'activo' %}
-                <span class="badge p-2 bg-success ">Activo</span>
+                <span class="badge p-2 bg-success">Activo</span>
                 {% else %}
-                <span class="badge  p-2bg-secondary">Inactivo</span>
+                <span class="badge p-2 bg-secondary">Inactivo</span>
                 {% endif %}
               </td>
-              <td>
+              <td class="text-nowrap">
                 {% if m.pago_mes_actual == 'completo' %}
                 <span class="badge p-2 bg-primary">Completo</span>
                 {% else %}


### PR DESCRIPTION
## Summary
- equalize active/inactive badges in the members table
- use gray inactive badge
- keep Estado and Pagos columns narrow
- enlarge the search icon

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687a8b62516c832181de7bd1db37b10d