### PR TITLE
Fix competitor modal styling

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -83,6 +83,12 @@
   align-items: center;
 }
 
+.profile-form .form-field .form-check-label {
+  position: static;
+  transform: none;
+  padding: 0;
+}
+
 .profile-form .form-field input:not(:placeholder-shown) ~ label,
 .profile-form .form-field input:focus ~ label,
 .profile-form .form-field textarea:not(:placeholder-shown) ~ label,
@@ -341,7 +347,7 @@ select option[value="España"] {
 }
 
 .member-search-form.open {
-  width: 220px;
+  width: 300px;
 }
 
 .member-search-form input {

--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -17,8 +17,8 @@
       {% endif %}
     </div>
     <div class="d-flex justify-content-center">
-      <div class="member-search">
-        <div class="member-search-form mb-2" id="competitor-member-search-form">
+      <div class="member-search mb-2">
+        <div class="member-search-form" id="competitor-member-search-form">
           <button type="button" class="search-icon"><i class="bi bi-search"></i></button>
           <input type="text" id="competitor-member-search" placeholder="Buscar miembro" autocomplete="off" />
           <button type="button" class="close-icon">&times;</button>


### PR DESCRIPTION
## Summary
- center labels for competitor type radios
- enlarge member search field in modal
- tweak competitor form layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687c6223e618832182250788c8a7517c