### PR TITLE
Add competitor type selector

### DIFF
--- a/static/js/age-category.js
+++ b/static/js/age-category.js
@@ -1,30 +1,56 @@
 function initAgeCategory(root = document) {
   const ageInput = root.querySelector('input[name="edad"]');
   const select = root.querySelector('select[name="modalidad"]');
-  if (!ageInput || !select) return;
+  const tipoRadios = root.querySelectorAll('input[name="tipo_competidor"]');
+  const modalidadField = select ? select.closest('.form-field') : null;
+  if (!ageInput) return;
+
+  const updateVisibility = () => {
+    const checked = root.querySelector('input[name="tipo_competidor"]:checked');
+    if (modalidadField) {
+      modalidadField.style.display = checked && checked.value === 'amateur' ? '' : 'none';
+    }
+  };
+
+  tipoRadios.forEach(r => r.addEventListener('change', updateVisibility));
 
   const update = () => {
     const age = parseInt(ageInput.value, 10);
+    let type = '';
     let value = '';
     if (!isNaN(age)) {
       if (age >= 13 && age <= 14) {
+        type = 'amateur';
         value = 'schoolboy';
       } else if (age >= 15 && age <= 16) {
+        type = 'amateur';
         value = 'junior';
       } else if (age >= 17 && age <= 18) {
+        type = 'amateur';
         value = 'joven';
       } else if (age >= 19 && age <= 40) {
+        type = 'amateur';
         value = 'elite';
-      } else if (age >= 18) {
+      } else if (age >= 41) {
+        type = 'profesional';
         value = 'profesional';
       }
     }
-    select.value = value;
-    select.dispatchEvent(new Event('change'));
+    if (tipoRadios.length) {
+      tipoRadios.forEach(r => {
+        r.checked = r.value === type;
+      });
+    }
+    if (select) {
+      select.value = type === 'amateur' ? value : '';
+      select.dispatchEvent(new Event('change'));
+    }
+    updateVisibility();
   };
 
   ageInput.addEventListener('input', update);
   update();
+  updateVisibility();
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -69,6 +69,15 @@
       </div>
     </div>
     <div class="form-field">
+      {{ form.tipo_competidor }}
+      <label>{{ form.tipo_competidor.label }}</label>
+      {% if form.tipo_competidor.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.tipo_competidor.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    <div class="form-field" id="modalidad-field">
       {{ form.modalidad }}
       <label for="{{ form.modalidad.id_for_label }}">{{ form.modalidad.label }}</label>
       {% if form.modalidad.errors %}

--- a/templates/clubs/competidor_form.html
+++ b/templates/clubs/competidor_form.html
@@ -38,7 +38,9 @@
         {% else %}
         <div class="form-field">
           {{ field }}
+          {% if field.field.widget.input_type != 'radio' %}
           <button type="button" class="clear-btn">×</button>
+          {% endif %}
           <label for="{{ field.id_for_label }}">{{ field.label }}</label>
           {% if field.errors %}
           <div class="invalid-feedback d-block">


### PR DESCRIPTION
## Summary
- ask user for competitor type (amateur o profesional)
- autofill category from age and limit amateur categories
- hide category dropdown when professional is selected
- don't show clear button for radio fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687c578b7c008321ac10ee9667e05811