### PR TITLE
Fix competitor modal layout

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -243,6 +243,10 @@ class CompetidorForm(forms.ModelForm):
                 ('elite', 'Elite'),
             ]
 
+        peso_field = self.fields.get('peso')
+        if peso_field:
+            peso_field.label = 'Categoría'
+
         tipo_field = self.fields.get('tipo_competidor')
         if tipo_field:
             tipo = 'profesional' if getattr(self.instance, 'modalidad', '') == 'profesional' else 'amateur'

--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -16,11 +16,13 @@
       </div>
       {% endif %}
     </div>
-    <div class="member-search mb-2 member-search-form" id="competitor-member-search-form">
-      <button type="button" class="search-icon"><i class="bi bi-search"></i></button>
-      <input type="text" id="competitor-member-search" placeholder="Buscar miembro" autocomplete="off" />
-      <button type="button" class="close-icon">&times;</button>
-      <ul id="competitor-member-results" class="list-group position-absolute w-100"></ul>
+    <div class="d-flex justify-content-center">
+      <div class="member-search mb-2 member-search-form" id="competitor-member-search-form">
+        <button type="button" class="search-icon"><i class="bi bi-search"></i></button>
+        <input type="text" id="competitor-member-search" placeholder="Buscar miembro" autocomplete="off" />
+        <button type="button" class="close-icon">&times;</button>
+        <ul id="competitor-member-results" class="list-group position-absolute w-100"></ul>
+      </div>
     </div>
     <div class="row g-2">
       <div class="col-6">
@@ -70,7 +72,7 @@
     </div>
     <div class="form-field">
       <label class="d-block">{{ form.tipo_competidor.label }}</label>
-      <div class="d-flex gap-3">
+      <div class="d-flex justify-content-center gap-3">
         {% for radio in form.tipo_competidor %}
         <div class="form-check form-check-inline">
           {{ radio.tag }}
@@ -93,15 +95,6 @@
       </div>
       {% endif %}
     </div>
-    <div class="form-field">
-      {{ form.peso }}
-      <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
-      {% if form.peso.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.peso.errors.as_text|striptags }}
-      </div>
-      {% endif %}
-    </div>
     <div class="row">
       <div class="col-6">
         <div class="form-field">
@@ -115,6 +108,15 @@
           <label for="{{ form.altura_cm.id_for_label }}">{{ form.altura_cm.label }}</label>
         </div>
       </div>
+    </div>
+    <div class="form-field">
+      {{ form.peso }}
+      <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
+      {% if form.peso.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.peso.errors.as_text|striptags }}
+      </div>
+      {% endif %}
     </div>
     <div class="form-field">
       {{ form.edad }}


### PR DESCRIPTION
## Summary
- center member search box in the competitor modal
- center radio buttons in competitor modal
- move weight category dropdown under the height/weight inputs and rename the label

## Testing
- `python -m py_compile apps/clubs/forms.py`
- ❌ `python manage.py check` *(fails: Django missing)*

------
https://chatgpt.com/codex/tasks/task_e_687c5bb62e808321949f0398dab2376f