### PR TITLE
Improve schedule display on dashboard

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -426,16 +426,22 @@
                 <div
                   class="small fw-medium d-flex justify-content-between align-items-center border rounded p-1 mb-1"
                 >
-                  <span>
-                    {% if bloque.estado == 'abierto' %} {{
-                    bloque.hora_inicio|time:'H:i' }} - {{
-                    bloque.hora_fin|time:'H:i' }} {% elif bloque.estado ==
-                    'cerrado' %}
-                    <span class="text-danger">Cerrado</span>
+                  <div>
+                    {% if bloque.estado == 'abierto' %}
+                      <div
+                        class="py-1 schedule-item"
+                        data-start="{{ bloque.hora_inicio|time:'H:i' }}"
+                        data-end="{{ bloque.hora_fin|time:'H:i' }}"
+                      >
+                        {{ bloque.hora_inicio|time:'H:i' }} -
+                        {{ bloque.hora_fin|time:'H:i' }}
+                      </div>
+                    {% elif bloque.estado == 'cerrado' %}
+                      <div class="py-1 text-danger">Cerrado</div>
                     {% else %}
-                    <span class="text-muted">{{ bloque.estado_otro }}</span>
+                      <div class="py-1 text-muted">{{ bloque.estado_otro }}</div>
                     {% endif %}
-                  </span>
+                  </div>
                   <span>
                     <!-- Editar -->
                     <a


### PR DESCRIPTION
## Summary
- show schedule blocks in Dashboard the same way as club profile

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687c3437121c83219ddcd11149572d14