### PR TITLE
Fix schedule display and reposition matchmaker filter

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -426,16 +426,19 @@
                 <div
                   class="small fw-medium d-flex justify-content-between align-items-center border rounded p-1 mb-1"
                 >
-                  <span>
-                    {% if bloque.estado == 'abierto' %} {{
-                    bloque.hora_inicio|time:'H:i' }} - {{
-                    bloque.hora_fin|time:'H:i' }} {% elif bloque.estado ==
-                    'cerrado' %}
-                    <span class="text-danger">Cerrado</span>
-                    {% else %}
-                    <span class="text-muted">{{ bloque.estado_otro }}</span>
-                    {% endif %}
-                  </span>
+                  {% if bloque.estado == 'abierto' %}
+                  <div
+                    class="schedule-item"
+                    data-start="{{ bloque.hora_inicio|time:'H:i' }}"
+                    data-end="{{ bloque.hora_fin|time:'H:i' }}"
+                  >
+                    {{ bloque.hora_inicio|time:'H:i' }} - {{ bloque.hora_fin|time:'H:i' }}
+                  </div>
+                  {% elif bloque.estado == 'cerrado' %}
+                  <div class="text-danger">Cerrado</div>
+                  {% else %}
+                  <div class="text-muted">{{ bloque.estado_otro }}</div>
+                  {% endif %}
                   <span>
                     <!-- Editar -->
                     <a
@@ -951,169 +954,142 @@
       </ul>
     </div>
     <div id="tab-matchmaker" class="profile-section">
-      <div class="row g-3">
-        <div class="col-lg-9">
-          <div class="table-responsive">
-            <table
-              class="table table-bordered text-center align-middle"
-              style="min-width: 600px"
-            >
-              <thead class="table-dark">
-                <tr>
-                  <th>Nombre</th>
-                  <th>Club</th>
-                  <th>Ciudad</th>
-                  <th>Peso</th>
-                  <th>Edad</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for c in match_results %}
-                <tr>
-                  <td>{{ c.nombre }} {{ c.apellidos }}</td>
-                  <td>{{ c.club.name }}</td>
-                  <td>{{ c.club.city }}</td>
-                  <td>{{ c.peso|default:'—' }}</td>
-                  <td>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</td>
-                </tr>
-                {% empty %}
-                <tr class="no-match-row">
-                  <td colspan="5" class="text-muted">No hay competidores.</td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+      <form
+        method="get"
+        id="matchmaker-filter-form"
+        class="row row-cols-lg-auto g-2 align-items-end mb-3"
+      >
+        <div class="col">
+          <span class="d-block small fw-bold">Sexo</span>
+          <div class="form-check d-flex align-items-center gap-2 mb-1 small ms-2 mt-2">
+            <input
+              class="form-check-input custom-check"
+              type="radio"
+              name="mm_sexo"
+              id="mm-sexo-m"
+              value="M"
+              {% if request.GET.mm_sexo == 'M' %}checked{% endif %}
+            />
+            <label class="form-check-label" for="mm-sexo-m">Masculino</label>
+          </div>
+          <div class="form-check d-flex align-items-center gap-2 mb-1 small ms-2 mt-2">
+            <input
+              class="form-check-input custom-check"
+              type="radio"
+              name="mm_sexo"
+              id="mm-sexo-f"
+              value="F"
+              {% if request.GET.mm_sexo == 'F' %}checked{% endif %}
+            />
+            <label class="form-check-label" for="mm-sexo-f">Femenino</label>
           </div>
         </div>
-        <div class="col-3">
-          <form method="get" id="matchmaker-filter-form" class="vstack gap-2">
-            <div>
-              <span class="d-block small fw-bold">Sexo</span>
-              <div
-                class="form-check d-flex align-items-center gap-2 mb-1 small ms-2 mt-2"
-              >
-                <input
-                  class="form-check-input custom-check"
-                  type="radio"
-                  name="mm_sexo"
-                  id="mm-sexo-m"
-                  value="M"
-                  {%
-                  if
-                  request.GET.mm_sexo=""
-                  ="M"
-                  %}checked{%
-                  endif
-                  %}
-                />
-                <label class="form-check-label" for="mm-sexo-m"
-                  >Masculino</label
-                >
-              </div>
-              <div
-                class="form-check d-flex align-items-center gap-2 mb-1 small ms-2 mt-2"
-              >
-                <input
-                  class="form-check-input custom-check"
-                  type="radio"
-                  name="mm_sexo"
-                  id="mm-sexo-f"
-                  value="F"
-                  {%
-                  if
-                  request.GET.mm_sexo=""
-                  ="F"
-                  %}checked{%
-                  endif
-                  %}
-                />
-                <label class="form-check-label" for="mm-sexo-f">Femenino</label>
-              </div>
+        <div class="col">
+          <span class="d-block small fw-bold">Peso</span>
+          <div class="range-slider ms-2 me-2">
+            <div class="range-values">
+              <span class="min-value"></span>
+              <span class="max-value"></span>
             </div>
-            <span class="d-block small fw-bold">Peso</span>
-            <div class="range-slider ms-2 me-2">
-              <div class="range-values">
-                <span class="min-value"></span>
-                <span class="max-value"></span>
-              </div>
-              <div class="slider-wrapper mt-2">
-                <div class="slider-track"></div>
-                <input
-                  type="range"
-                  name="mm_peso_min"
-                  min="30"
-                  max="160"
-                  step="1"
-                  value="{{ request.GET.mm_peso_min|default:30 }}"
-                />
-                <input
-                  type="range"
-                  name="mm_peso_max"
-                  min="30"
-                  max="160"
-                  step="1"
-                  value="{{ request.GET.mm_peso_max|default:160 }}"
-                />
-              </div>
+            <div class="slider-wrapper mt-2">
+              <div class="slider-track"></div>
+              <input
+                type="range"
+                name="mm_peso_min"
+                min="30"
+                max="160"
+                step="1"
+                value="{{ request.GET.mm_peso_min|default:30 }}"
+              />
+              <input
+                type="range"
+                name="mm_peso_max"
+                min="30"
+                max="160"
+                step="1"
+                value="{{ request.GET.mm_peso_max|default:160 }}"
+              />
             </div>
-            <div>
-              <span class="d-block small fw-bold">Ciudad</span>
-              <select name="mm_ciudad" class="form-select form-select-sm">
-                <option value="">Todas</option>
-                {% for city in cities %}
-                <option
-                  value="{{ city }}"
-                  {%
-                  if
-                  request.GET.mm_ciudad=""
-                  ="city"
-                  %}selected{%
-                  endif
-                  %}
-                >
-                  {{ city }}
-                </option>
-                {% endfor %}
-              </select>
-            </div>
-            <span class="d-block small fw-bold">Edad</span>
-            <div class="range-slider ms-2 me-2">
-              <div class="range-values">
-                <span class="min-value"></span>
-                <span class="max-value"></span>
-              </div>
-              <div class="slider-wrapper mt-2">
-                <div class="slider-track"></div>
-                <input
-                  type="range"
-                  name="mm_edad_min"
-                  min="10"
-                  max="60"
-                  step="1"
-                  value="{{ request.GET.mm_edad_min|default:10 }}"
-                />
-                <input
-                  type="range"
-                  name="mm_edad_max"
-                  min="10"
-                  max="60"
-                  step="1"
-                  value="{{ request.GET.mm_edad_max|default:60 }}"
-                />
-              </div>
-            </div>
-            <div class="text-end mt-4">
-              <button
-                type="button"
-                id="clear-matchmaker-filter-btn"
-                class="btn btn-outline-dark btn-sm ms-2"
-              >
-                Limpiar
-              </button>
-              <button type="submit" class="btn btn-dark btn-sm">Filtrar</button>
-            </div>
-          </form>
+          </div>
         </div>
+        <div class="col">
+          <span class="d-block small fw-bold">Ciudad</span>
+          <select name="mm_ciudad" class="form-select form-select-sm">
+            <option value="">Todas</option>
+            {% for city in cities %}
+            <option value="{{ city }}" {% if request.GET.mm_ciudad == city %}selected{% endif %}>{{ city }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="col">
+          <span class="d-block small fw-bold">Edad</span>
+          <div class="range-slider ms-2 me-2">
+            <div class="range-values">
+              <span class="min-value"></span>
+              <span class="max-value"></span>
+            </div>
+            <div class="slider-wrapper mt-2">
+              <div class="slider-track"></div>
+              <input
+                type="range"
+                name="mm_edad_min"
+                min="10"
+                max="60"
+                step="1"
+                value="{{ request.GET.mm_edad_min|default:10 }}"
+              />
+              <input
+                type="range"
+                name="mm_edad_max"
+                min="10"
+                max="60"
+                step="1"
+                value="{{ request.GET.mm_edad_max|default:60 }}"
+              />
+            </div>
+          </div>
+        </div>
+        <div class="col-auto text-end">
+          <button
+            type="button"
+            id="clear-matchmaker-filter-btn"
+            class="btn btn-outline-dark btn-sm ms-2"
+          >
+            Limpiar
+          </button>
+          <button type="submit" class="btn btn-dark btn-sm">Filtrar</button>
+        </div>
+      </form>
+      <div class="table-responsive">
+        <table
+          class="table table-bordered text-center align-middle"
+          style="min-width: 600px"
+        >
+          <thead class="table-dark">
+            <tr>
+              <th>Nombre</th>
+              <th>Club</th>
+              <th>Ciudad</th>
+              <th>Peso</th>
+              <th>Edad</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for c in match_results %}
+            <tr>
+              <td>{{ c.nombre }} {{ c.apellidos }}</td>
+              <td>{{ c.club.name }}</td>
+              <td>{{ c.club.city }}</td>
+              <td>{{ c.peso|default:'—' }}</td>
+              <td>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</td>
+            </tr>
+            {% empty %}
+            <tr class="no-match-row">
+              <td colspan="5" class="text-muted">No hay competidores.</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show schedule items in dashboard like the public club profile
- move the Matchmaker filter above its table

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687c35d7fcdc8321866fb72497da0d6d