### PR TITLE
Update competitor modal features

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -185,12 +185,15 @@ class CompetidorForm(forms.ModelForm):
     altura_cm = forms.DecimalField(
         required=False, max_digits=5, decimal_places=2, label='Altura (cm)'
     )
+    edad = forms.IntegerField(required=False, min_value=0, label='Edad')
 
     class Meta:
         model = models.Competidor
         fields = [
             'avatar',
             'nombre',
+            'apellidos',
+            'edad',
             'modalidad',
             'peso',
             'peso_kg',
@@ -218,6 +221,10 @@ class CompetidorForm(forms.ModelForm):
                 forms.TimeInput,
             )):
                 field.widget.attrs.setdefault('placeholder', ' ')
+
+        palmares_field = self.fields.get('palmares')
+        if palmares_field:
+            palmares_field.widget.attrs['rows'] = 3
 
         if self.instance and getattr(self.instance, 'record', None):
             try:

--- a/apps/clubs/migrations/0028_competidor_apellidos_edad.py
+++ b/apps/clubs/migrations/0028_competidor_apellidos_edad.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('clubs', '0027_competidor_extra_metrics'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='competidor',
+            name='apellidos',
+            field=models.CharField(max_length=150, blank=True),
+        ),
+        migrations.AddField(
+            model_name='competidor',
+            name='edad',
+            field=models.PositiveIntegerField(null=True, blank=True),
+        ),
+    ]

--- a/apps/clubs/models/competidor.py
+++ b/apps/clubs/models/competidor.py
@@ -35,6 +35,8 @@ class Competidor(models.Model):
     club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name="competidores")
     avatar = models.ImageField(upload_to="competidores/", blank=True, null=True)
     nombre = models.CharField(max_length=100)
+    apellidos = models.CharField(max_length=150, blank=True)
+    edad = models.PositiveIntegerField(null=True, blank=True)
     record = models.CharField(max_length=20, blank=True)
     modalidad = models.CharField(max_length=15, choices=MODALIDAD_CHOICES, blank=True)
     peso = models.CharField(max_length=15, choices=PESO_CHOICES, blank=True)
@@ -60,7 +62,7 @@ class Competidor(models.Model):
         return " ".join(parts)
 
     def __str__(self):
-        return self.nombre
+        return f"{self.nombre} {self.apellidos}".strip()
 
     @property
     def record_tuple(self):

--- a/static/js/competitor-modal.js
+++ b/static/js/competitor-modal.js
@@ -39,7 +39,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 li.textContent = `${m.nombre} ${m.apellidos}`;
                 li.addEventListener('click', () => {
                   const nameField = addEl.querySelector(`input[name='nombre']`);
-                  if (nameField) nameField.value = `${m.nombre} ${m.apellidos}`;
+                  const lastField = addEl.querySelector(`input[name='apellidos']`);
+                  if (nameField) nameField.value = m.nombre || '';
+                  if (lastField) lastField.value = m.apellidos || '';
                   const sexoField = addEl.querySelector(`select[name='sexo']`);
                   if (sexoField) sexoField.value = m.sexo || '';
                   const pesoField = addEl.querySelector(`input[name='peso_kg']`);

--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -10,31 +10,44 @@
           </div>
         </div>
       </div>
-      <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
       {% if form.avatar.errors %}
       <div class="invalid-feedback d-block">
         {{ form.avatar.errors.as_text|striptags }}
       </div>
       {% endif %}
     </div>
-    <div class="d-flex gap-2 align-items-start">
-      <div class="form-field flex-grow-1">
-        {{ form.nombre }}
-        <button type="button" class="clear-btn">×</button>
-        <label for="{{ form.nombre.id_for_label }}">{{ form.nombre.label }}</label>
-        {% if form.nombre.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.nombre.errors.as_text|striptags }}
+    <div class="member-search mb-2">
+      <form id="competitor-member-search-form" class="member-search-form" onsubmit="return false;">
+        <button type="submit" class="search-icon"><i class="bi bi-search"></i></button>
+        <input type="text" id="competitor-member-search" placeholder="Buscar miembro" autocomplete="off" />
+        <button type="button" class="close-icon">&times;</button>
+      </form>
+      <ul id="competitor-member-results" class="list-group position-absolute w-100"></ul>
+    </div>
+    <div class="row g-2">
+      <div class="col-6">
+        <div class="form-field">
+          {{ form.nombre }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ form.nombre.id_for_label }}">{{ form.nombre.label }}</label>
+          {% if form.nombre.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.nombre.errors.as_text|striptags }}
+          </div>
+          {% endif %}
         </div>
-        {% endif %}
       </div>
-      <div class="member-search">
-        <form id="competitor-member-search-form" class="member-search-form" onsubmit="return false;">
-          <button type="submit" class="search-icon"><i class="bi bi-search"></i></button>
-          <input type="text" id="competitor-member-search" placeholder="Buscar miembro" autocomplete="off" />
-          <button type="button" class="close-icon">&times;</button>
-        </form>
-        <ul id="competitor-member-results" class="list-group position-absolute w-100"></ul>
+      <div class="col-6">
+        <div class="form-field">
+          {{ form.apellidos }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ form.apellidos.id_for_label }}">{{ form.apellidos.label }}</label>
+          {% if form.apellidos.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.apellidos.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
       </div>
     </div>
     <div class="row">
@@ -88,6 +101,15 @@
           <label for="{{ form.altura_cm.id_for_label }}">{{ form.altura_cm.label }}</label>
         </div>
       </div>
+    </div>
+    <div class="form-field">
+      {{ form.edad }}
+      <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
+      {% if form.edad.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.edad.errors.as_text|striptags }}
+      </div>
+      {% endif %}
     </div>
     <div class="form-field">
       {{ form.sexo }}

--- a/templates/clubs/_entrenador_form.html
+++ b/templates/clubs/_entrenador_form.html
@@ -10,7 +10,6 @@
           </div>
         </div>
       </div>
-      <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
       {% if form.avatar.errors %}
       <div class="invalid-feedback d-block">
         {{ form.avatar.errors.as_text|striptags }}

--- a/templates/clubs/competidor_form.html
+++ b/templates/clubs/competidor_form.html
@@ -23,15 +23,31 @@
       </div>
       {% endif %}
     </div>
-    <div class="form-field">
-      {{ form.nombre }}
-      <button type="button" class="clear-btn">×</button>
-      <label for="{{ form.nombre.id_for_label }}">{{ form.nombre.label }}</label>
-      {% if form.nombre.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.nombre.errors.as_text|striptags }}
+    <div class="row g-2">
+      <div class="col-6">
+        <div class="form-field">
+          {{ form.nombre }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ form.nombre.id_for_label }}">{{ form.nombre.label }}</label>
+          {% if form.nombre.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.nombre.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
       </div>
-      {% endif %}
+      <div class="col-6">
+        <div class="form-field">
+          {{ form.apellidos }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ form.apellidos.id_for_label }}">{{ form.apellidos.label }}</label>
+          {% if form.apellidos.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.apellidos.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
     </div>
     <div class="form-field">
       {{ form.record }}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -645,14 +645,14 @@
               src="{{ comp.avatar.url }}"
               class="card-img-top object-fit-cover"
               style="height: 200px"
-              alt="{{ comp.nombre }}"
+              alt="{{ comp.nombre }} {{ comp.apellidos }}"
             />
             {% else %}
             <div
               class="card-img-top d-flex align-items-center justify-content-center bg-light"
               style="height: 200px"
             >
-              <span class="text-muted">{{ comp.nombre|initials }}</span>
+              <span class="text-muted">{{ comp.nombre|add:' '|add:comp.apellidos|initials }}</span>
             </div>
             {% endif %}
             <div
@@ -662,7 +662,7 @@
               <div
                 class="d-flex justify-content-center align-items-center mb-2"
               >
-                <span class="fw-medium text-center">{{ comp.nombre }}</span>
+                <span class="fw-medium text-center">{{ comp.nombre }} {{ comp.apellidos }}</span>
               </div>
 
               <!-- Información del competidor -->
@@ -1244,7 +1244,7 @@
 
 <!-- Add Coach Modal -->
 <div class="modal fade" id="addCoachModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-xl">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Nuevo entrenador</h5>
@@ -1267,7 +1267,7 @@
   tabindex="-1"
   aria-hidden="true"
 >
-  <div class="modal-dialog modal-dialog-centered modal-xl">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Nuevo competidor</h5>


### PR DESCRIPTION
## Summary
- extend `Competidor` model with `apellidos` and `edad`
- support new fields in `CompetidorForm`
- reduce textarea height
- adapt competitor modal UI: moved search above, added surname & age, removed avatar labels
- adjust JS to fill new surname field
- show full competitor names in dashboard and reduce modal size
- add migration for new model fields

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687c4859da988321a2af14442ac3ef3e