### PR TITLE
Adjust competitor form layout

### DIFF
--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -53,47 +53,23 @@
       </div>
  
     </div>
-    <div class="row">
-      <div class="col-4">
+    <div class="row align-items-end">
+      <div class="col-4 col-md-2">
         <div class="form-field">
           {{ form.victorias }}
           <label for="{{ form.victorias.id_for_label }}" class="text-success">Victorias</label>
         </div>
       </div>
-      <div class="col-4">
+      <div class="col-4 col-md-2">
         <div class="form-field">
           {{ form.derrotas }}
           <label for="{{ form.derrotas.id_for_label }}" class="text-danger">Derrotas</label>
         </div>
       </div>
-      <div class="col-4">
+      <div class="col-4 col-md-2">
         <div class="form-field">
           {{ form.empates }}
           <label for="{{ form.empates.id_for_label }}" class="text-primary">Empates</label>
-        </div>
-      </div>
-    </div>
-    <div class="row g-2 align-items-end">
-      <div class="col-6 col-md-3">
-        <div class="form-field">
-          {{ form.sexo }}
-          <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
-          {% if form.sexo.errors %}
-          <div class="invalid-feedback d-block">
-            {{ form.sexo.errors.as_text|striptags }}
-          </div>
-          {% endif %}
-        </div>
-      </div>
-      <div class="col-6 col-md-3">
-        <div class="form-field">
-          {{ form.edad }}
-          <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
-          {% if form.edad.errors %}
-          <div class="invalid-feedback d-block">
-            {{ form.edad.errors.as_text|striptags }}
-          </div>
-          {% endif %}
         </div>
       </div>
       <div class="col-12 col-md-6">
@@ -114,14 +90,53 @@
         </div>
       </div>
     </div>
-    <div class="form-field" id="modalidad-field">
-      {{ form.modalidad }}
-      <label for="{{ form.modalidad.id_for_label }}">{{ form.modalidad.label }}</label>
-      {% if form.modalidad.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.modalidad.errors.as_text|striptags }}
+    <div class="row g-2 align-items-end">
+      <div class="col-6 col-md-4">
+        <div class="form-field">
+          {{ form.sexo }}
+          <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
+          {% if form.sexo.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.sexo.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
       </div>
-      {% endif %}
+      <div class="col-6 col-md-2">
+        <div class="form-field">
+          {{ form.edad }}
+          <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
+          {% if form.edad.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.edad.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    <div class="row g-2">
+      <div class="col-12 col-md-6">
+        <div class="form-field" id="modalidad-field">
+          {{ form.modalidad }}
+          <label for="{{ form.modalidad.id_for_label }}">{{ form.modalidad.label }}</label>
+          {% if form.modalidad.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.modalidad.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+      <div class="col-12 col-md-6">
+        <div class="form-field">
+          {{ form.peso }}
+          <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
+          {% if form.peso.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.peso.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
     </div>
     <div class="row">
       <div class="col-6">
@@ -136,15 +151,6 @@
           <label for="{{ form.altura_cm.id_for_label }}">{{ form.altura_cm.label }}</label>
         </div>
       </div>
-    </div>
-    <div class="form-field">
-      {{ form.peso }}
-      <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
-      {% if form.peso.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.peso.errors.as_text|striptags }}
-      </div>
-      {% endif %}
     </div>
     <div class="form-field">
       {{ form.palmares }}

--- a/templates/clubs/competidor_form.html
+++ b/templates/clubs/competidor_form.html
@@ -4,72 +4,7 @@
 <div class="container py-4">
   {% include 'partials/_back-btn.html' %}
   <h1 class="h5">{% if competidor %}Editar{% else %}Nuevo{% endif %} competidor</h1>
-  <form method="post" enctype="multipart/form-data" class="profile-form">
-    {% csrf_token %}
-    <div class="form-field">
-      <div class="avatar-dropzone">
-        {{ form.avatar }}
-        <div class="avatar-preview{% if competidor and competidor.avatar %} has-image{% endif %}"{% if competidor and competidor.avatar %} style="background-image:url('{{ competidor.avatar.url }}')"{% endif %}>
-          <div class="avatar-dropzone-msg">
-            <i class="bi bi-cloud-upload mb-1 fs-4"></i>
-            <span>Sube avatar</span>
-          </div>
-        </div>
-      </div>
-      <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
-      {% if form.avatar.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.avatar.errors.as_text|striptags }}
-      </div>
-      {% endif %}
-    </div>
-    {% for field in form %}
-      {% if field.name != 'avatar' %}
-        {% if field.name == 'tipo_competidor' %}
-        <div class="form-field">
-          <label class="d-block">{{ field.label }}</label>
-          <div class="d-flex gap-3">
-            {% for radio in field %}
-            <div class="form-check form-check-inline">
-              {{ radio.tag }}
-              <label class="form-check-label">{{ radio.choice_label }}</label>
-            </div>
-            {% endfor %}
-          </div>
-          {% if field.errors %}
-          <div class="invalid-feedback d-block">
-            {{ field.errors.as_text|striptags }}
-          </div>
-          {% endif %}
-        </div>
-        {% elif field.field.widget.input_type == 'checkbox' %}
-        <div class="form-field checkbox-field">
-          {{ field }}
-          <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-          {% if field.errors %}
-          <div class="invalid-feedback d-block">
-            {{ field.errors.as_text|striptags }}
-          </div>
-          {% endif %}
-        </div>
-        {% else %}
-        <div class="form-field">
-          {{ field }}
-          {% if field.field.widget.input_type != 'radio' %}
-          <button type="button" class="clear-btn">×</button>
-          {% endif %}
-          <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-          {% if field.errors %}
-          <div class="invalid-feedback d-block">
-            {{ field.errors.as_text|striptags }}
-          </div>
-          {% endif %}
-        </div>
-        {% endif %}
-      {% endif %}
-    {% endfor %}
-    <button type="submit" class="btn btn-dark">Guardar</button>
-  </form>
+  {% include 'clubs/_competidor_form.html' %}
 </div>
 {% endblock %}
 {% block extra_js %}


### PR DESCRIPTION
## Summary
- tweak competitor form markup for better alignment
- simplify full-page competitor form to reuse shared template

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==5.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_687c6d86c51c8321803c67aa3450f1fa