### PR TITLE
Improve schedule display on dashboard

### DIFF
--- a/static/css/matchmaker.css
+++ b/static/css/matchmaker.css
@@ -1,0 +1,10 @@
+.matchmaker-card {
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+}
+.matchmaker-card .competitor-avatar,
+.matchmaker-card .competitor-avatar-img {
+  width: 60px;
+  height: 60px;
+  font-size: 1rem;
+}

--- a/static/css/matchmaker.css
+++ b/static/css/matchmaker.css
@@ -1,7 +1,34 @@
 .matchmaker-card {
   border: 1px solid #dee2e6;
   border-radius: 0.25rem;
+  perspective: 1000px;
 }
+
+.matchmaker-card .matchmaker-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.matchmaker-card:hover .matchmaker-inner {
+  transform: rotateY(180deg);
+}
+
+.matchmaker-card .matchmaker-front,
+.matchmaker-card .matchmaker-back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+}
+
+.matchmaker-card .matchmaker-back {
+  transform: rotateY(180deg);
+  background-color: #000;
+  color: #fff;
+}
+
 .matchmaker-card .competitor-avatar,
 .matchmaker-card .competitor-avatar-img {
   width: 60px;

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1086,8 +1086,9 @@
             {% for c in match_results %}
             <div class="col">
               <div class="card matchmaker-card h-100">
-                <div class="card-body">
-                  <div class="d-flex align-items-center mb-2">
+                <div class="matchmaker-inner">
+                  <div class="matchmaker-front card-body">
+                    <div class="d-flex align-items-center mb-2">
                     {% if c.avatar %}
                       <img src="{{ c.avatar.url }}" alt="{{ c.nombre }}" class="competitor-avatar-img me-2">
                     {% else %}
@@ -1098,30 +1099,33 @@
                       <div class="small text-muted">{{ c.club.name }} - {{ c.club.city }}</div>
                     </div>
                   </div>
-                  <div class="row text-center">
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Peso</span>
-                      <span>{{ c.peso|default:'—' }}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Edad</span>
-                      <span>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Sexo</span>
-                      <span>{{ c.get_sexo_display|default:'—' }}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Altura</span>
-                      <span>{{ c.altura|default:'—' }}</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Categoria</span>
-                      <span>—</span>
-                    </div>
-                    <div class="col-6">
-                      <span class="d-block small fw-bold">Record</span>
-                      <span>—</span>
+                  </div>
+                  <div class="matchmaker-back card-body d-flex align-items-center">
+                    <div class="row text-center w-100">
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Peso</span>
+                        <span>{{ c.peso|default:'—' }}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Edad</span>
+                        <span>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Sexo</span>
+                        <span>{{ c.get_sexo_display|default:'—' }}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Altura</span>
+                        <span>{{ c.altura|default:'—' }}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Categoria</span>
+                        <span>—</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="d-block small fw-bold">Record</span>
+                        <span>—</span>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -426,16 +426,22 @@
                 <div
                   class="small fw-medium d-flex justify-content-between align-items-center border rounded p-1 mb-1"
                 >
-                  <span>
-                    {% if bloque.estado == 'abierto' %} {{
-                    bloque.hora_inicio|time:'H:i' }} - {{
-                    bloque.hora_fin|time:'H:i' }} {% elif bloque.estado ==
-                    'cerrado' %}
-                    <span class="text-danger">Cerrado</span>
+                  <div>
+                    {% if bloque.estado == 'abierto' %}
+                      <div
+                        class="py-1 schedule-item"
+                        data-start="{{ bloque.hora_inicio|time:'H:i' }}"
+                        data-end="{{ bloque.hora_fin|time:'H:i' }}"
+                      >
+                        {{ bloque.hora_inicio|time:'H:i' }} -
+                        {{ bloque.hora_fin|time:'H:i' }}
+                      </div>
+                    {% elif bloque.estado == 'cerrado' %}
+                      <div class="py-1 text-danger">Cerrado</div>
                     {% else %}
-                    <span class="text-muted">{{ bloque.estado_otro }}</span>
+                      <div class="py-1 text-muted">{{ bloque.estado_otro }}</div>
                     {% endif %}
-                  </span>
+                  </div>
                   <span>
                     <!-- Editar -->
                     <a

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -952,41 +952,8 @@
     </div>
     <div id="tab-matchmaker" class="profile-section">
       <div class="row g-3">
-        <div class="col-lg-9">
-          <div class="table-responsive">
-            <table
-              class="table table-bordered text-center align-middle"
-              style="min-width: 600px"
-            >
-              <thead class="table-dark">
-                <tr>
-                  <th>Nombre</th>
-                  <th>Club</th>
-                  <th>Ciudad</th>
-                  <th>Peso</th>
-                  <th>Edad</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for c in match_results %}
-                <tr>
-                  <td>{{ c.nombre }} {{ c.apellidos }}</td>
-                  <td>{{ c.club.name }}</td>
-                  <td>{{ c.club.city }}</td>
-                  <td>{{ c.peso|default:'—' }}</td>
-                  <td>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</td>
-                </tr>
-                {% empty %}
-                <tr class="no-match-row">
-                  <td colspan="5" class="text-muted">No hay competidores.</td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </div>
-        <div class="col-3">
-          <form method="get" id="matchmaker-filter-form" class="vstack gap-2">
+        <div class="col-12">
+          <form method="get" id="matchmaker-filter-form" class="vstack gap-2 mb-3">
             <div>
               <span class="d-block small fw-bold">Sexo</span>
               <div
@@ -1114,10 +1081,62 @@
             </div>
           </form>
         </div>
+        <div class="col-12">
+          <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3">
+            {% for c in match_results %}
+            <div class="col">
+              <div class="card matchmaker-card h-100">
+                <div class="card-body">
+                  <div class="d-flex align-items-center mb-2">
+                    {% if c.avatar %}
+                      <img src="{{ c.avatar.url }}" alt="{{ c.nombre }}" class="competitor-avatar-img me-2">
+                    {% else %}
+                      <div class="competitor-avatar me-2">{{ c.nombre|initials }}</div>
+                    {% endif %}
+                    <div>
+                      <div class="fw-bold">{{ c.nombre }} {{ c.apellidos }}</div>
+                      <div class="small text-muted">{{ c.club.name }} - {{ c.club.city }}</div>
+                    </div>
+                  </div>
+                  <div class="row text-center">
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Peso</span>
+                      <span>{{ c.peso|default:'—' }}</span>
+                    </div>
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Edad</span>
+                      <span>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</span>
+                    </div>
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Sexo</span>
+                      <span>{{ c.get_sexo_display|default:'—' }}</span>
+                    </div>
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Altura</span>
+                      <span>{{ c.altura|default:'—' }}</span>
+                    </div>
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Categoria</span>
+                      <span>—</span>
+                    </div>
+                    <div class="col-6">
+                      <span class="d-block small fw-bold">Record</span>
+                      <span>—</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% empty %}
+            <div class="col">
+              <p class="text-muted">No hay competidores.</p>
+            </div>
+            {% endfor %}
+          </div>
+        </div>
       </div>
     </div>
   </div>
-</div>
 <!-- Confirm Delete Modal -->
 <div
   class="modal fade"


### PR DESCRIPTION
## Summary
- show schedule blocks in Dashboard the same way as club profile

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687c3437121c83219ddcd11149572d14