### PR TITLE
Update competitor modal search UX

### DIFF
--- a/static/js/competitor-modal.js
+++ b/static/js/competitor-modal.js
@@ -28,9 +28,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 members = JSON.parse(membersDataEl.textContent);
               } catch (e) {}
             }
+            const searchForm = addEl.querySelector('#competitor-member-search-form');
             const searchInput = addEl.querySelector('#competitor-member-search');
             const resultsEl = addEl.querySelector('#competitor-member-results');
-            const closeBtn = addEl.querySelector('#competitor-member-search-form .close-icon');
+            const searchBtn = searchForm ? searchForm.querySelector('.search-icon') : null;
+            const closeBtn = searchForm ? searchForm.querySelector('.close-icon') : null;
             function renderResults(query) {
               if (!resultsEl) return;
               resultsEl.innerHTML = '';
@@ -61,11 +63,24 @@ document.addEventListener('DOMContentLoaded', () => {
               searchInput.addEventListener('input', () => {
                 renderResults(searchInput.value);
               });
+              searchInput.addEventListener('blur', () => {
+                if (!searchInput.value && searchForm) searchForm.classList.remove('open');
+              });
+            }
+            if (searchBtn) {
+              searchBtn.addEventListener('click', e => {
+                if (searchForm && !searchForm.classList.contains('open')) {
+                  e.preventDefault();
+                  searchForm.classList.add('open');
+                  searchInput && searchInput.focus();
+                }
+              });
             }
             if (closeBtn) {
               closeBtn.addEventListener('click', () => {
                 if (resultsEl) resultsEl.innerHTML = '';
                 if (searchInput) searchInput.value = '';
+                if (searchForm) searchForm.classList.remove('open');
               });
             }
             const form = addEl.querySelector('form');

--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -17,11 +17,13 @@
       {% endif %}
     </div>
     <div class="d-flex justify-content-center">
-      <div class="member-search mb-2 member-search-form" id="competitor-member-search-form">
-        <button type="button" class="search-icon"><i class="bi bi-search"></i></button>
-        <input type="text" id="competitor-member-search" placeholder="Buscar miembro" autocomplete="off" />
-        <button type="button" class="close-icon">&times;</button>
-        <ul id="competitor-member-results" class="list-group position-absolute w-100"></ul>
+      <div class="member-search">
+        <div class="member-search-form mb-2" id="competitor-member-search-form">
+          <button type="button" class="search-icon"><i class="bi bi-search"></i></button>
+          <input type="text" id="competitor-member-search" placeholder="Buscar miembro" autocomplete="off" />
+          <button type="button" class="close-icon">&times;</button>
+          <ul id="competitor-member-results" class="list-group position-absolute w-100"></ul>
+        </div>
       </div>
     </div>
     <div class="row g-2">
@@ -71,7 +73,6 @@
       </div>
     </div>
     <div class="form-field">
-      <label class="d-block">{{ form.tipo_competidor.label }}</label>
       <div class="d-flex justify-content-center gap-3">
         {% for radio in form.tipo_competidor %}
         <div class="form-check form-check-inline">
@@ -118,23 +119,29 @@
       </div>
       {% endif %}
     </div>
-    <div class="form-field">
-      {{ form.edad }}
-      <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
-      {% if form.edad.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.edad.errors.as_text|striptags }}
+    <div class="row">
+      <div class="col-6 col-md-4">
+        <div class="form-field">
+          {{ form.edad }}
+          <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
+          {% if form.edad.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.edad.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
       </div>
-      {% endif %}
-    </div>
-    <div class="form-field">
-      {{ form.sexo }}
-      <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
-      {% if form.sexo.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.sexo.errors.as_text|striptags }}
+      <div class="col-6 col-md-4">
+        <div class="form-field">
+          {{ form.sexo }}
+          <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
+          {% if form.sexo.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.sexo.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
       </div>
-      {% endif %}
     </div>
     <div class="form-field">
       {{ form.palmares }}


### PR DESCRIPTION
## Summary
- rework competitor modal search markup to match member search design
- add open/close behaviour in `competitor-modal.js`
- show competitor type radios without outer label
- place age and sex fields in same row to reduce age width

## Testing
- `python manage.py test` *(fails: Could not install Django)*

------
https://chatgpt.com/codex/tasks/task_e_687c5e13e690832188d6d608417f65c5