### PR TITLE
Improve matchmaker card hover

### DIFF
--- a/static/css/matchmaker.css
+++ b/static/css/matchmaker.css
@@ -1,7 +1,34 @@
 .matchmaker-card {
   border: 1px solid #dee2e6;
   border-radius: 0.25rem;
+  perspective: 1000px;
 }
+
+.matchmaker-card .matchmaker-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.matchmaker-card:hover .matchmaker-inner {
+  transform: rotateY(180deg);
+}
+
+.matchmaker-card .matchmaker-front,
+.matchmaker-card .matchmaker-back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+}
+
+.matchmaker-card .matchmaker-back {
+  transform: rotateY(180deg);
+  background-color: #000;
+  color: #fff;
+}
+
 .matchmaker-card .competitor-avatar,
 .matchmaker-card .competitor-avatar-img {
   width: 60px;

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1086,8 +1086,9 @@
             {% for c in match_results %}
             <div class="col">
               <div class="card matchmaker-card h-100">
-                <div class="card-body">
-                  <div class="d-flex align-items-center mb-2">
+                <div class="matchmaker-inner">
+                  <div class="matchmaker-front card-body">
+                    <div class="d-flex align-items-center mb-2">
                     {% if c.avatar %}
                       <img src="{{ c.avatar.url }}" alt="{{ c.nombre }}" class="competitor-avatar-img me-2">
                     {% else %}
@@ -1098,30 +1099,33 @@
                       <div class="small text-muted">{{ c.club.name }} - {{ c.club.city }}</div>
                     </div>
                   </div>
-                  <div class="row text-center">
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Peso</span>
-                      <span>{{ c.peso|default:'—' }}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Edad</span>
-                      <span>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Sexo</span>
-                      <span>{{ c.get_sexo_display|default:'—' }}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Altura</span>
-                      <span>{{ c.altura|default:'—' }}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Categoria</span>
-                      <span>—</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Record</span>
-                      <span>—</span>
+                  </div>
+                  <div class="matchmaker-back card-body d-flex align-items-center">
+                    <div class="row text-center w-100">
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Peso</span>
+                        <span>{{ c.peso|default:'—' }}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Edad</span>
+                        <span>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Sexo</span>
+                        <span>{{ c.get_sexo_display|default:'—' }}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Altura</span>
+                        <span>{{ c.altura|default:'—' }}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Categoria</span>
+                        <span>—</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Record</span>
+                        <span>—</span>
+                      </div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- restyle matchmaker cards with a flip animation
- reveal more competitor info on hover

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Django & PIL)*

------
https://chatgpt.com/codex/tasks/task_e_687c2ee5a05883219468d69f2adfaff5