### PR TITLE
Add member search for competitor modal

### DIFF
--- a/apps/clubs/migrations/0027_competidor_extra_metrics.py
+++ b/apps/clubs/migrations/0027_competidor_extra_metrics.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('clubs', '0026_merge_0025_merge_20250715_0837_0025_miembro_location'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='competidor',
+            name='peso_kg',
+            field=models.DecimalField(blank=True, null=True, max_digits=5, decimal_places=2),
+        ),
+        migrations.AddField(
+            model_name='competidor',
+            name='altura_cm',
+            field=models.DecimalField(blank=True, null=True, max_digits=5, decimal_places=2),
+        ),
+    ]

--- a/apps/clubs/models/competidor.py
+++ b/apps/clubs/models/competidor.py
@@ -39,6 +39,8 @@ class Competidor(models.Model):
     modalidad = models.CharField(max_length=15, choices=MODALIDAD_CHOICES, blank=True)
     peso = models.CharField(max_length=15, choices=PESO_CHOICES, blank=True)
     sexo = models.CharField(max_length=1, choices=SEXO_CHOICES, blank=True)
+    peso_kg = models.DecimalField(max_digits=5, decimal_places=2, blank=True, null=True)
+    altura_cm = models.DecimalField(max_digits=5, decimal_places=2, blank=True, null=True)
     palmares = models.TextField(blank=True, verbose_name="Palmarés")
 
     def save(self, *args, **kwargs):

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -35,6 +35,7 @@ from apps.clubs.views.dashboard import (
     pago_create,
     pago_update,
     pago_delete,
+    miembros_json,
 )
 
 urlpatterns = [
@@ -55,6 +56,7 @@ urlpatterns = [
     path('<slug:slug>/competidor/nuevo/', competidor_create, name='competidor_create'),
     path('competidor/<int:pk>/editar/', competidor_update, name='competidor_update'),
     path('competidor/<int:pk>/eliminar/', competidor_delete, name='competidor_delete'),
+    path('<slug:slug>/miembros/json/', miembros_json, name='miembros_json'),
 
     path('<slug:slug>/entrenador/nuevo/', entrenador_create, name='entrenador_create'),
     path('entrenador/<int:pk>/editar/', entrenador_update, name='entrenador_update'),

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -393,6 +393,12 @@ select option[value="España"] {
   display: block;
 }
 
+#competitor-member-results {
+  max-height: 200px;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
 /* Generic search field with clear button and icon */
 .search-field {
   position: relative;

--- a/static/js/competitor-modal.js
+++ b/static/js/competitor-modal.js
@@ -18,6 +18,51 @@ document.addEventListener('DOMContentLoaded', () => {
             if (window.initSelectLabels) {
               window.initSelectLabels(addEl);
             }
+            const membersDataEl = addEl.querySelector('#competitor-members');
+            let members = [];
+            if (membersDataEl) {
+              try {
+                members = JSON.parse(membersDataEl.textContent);
+              } catch (e) {}
+            }
+            const searchInput = addEl.querySelector('#competitor-member-search');
+            const resultsEl = addEl.querySelector('#competitor-member-results');
+            const closeBtn = addEl.querySelector('#competitor-member-search-form .close-icon');
+            function renderResults(query) {
+              if (!resultsEl) return;
+              resultsEl.innerHTML = '';
+              if (!query) return;
+              const q = query.toLowerCase();
+              members.filter(m => (`${m.nombre} ${m.apellidos}`.toLowerCase().includes(q))).slice(0,5).forEach(m => {
+                const li = document.createElement('li');
+                li.className = 'list-group-item list-group-item-action';
+                li.textContent = `${m.nombre} ${m.apellidos}`;
+                li.addEventListener('click', () => {
+                  const nameField = addEl.querySelector(`input[name='nombre']`);
+                  if (nameField) nameField.value = `${m.nombre} ${m.apellidos}`;
+                  const sexoField = addEl.querySelector(`select[name='sexo']`);
+                  if (sexoField) sexoField.value = m.sexo || '';
+                  const pesoField = addEl.querySelector(`input[name='peso_kg']`);
+                  if (pesoField) pesoField.value = m.peso || '';
+                  const alturaField = addEl.querySelector(`input[name='altura_cm']`);
+                  if (alturaField) alturaField.value = m.altura || '';
+                  resultsEl.innerHTML = '';
+                  searchInput.value = '';
+                });
+                resultsEl.appendChild(li);
+              });
+            }
+            if (searchInput) {
+              searchInput.addEventListener('input', () => {
+                renderResults(searchInput.value);
+              });
+            }
+            if (closeBtn) {
+              closeBtn.addEventListener('click', () => {
+                if (resultsEl) resultsEl.innerHTML = '';
+                if (searchInput) searchInput.value = '';
+              });
+            }
             const form = addEl.querySelector('form');
             form.addEventListener('submit', e => {
               e.preventDefault();

--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -17,25 +17,45 @@
       </div>
       {% endif %}
     </div>
-    <div class="form-field">
-      {{ form.nombre }}
-      <button type="button" class="clear-btn">×</button>
-      <label for="{{ form.nombre.id_for_label }}">{{ form.nombre.label }}</label>
-      {% if form.nombre.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.nombre.errors.as_text|striptags }}
+    <div class="d-flex gap-2 align-items-start">
+      <div class="form-field flex-grow-1">
+        {{ form.nombre }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.nombre.id_for_label }}">{{ form.nombre.label }}</label>
+        {% if form.nombre.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.nombre.errors.as_text|striptags }}
+        </div>
+        {% endif %}
       </div>
-      {% endif %}
+      <div class="member-search">
+        <form id="competitor-member-search-form" class="member-search-form" onsubmit="return false;">
+          <button type="submit" class="search-icon"><i class="bi bi-search"></i></button>
+          <input type="text" id="competitor-member-search" placeholder="Buscar miembro" autocomplete="off" />
+          <button type="button" class="close-icon">&times;</button>
+        </form>
+        <ul id="competitor-member-results" class="list-group position-absolute w-100"></ul>
+      </div>
     </div>
-    <div class="form-field">
-      {{ form.record }}
-      <button type="button" class="clear-btn">×</button>
-      <label for="{{ form.record.id_for_label }}">{{ form.record.label }}</label>
-      {% if form.record.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.record.errors.as_text|striptags }}
+    <div class="row">
+      <div class="col-4">
+        <div class="form-field">
+          {{ form.victorias }}
+          <label for="{{ form.victorias.id_for_label }}" class="text-success">Victorias</label>
+        </div>
       </div>
-      {% endif %}
+      <div class="col-4">
+        <div class="form-field">
+          {{ form.derrotas }}
+          <label for="{{ form.derrotas.id_for_label }}" class="text-danger">Derrotas</label>
+        </div>
+      </div>
+      <div class="col-4">
+        <div class="form-field">
+          {{ form.empates }}
+          <label for="{{ form.empates.id_for_label }}" class="text-primary">Empates</label>
+        </div>
+      </div>
     </div>
     <div class="form-field">
       {{ form.modalidad }}
@@ -54,6 +74,20 @@
         {{ form.peso.errors.as_text|striptags }}
       </div>
       {% endif %}
+    </div>
+    <div class="row">
+      <div class="col-6">
+        <div class="form-field">
+          {{ form.peso_kg }}
+          <label for="{{ form.peso_kg.id_for_label }}">{{ form.peso_kg.label }}</label>
+        </div>
+      </div>
+      <div class="col-6">
+        <div class="form-field">
+          {{ form.altura_cm }}
+          <label for="{{ form.altura_cm.id_for_label }}">{{ form.altura_cm.label }}</label>
+        </div>
+      </div>
     </div>
     <div class="form-field">
       {{ form.sexo }}
@@ -75,3 +109,4 @@
     </div>
     <button type="submit" class="btn btn-dark">Guardar</button>
 </form>
+{{ members|json_script:"competitor-members" }}


### PR DESCRIPTION
## Summary
- extend `Competidor` model with `peso_kg` and `altura_cm`
- store new metrics via migration
- rework `CompetidorForm` to expose victories, defeats, draws and numeric metrics
- allow selecting existing club members when creating a competitor
- update modal HTML/JS/CSS for search and new fields
- expose member list JSON endpoint

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_687c41031c88832180aa3bd8ba0f8f0e