### PR TITLE
Update competitor modal layout and styles

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -550,3 +550,18 @@ select option[value="España"] {
   width: 1%;
   white-space: nowrap;
 }
+
+/* Larger radio buttons for competitor type */
+.profile-form input[name="tipo_competidor"] {
+  width: 1.3em;
+  height: 1.3em;
+  border-radius: 50%;
+}
+.profile-form input[name="tipo_competidor"]:checked {
+  background-color: #000;
+  border-color: #000;
+}
+.profile-form input[name="tipo_competidor"] + .form-check-label {
+  font-size: 1rem;
+  font-weight: 500;
+}

--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -27,7 +27,7 @@
       </div>
     </div>
     <div class="row g-2">
-      <div class="col-6">
+      <div class="col-6 col-md-3">
         <div class="form-field">
           {{ form.nombre }}
           <button type="button" class="clear-btn">×</button>
@@ -39,7 +39,7 @@
           {% endif %}
         </div>
       </div>
-      <div class="col-6">
+      <div class="col-6 col-md-3">
         <div class="form-field">
           {{ form.apellidos }}
           <button type="button" class="clear-btn">×</button>
@@ -47,6 +47,28 @@
           {% if form.apellidos.errors %}
           <div class="invalid-feedback d-block">
             {{ form.apellidos.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+      <div class="col-6 col-md-3">
+        <div class="form-field">
+          {{ form.sexo }}
+          <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
+          {% if form.sexo.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.sexo.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+      <div class="col-6 col-md-3">
+        <div class="form-field">
+          {{ form.edad }}
+          <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
+          {% if form.edad.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.edad.errors.as_text|striptags }}
           </div>
           {% endif %}
         </div>
@@ -119,30 +141,6 @@
       </div>
       {% endif %}
     </div>
-    <div class="row">
-      <div class="col-6 col-md-4">
-        <div class="form-field">
-          {{ form.edad }}
-          <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
-          {% if form.edad.errors %}
-          <div class="invalid-feedback d-block">
-            {{ form.edad.errors.as_text|striptags }}
-          </div>
-          {% endif %}
-        </div>
-      </div>
-      <div class="col-6 col-md-4">
-        <div class="form-field">
-          {{ form.sexo }}
-          <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
-          {% if form.sexo.errors %}
-          <div class="invalid-feedback d-block">
-            {{ form.sexo.errors.as_text|striptags }}
-          </div>
-          {% endif %}
-        </div>
-      </div>
-    </div>
     <div class="form-field">
       {{ form.palmares }}
       <label for="{{ form.palmares.id_for_label }}">{{ form.palmares.label }}</label>
@@ -152,6 +150,8 @@
       </div>
       {% endif %}
     </div>
-    <button type="submit" class="btn btn-dark">Guardar</button>
+    <div class="text-end">
+      <button type="submit" class="btn btn-dark">Guardar</button>
+    </div>
 </form>
 {{ members|json_script:"competitor-members" }}


### PR DESCRIPTION
## Summary
- rearrange competitor form fields so sexo and edad share a row with nombre and apellidos
- enlarge amateur/professional radio buttons and style labels
- right align save button in competitor modal

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687c65671b588321bf908a791629c4a4