### PR TITLE
Align competitor form with coach UX

### DIFF
--- a/templates/clubs/competidor_form.html
+++ b/templates/clubs/competidor_form.html
@@ -4,7 +4,7 @@
 <div class="container py-4">
   {% include 'partials/_back-btn.html' %}
   <h1 class="h5">{% if competidor %}Editar{% else %}Nuevo{% endif %} competidor</h1>
-  <form method="post" enctype="multipart/form-data" class="profile-form" action="{% if competidor %}{% url 'competidor_update' competidor.id %}{% else %}{% url 'competidor_create' club.slug %}{% endif %}">
+  <form method="post" enctype="multipart/form-data" class="profile-form">
     {% csrf_token %}
     <div class="form-field">
       <div class="avatar-dropzone">
@@ -23,87 +23,32 @@
       </div>
       {% endif %}
     </div>
-    <div class="row g-2">
-      <div class="col-6">
-        <div class="form-field">
-          {{ form.nombre }}
-          <button type="button" class="clear-btn">×</button>
-          <label for="{{ form.nombre.id_for_label }}">{{ form.nombre.label }}</label>
-          {% if form.nombre.errors %}
+    {% for field in form %}
+      {% if field.name != 'avatar' %}
+        {% if field.field.widget.input_type == 'checkbox' %}
+        <div class="form-field checkbox-field">
+          {{ field }}
+          <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+          {% if field.errors %}
           <div class="invalid-feedback d-block">
-            {{ form.nombre.errors.as_text|striptags }}
+            {{ field.errors.as_text|striptags }}
           </div>
           {% endif %}
         </div>
-      </div>
-      <div class="col-6">
+        {% else %}
         <div class="form-field">
-          {{ form.apellidos }}
+          {{ field }}
           <button type="button" class="clear-btn">×</button>
-          <label for="{{ form.apellidos.id_for_label }}">{{ form.apellidos.label }}</label>
-          {% if form.apellidos.errors %}
+          <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+          {% if field.errors %}
           <div class="invalid-feedback d-block">
-            {{ form.apellidos.errors.as_text|striptags }}
+            {{ field.errors.as_text|striptags }}
           </div>
           {% endif %}
         </div>
-      </div>
-    </div>
-    <div class="form-field">
-      {{ form.record }}
-      <button type="button" class="clear-btn">×</button>
-      <label for="{{ form.record.id_for_label }}">{{ form.record.label }}</label>
-      {% if form.record.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.record.errors.as_text|striptags }}
-      </div>
+        {% endif %}
       {% endif %}
-    </div>
-    <div class="form-field">
-      {{ form.modalidad }}
-      <label for="{{ form.modalidad.id_for_label }}">{{ form.modalidad.label }}</label>
-      {% if form.modalidad.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.modalidad.errors.as_text|striptags }}
-      </div>
-      {% endif %}
-    </div>
-    <div class="form-field">
-      {{ form.peso }}
-      <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
-      {% if form.peso.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.peso.errors.as_text|striptags }}
-      </div>
-      {% endif %}
-    </div>
-    <div class="form-field">
-      {{ form.edad }}
-      <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
-      {% if form.edad.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.edad.errors.as_text|striptags }}
-      </div>
-      {% endif %}
-    </div>
-    <div class="form-field">
-      {{ form.sexo }}
-      <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
-      {% if form.sexo.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.sexo.errors.as_text|striptags }}
-      </div>
-      {% endif %}
-    </div>
-    <div class="form-field">
-      {{ form.palmares }}
-      <label for="{{ form.palmares.id_for_label }}">{{ form.palmares.label }}</label>
-      {% if form.palmares.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.palmares.errors.as_text|striptags }}
-      </div>
-      {% endif %}
-    </div>
+    {% endfor %}
     <button type="submit" class="btn btn-dark">Guardar</button>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- clean up competitor form to match coach form UX

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'Django')*

------
https://chatgpt.com/codex/tasks/task_e_687c4f233df483218228eb6eac01c360