### PR TITLE
Add age field to member and competitor forms

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -285,6 +285,7 @@ class EntrenadorForm(forms.ModelForm):
 
 
 class MiembroForm(forms.ModelForm):
+    edad = forms.IntegerField(required=False, min_value=0, label='Edad')
     nacionalidad = forms.ChoiceField(
         choices=[('', 'País')] + COUNTRY_CHOICES,
         required=False,

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -192,6 +192,15 @@
     </div>
   </div>
   <div class="form-field">
+    {{ form.edad }}
+    <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
+    {% if form.edad.errors %}
+    <div class="invalid-feedback d-block">
+      {{ form.edad.errors.as_text|striptags }}
+    </div>
+    {% endif %}
+  </div>
+  <div class="form-field">
     {{ form.estado }}
     <label for="{{ form.estado.id_for_label }}">{{ form.estado.label }}</label>
     {% if form.estado.errors %}

--- a/templates/clubs/competidor_form.html
+++ b/templates/clubs/competidor_form.html
@@ -78,6 +78,15 @@
       {% endif %}
     </div>
     <div class="form-field">
+      {{ form.edad }}
+      <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
+      {% if form.edad.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.edad.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    <div class="form-field">
       {{ form.sexo }}
       <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
       {% if form.sexo.errors %}


### PR DESCRIPTION
## Summary
- include optional `edad` field in `MiembroForm`
- display `edad` in member modal form
- show `edad` input on competitor form

## Testing
- `python manage.py test` *(fails: Could not import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687c4cacb6308321b807fce15c60f67a