### PR TITLE
Update matchmaker layout

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -954,17 +954,19 @@
       </ul>
     </div>
     <div id="tab-matchmaker" class="profile-section">
-      <form
-        method="get"
-        id="matchmaker-filter-form"
-        class="row row-cols-lg-auto g-2 align-items-end mb-3"
-      >
-        <div class="col">
-          <span class="d-block small fw-bold">Sexo</span>
-          <div class="form-check d-flex align-items-center gap-2 mb-1 small ms-2 mt-2">
-            <input
-              class="form-check-input custom-check"
-              type="radio"
+      <div class="row">
+        <div class="col-12 col-lg-4">
+          <form
+            method="get"
+            id="matchmaker-filter-form"
+            class="d-grid gap-3 mb-3"
+          >
+            <div>
+              <span class="d-block small fw-bold">Sexo</span>
+              <div class="form-check d-flex align-items-center gap-2 mb-1 small ms-2 mt-2">
+                <input
+                  class="form-check-input custom-check"
+                  type="radio"
               name="mm_sexo"
               id="mm-sexo-m"
               value="M"
@@ -981,15 +983,15 @@
               value="F"
               {% if request.GET.mm_sexo == 'F' %}checked{% endif %}
             />
-            <label class="form-check-label" for="mm-sexo-f">Femenino</label>
-          </div>
-        </div>
-        <div class="col">
-          <span class="d-block small fw-bold">Peso</span>
-          <div class="range-slider ms-2 me-2">
-            <div class="range-values">
-              <span class="min-value"></span>
-              <span class="max-value"></span>
+                <label class="form-check-label" for="mm-sexo-f">Femenino</label>
+              </div>
+            </div>
+            <div>
+              <span class="d-block small fw-bold">Peso</span>
+              <div class="range-slider ms-2 me-2">
+                <div class="range-values">
+                  <span class="min-value"></span>
+                  <span class="max-value"></span>
             </div>
             <div class="slider-wrapper mt-2">
               <div class="slider-track"></div>
@@ -1011,22 +1013,22 @@
               />
             </div>
           </div>
-        </div>
-        <div class="col">
-          <span class="d-block small fw-bold">Ciudad</span>
-          <select name="mm_ciudad" class="form-select form-select-sm">
-            <option value="">Todas</option>
-            {% for city in cities %}
-            <option value="{{ city }}" {% if request.GET.mm_ciudad == city %}selected{% endif %}>{{ city }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="col">
-          <span class="d-block small fw-bold">Edad</span>
-          <div class="range-slider ms-2 me-2">
-            <div class="range-values">
-              <span class="min-value"></span>
-              <span class="max-value"></span>
+            </div>
+            <div>
+              <span class="d-block small fw-bold">Ciudad</span>
+              <select name="mm_ciudad" class="form-select form-select-sm">
+                <option value="">Todas</option>
+                {% for city in cities %}
+                <option value="{{ city }}" {% if request.GET.mm_ciudad == city %}selected{% endif %}>{{ city }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div>
+              <span class="d-block small fw-bold">Edad</span>
+              <div class="range-slider ms-2 me-2">
+                <div class="range-values">
+                  <span class="min-value"></span>
+                  <span class="max-value"></span>
             </div>
             <div class="slider-wrapper mt-2">
               <div class="slider-track"></div>
@@ -1048,48 +1050,46 @@
               />
             </div>
           </div>
+            </div>
+            <div class="text-end">
+              <button
+                type="button"
+                id="clear-matchmaker-filter-btn"
+                class="btn btn-outline-dark btn-sm ms-2"
+              >
+                Limpiar
+              </button>
+              <button type="submit" class="btn btn-dark btn-sm">Filtrar</button>
+            </div>
+          </form>
         </div>
-        <div class="col-auto text-end">
-          <button
-            type="button"
-            id="clear-matchmaker-filter-btn"
-            class="btn btn-outline-dark btn-sm ms-2"
-          >
-            Limpiar
-          </button>
-          <button type="submit" class="btn btn-dark btn-sm">Filtrar</button>
-        </div>
-      </form>
-      <div class="table-responsive">
-        <table
-          class="table table-bordered text-center align-middle"
-          style="min-width: 600px"
-        >
-          <thead class="table-dark">
-            <tr>
-              <th>Nombre</th>
-              <th>Club</th>
-              <th>Ciudad</th>
-              <th>Peso</th>
-              <th>Edad</th>
-            </tr>
-          </thead>
-          <tbody>
+        <div class="col-12 col-lg-8">
+          <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
             {% for c in match_results %}
-            <tr>
-              <td>{{ c.nombre }} {{ c.apellidos }}</td>
-              <td>{{ c.club.name }}</td>
-              <td>{{ c.club.city }}</td>
-              <td>{{ c.peso|default:'—' }}</td>
-              <td>{% if c.edad %}{{ c.edad }}{% else %}—{% endif %}</td>
-            </tr>
+            <div class="col">
+              <div class="card text-center">
+                {% if c.avatar %}
+                <img src="{{ c.avatar.url }}" class="card-img-top object-fit-cover" style="height: 200px" alt="{{ c.nombre }}" />
+                {% else %}
+                <div class="card-img-top d-flex align-items-center justify-content-center bg-light" style="height: 200px">
+                  <span class="text-muted">{{ c.nombre|initials }}</span>
+                </div>
+                {% endif %}
+                <div class="card-body p-2">
+                  <span class="fw-medium d-block">{{ c.nombre }} {{ c.apellidos }}</span>
+                  <small class="text-muted d-block">{{ c.club.name }} - {{ c.club.city }}</small>
+                  <small class="d-block">
+                    {{ c.peso|default:'—' }}
+                    {% if c.edad %}| {{ c.edad }}{% else %}| —{% endif %}
+                  </small>
+                </div>
+              </div>
+            </div>
             {% empty %}
-            <tr class="no-match-row">
-              <td colspan="5" class="text-muted">No hay competidores.</td>
-            </tr>
+            <p>No hay competidores.</p>
             {% endfor %}
-          </tbody>
-        </table>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- make matchmaker filters vertical and limit width to 4 bootstrap columns
- display match results as cards instead of a table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_687c37e9e2588321bbb1b5debb5ecc52