### PR TITLE
Improve matchmaker card hover

### DIFF
--- a/static/css/matchmaker.css
+++ b/static/css/matchmaker.css
@@ -1,0 +1,10 @@
+.matchmaker-card {
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+}
+.matchmaker-card .competitor-avatar,
+.matchmaker-card .competitor-avatar-img {
+  width: 60px;
+  height: 60px;
+  font-size: 1rem;
+}

--- a/static/css/matchmaker.css
+++ b/static/css/matchmaker.css
@@ -1,7 +1,42 @@
 .matchmaker-card {
+  width: 400px;
+  height: 600px;
   border: 1px solid #dee2e6;
   border-radius: 0.25rem;
+  perspective: 1000px;
+  overflow: hidden;
+  margin: auto;
 }
+
+.matchmaker-card .matchmaker-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.matchmaker-card:hover .matchmaker-inner {
+  transform: rotateY(180deg);
+}
+
+.matchmaker-card .matchmaker-front,
+.matchmaker-card .matchmaker-back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.matchmaker-card .matchmaker-back {
+  transform: rotateY(180deg);
+  background-color: #000;
+  color: #fff;
+  align-items: center;
+  justify-content: center;
+}
+
 .matchmaker-card .competitor-avatar,
 .matchmaker-card .competitor-avatar-img {
   width: 60px;

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1085,43 +1085,47 @@
           <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3">
             {% for c in match_results %}
             <div class="col">
-              <div class="card matchmaker-card h-100">
-                <div class="card-body">
-                  <div class="d-flex align-items-center mb-2">
+              <div class="card text-center matchmaker-card">
+                <div class="matchmaker-inner">
+                  <div class="matchmaker-front">
                     {% if c.avatar %}
-                      <img src="{{ c.avatar.url }}" alt="{{ c.nombre }}" class="competitor-avatar-img me-2">
+                      <img src="{{ c.avatar.url }}" class="card-img-top object-fit-cover" style="height: 200px" alt="{{ c.nombre }}" />
                     {% else %}
-                      <div class="competitor-avatar me-2">{{ c.nombre|initials }}</div>
+                      <div class="card-img-top d-flex align-items-center justify-content-center bg-light" style="height: 200px">
+                        <span class="text-muted">{{ c.nombre|initials }}</span>
+                      </div>
                     {% endif %}
-                    <div>
+                    <div class="card-body p-2">
                       <div class="fw-bold">{{ c.nombre }} {{ c.apellidos }}</div>
                       <div class="small text-muted">{{ c.club.name }} - {{ c.club.city }}</div>
                     </div>
                   </div>
-                  <div class="row text-center">
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Peso</span>
-                      <span>{{ c.peso|default:'—' }}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Edad</span>
-                      <span>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Sexo</span>
-                      <span>{{ c.get_sexo_display|default:'—' }}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Altura</span>
-                      <span>{{ c.altura|default:'—' }}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Categoria</span>
-                      <span>—</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Record</span>
-                      <span>—</span>
+                  <div class="matchmaker-back card-body">
+                    <div class="row text-center w-100 mx-0">
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Peso</span>
+                        <span>{{ c.peso|default:'—' }}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Edad</span>
+                        <span>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Sexo</span>
+                        <span>{{ c.get_sexo_display|default:'—' }}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Altura</span>
+                        <span>{{ c.altura|default:'—' }}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Categoria</span>
+                        <span>—</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Record</span>
+                        <span>—</span>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -952,41 +952,8 @@
     </div>
     <div id="tab-matchmaker" class="profile-section">
       <div class="row g-3">
-        <div class="col-lg-9">
-          <div class="table-responsive">
-            <table
-              class="table table-bordered text-center align-middle"
-              style="min-width: 600px"
-            >
-              <thead class="table-dark">
-                <tr>
-                  <th>Nombre</th>
-                  <th>Club</th>
-                  <th>Ciudad</th>
-                  <th>Peso</th>
-                  <th>Edad</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for c in match_results %}
-                <tr>
-                  <td>{{ c.nombre }} {{ c.apellidos }}</td>
-                  <td>{{ c.club.name }}</td>
-                  <td>{{ c.club.city }}</td>
-                  <td>{{ c.peso|default:'—' }}</td>
-                  <td>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</td>
-                </tr>
-                {% empty %}
-                <tr class="no-match-row">
-                  <td colspan="5" class="text-muted">No hay competidores.</td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </div>
-        <div class="col-3">
-          <form method="get" id="matchmaker-filter-form" class="vstack gap-2">
+        <div class="col-12">
+          <form method="get" id="matchmaker-filter-form" class="vstack gap-2 mb-3">
             <div>
               <span class="d-block small fw-bold">Sexo</span>
               <div
@@ -1114,10 +1081,62 @@
             </div>
           </form>
         </div>
+        <div class="col-12">
+          <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3">
+            {% for c in match_results %}
+            <div class="col">
+              <div class="card matchmaker-card h-100">
+                <div class="card-body">
+                  <div class="d-flex align-items-center mb-2">
+                    {% if c.avatar %}
+                      <img src="{{ c.avatar.url }}" alt="{{ c.nombre }}" class="competitor-avatar-img me-2">
+                    {% else %}
+                      <div class="competitor-avatar me-2">{{ c.nombre|initials }}</div>
+                    {% endif %}
+                    <div>
+                      <div class="fw-bold">{{ c.nombre }} {{ c.apellidos }}</div>
+                      <div class="small text-muted">{{ c.club.name }} - {{ c.club.city }}</div>
+                    </div>
+                  </div>
+                  <div class="row text-center">
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Peso</span>
+                      <span>{{ c.peso|default:'—' }}</span>
+                    </div>
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Edad</span>
+                      <span>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</span>
+                    </div>
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Sexo</span>
+                      <span>{{ c.get_sexo_display|default:'—' }}</span>
+                    </div>
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Altura</span>
+                      <span>{{ c.altura|default:'—' }}</span>
+                    </div>
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Categoria</span>
+                      <span>—</span>
+                    </div>
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Record</span>
+                      <span>—</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% empty %}
+            <div class="col">
+              <p class="text-muted">No hay competidores.</p>
+            </div>
+            {% endfor %}
+          </div>
+        </div>
       </div>
     </div>
   </div>
-</div>
 <!-- Confirm Delete Modal -->
 <div
   class="modal fade"


### PR DESCRIPTION
## Summary
- restyle matchmaker cards with a flip animation and competitor-like layout
- set card size to 400x600

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Django & PIL)*

------
https://chatgpt.com/codex/tasks/task_e_687c2ee5a05883219468d69f2adfaff5