### PR TITLE
Fix competitor type layout

### DIFF
--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -69,8 +69,15 @@
       </div>
     </div>
     <div class="form-field">
-      {{ form.tipo_competidor }}
-      <label>{{ form.tipo_competidor.label }}</label>
+      <label class="d-block">{{ form.tipo_competidor.label }}</label>
+      <div class="d-flex gap-3">
+        {% for radio in form.tipo_competidor %}
+        <div class="form-check form-check-inline">
+          {{ radio.tag }}
+          <label class="form-check-label">{{ radio.choice_label }}</label>
+        </div>
+        {% endfor %}
+      </div>
       {% if form.tipo_competidor.errors %}
       <div class="invalid-feedback d-block">
         {{ form.tipo_competidor.errors.as_text|striptags }}

--- a/templates/clubs/competidor_form.html
+++ b/templates/clubs/competidor_form.html
@@ -25,7 +25,24 @@
     </div>
     {% for field in form %}
       {% if field.name != 'avatar' %}
-        {% if field.field.widget.input_type == 'checkbox' %}
+        {% if field.name == 'tipo_competidor' %}
+        <div class="form-field">
+          <label class="d-block">{{ field.label }}</label>
+          <div class="d-flex gap-3">
+            {% for radio in field %}
+            <div class="form-check form-check-inline">
+              {{ radio.tag }}
+              <label class="form-check-label">{{ radio.choice_label }}</label>
+            </div>
+            {% endfor %}
+          </div>
+          {% if field.errors %}
+          <div class="invalid-feedback d-block">
+            {{ field.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+        {% elif field.field.widget.input_type == 'checkbox' %}
         <div class="form-field checkbox-field">
           {{ field }}
           <label for="{{ field.id_for_label }}">{{ field.label }}</label>


### PR DESCRIPTION
## Summary
- display competitor type radios horizontally in forms

## Testing
- `python -m pip install --quiet -r requirements.txt` *(fails: Tunnel connection failed)*
- `python manage.py check` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687c593b6e248321bcde0ec48a258e29