### PR TITLE
Auto-fill competitor category

### DIFF
--- a/apps/clubs/models/competidor.py
+++ b/apps/clubs/models/competidor.py
@@ -46,6 +46,17 @@ class Competidor(models.Model):
     palmares = models.TextField(blank=True, verbose_name="Palmarés")
 
     def save(self, *args, **kwargs):
+        if self.edad is not None and not self.modalidad:
+            if 13 <= self.edad <= 14:
+                self.modalidad = "schoolboy"
+            elif 15 <= self.edad <= 16:
+                self.modalidad = "junior"
+            elif 17 <= self.edad <= 18:
+                self.modalidad = "joven"
+            elif 19 <= self.edad <= 40:
+                self.modalidad = "elite"
+            elif self.edad >= 18:
+                self.modalidad = "profesional"
         super().save(*args, **kwargs)
         if self.avatar and hasattr(self.avatar, "path"):
             resize_image(self.avatar.path)

--- a/static/js/age-category.js
+++ b/static/js/age-category.js
@@ -1,0 +1,34 @@
+function initAgeCategory(root = document) {
+  const ageInput = root.querySelector('input[name="edad"]');
+  const select = root.querySelector('select[name="modalidad"]');
+  if (!ageInput || !select) return;
+
+  const update = () => {
+    const age = parseInt(ageInput.value, 10);
+    let value = '';
+    if (!isNaN(age)) {
+      if (age >= 13 && age <= 14) {
+        value = 'schoolboy';
+      } else if (age >= 15 && age <= 16) {
+        value = 'junior';
+      } else if (age >= 17 && age <= 18) {
+        value = 'joven';
+      } else if (age >= 19 && age <= 40) {
+        value = 'elite';
+      } else if (age >= 18) {
+        value = 'profesional';
+      }
+    }
+    select.value = value;
+    select.dispatchEvent(new Event('change'));
+  };
+
+  ageInput.addEventListener('input', update);
+  update();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initAgeCategory();
+});
+
+window.initAgeCategory = initAgeCategory;

--- a/static/js/competitor-modal.js
+++ b/static/js/competitor-modal.js
@@ -18,6 +18,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (window.initSelectLabels) {
               window.initSelectLabels(addEl);
             }
+            if (window.initAgeCategory) {
+              window.initAgeCategory(addEl);
+            }
             const membersDataEl = addEl.querySelector('#competitor-members');
             let members = [];
             if (membersDataEl) {

--- a/templates/clubs/competidor_form.html
+++ b/templates/clubs/competidor_form.html
@@ -55,4 +55,5 @@
 {% endblock %}
 {% block extra_js %}
 <script src="{% static 'js/avatar-dropzone.js' %}"></script>
+<script src="{% static 'js/age-category.js' %}"></script>
 {% endblock %}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1294,6 +1294,7 @@
 <script src="{% static 'js/member-modal.js' %}"></script>
 <script src="{% static 'js/coach-modal.js' %}"></script>
 <script src="{% static 'js/competitor-modal.js' %}"></script>
+<script src="{% static 'js/age-category.js' %}"></script>
 <script src="{% static 'js/member-search.js' %}"></script>
 <script src="{% static 'js/sort.js' %}"></script>
 <script src="{% static 'js/range-slider.js' %}"></script>


### PR DESCRIPTION
## Summary
- set competitor category automatically based on age
- add age-category JS helper
- invoke helper for competitor form and dashboard modals

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687c54405668832197aff3d07ce03850