### PR TITLE
Fix members table layout

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -522,3 +522,15 @@ select option[value="España"] {
   background: #000;
   top: 0;
 }
+
+/* Members table adjustments */
+#tab-members .members-table-responsive {
+  overflow-x: auto;
+  overflow-y: visible;
+}
+
+#tab-members .phone-column,
+#tab-members .actions-column {
+  width: 1%;
+  white-space: nowrap;
+}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -649,14 +649,14 @@
           </div>
         </form>
       </div>
-      <div class="row g-3">
-        <div class="col-12">
-          <div class="table-responsive">
+        <div class="row g-3">
+          <div class="col-12">
+          <div class="table-responsive members-table-responsive">
             <table class="table table-bordered text-center align-middle" style="min-width: 600px">
           <thead class="table-dark">
             <tr>
               <th>Miembro</th>
-              <th>Teléfono</th>
+              <th class="text-nowrap phone-column">Teléfono</th>
               <th>Email</th>
               <th>Inscrito</th>
               <th class="text-nowrap" style="width:1%">
@@ -703,11 +703,11 @@
                   </form>
                 </div>
               </th>
-              <th></th>
+              <th class="actions-column"></th>
             </tr>
           </thead>
           <tbody>
-{% for m in members %}
+  {% for m in members %}
             <tr data-estado="{{ m.estado }}" data-pago="{{ m.pago_mes_actual }}">
               <td>
                 {{ m.nombre }} {{ m.apellidos }}
@@ -715,7 +715,7 @@
              <i class="bi bi-person-bounding-box"></i>
                 </button>
               </td>
-              <td>{{ m.telefono }}</td>
+              <td class="phone-column">{{ m.telefono }}</td>
               <td>{{ m.email }}</td>
               <td>{{ m.fecha_inscripcion|date:"d/m/Y" }}</td>
               <td class="text-nowrap">
@@ -735,7 +735,7 @@
 <i class="bi bi-kanban"></i>
                 </button>
               </td>
-              <td>
+              <td class="actions-column">
                 <button type="button" class="btn btn-sm btn-link edit-member-btn text-dark" data-member-id="{{ m.id }}">
                   <i class="bi bi-pencil-square icon-large text-dark"></i>
                 </button>


### PR DESCRIPTION
## Summary
- tweak members table to adapt phone and actions columns
- allow filter dropdowns to display fully

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687a8e8c3624832193fc0704b654c2bd