### PR TITLE
Add flip effect to matchmaker cards

### DIFF
--- a/static/css/matchmaker.css
+++ b/static/css/matchmaker.css
@@ -1,0 +1,29 @@
+.card-flip {
+  perspective: 1000px;
+}
+
+.card-flip-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.card-flip:hover .card-flip-inner {
+  transform: rotateY(180deg);
+}
+
+.card-flip-front,
+.card-flip-back {
+  backface-visibility: hidden;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.card-flip-back {
+  transform: rotateY(180deg);
+}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -954,7 +954,7 @@
       </ul>
     </div>
     <div id="tab-matchmaker" class="profile-section">
-      <div class="row">
+      <div class="row mb-3">
         <div class="col-12 col-lg-4">
           <form
             method="get"
@@ -1063,11 +1063,13 @@
             </div>
           </form>
         </div>
-        <div class="col-12 col-lg-8">
-          <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
-            {% for c in match_results %}
-            <div class="col">
-              <div class="card text-center">
+      </div>
+      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 g-4">
+        {% for c in match_results %}
+        <div class="col">
+          <div class="card-flip">
+            <div class="card-flip-inner">
+              <div class="card text-center card-flip-front">
                 {% if c.avatar %}
                 <img src="{{ c.avatar.url }}" class="card-img-top object-fit-cover" style="height: 200px" alt="{{ c.nombre }}" />
                 {% else %}
@@ -1084,12 +1086,19 @@
                   </small>
                 </div>
               </div>
+              <div class="card card-flip-back text-center bg-dark text-white">
+                <div class="p-2 d-flex flex-column justify-content-center align-items-center h-100">
+                  <small class="d-block">Sexo: {{ c.get_sexo_display|default:'—' }}</small>
+                  <small class="d-block">Edad: {{ c.edad|default:'—' }}</small>
+                  <small class="d-block">Peso: {{ c.peso|default:'—' }}</small>
+                </div>
+              </div>
             </div>
-            {% empty %}
-            <p>No hay competidores.</p>
-            {% endfor %}
           </div>
         </div>
+        {% empty %}
+        <p>No hay competidores.</p>
+        {% endfor %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- move matchmaker cards below the filter
- show more cards per row on wide screens
- add card flip effect with extra info on hover

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687c3cddd76c83219776b7bd49b6efd4