### PR TITLE
Add signup and booking modals

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -19,6 +19,8 @@ urlpatterns = [
 
     # Perfil público de clubs
     path('@<slug:slug>/admin/', dashboard, name='club_dashboard'),
+    path('@<slug:slug>/inscribirse/', club_public.member_signup, name='club_member_signup'),
+    path('@<slug:slug>/reservar/', club_public.booking_form, name='club_booking'),
     path('@<slug:slug>/', club_public.club_profile, name='club_profile'),
     path('coach/@<slug:slug>/', club_public.coach_profile, name='coach_profile'),
 

--- a/static/js/booking-modal.js
+++ b/static/js/booking-modal.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('bookingModal');
+  const modal = modalEl ? new bootstrap.Modal(modalEl) : null;
+  const btn = document.querySelector('.booking-btn');
+  if (btn && modal) {
+    btn.addEventListener('click', () => {
+      modal.show();
+    });
+    const form = modalEl.querySelector('#booking-form');
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      modal.hide();
+    });
+  }
+});

--- a/static/js/member-signup-modal.js
+++ b/static/js/member-signup-modal.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('memberSignupModal');
+  const modal = modalEl ? new bootstrap.Modal(modalEl) : null;
+  const btn = document.querySelector('.signup-member-btn');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      const slug = btn.dataset.clubSlug;
+        fetch(`/@${slug}/inscribirse/`, { headers: { "X-Requested-With": "XMLHttpRequest" } })
+        .then(res => res.text())
+        .then(html => {
+          if (modalEl) {
+            modalEl.querySelector('.modal-body').innerHTML = html;
+            if (window.initAvatarDropzones) {
+              window.initAvatarDropzones(modalEl);
+            }
+            if (window.initSelectLabels) {
+              window.initSelectLabels(modalEl);
+            }
+            const form = modalEl.querySelector('form');
+            form.addEventListener('submit', e => {
+              e.preventDefault();
+              const fd = new FormData(form);
+              fetch(form.action, { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }, body: fd })
+                .then(() => {
+                  modal.hide();
+                });
+            });
+            modal.show();
+          }
+        });
+    });
+  }
+});

--- a/templates/clubs/_miembro_public_form.html
+++ b/templates/clubs/_miembro_public_form.html
@@ -1,0 +1,221 @@
+<form method="post" enctype="multipart/form-data" class="profile-form" action="{% url 'club_member_signup' club.slug %}">
+  {% csrf_token %}
+  <div class="form-field text-center">
+    <div class="avatar-dropzone mx-auto">
+      {{ form.avatar }}
+      <div
+        class="avatar-preview rounded-circle{% if miembro and miembro.avatar.name %} has-image{% endif %}"
+        {% if miembro and miembro.avatar.name %}
+        style="background-image:url('{{ miembro.avatar.url }}')"
+        {% endif %}
+      >
+        <div class="avatar-dropzone-msg">
+          <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+          <span>Sube avatar</span>
+        </div>
+      </div>
+    </div>
+    {% if form.avatar.errors %}
+    <div class="invalid-feedback d-block">
+      {{ form.avatar.errors.as_text|striptags }}
+    </div>
+    {% endif %}
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.nombre }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.nombre.id_for_label }}"
+          >{{ form.nombre.label }}</label
+        >
+        {% if form.nombre.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.nombre.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.apellidos }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.apellidos.id_for_label }}"
+          >{{ form.apellidos.label }}</label
+        >
+        {% if form.apellidos.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.apellidos.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-4">
+      <div class="form-field">
+        {{ form.telefono }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.telefono.id_for_label }}"
+          >{{ form.telefono.label }}</label
+        >
+        {% if form.telefono.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.telefono.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-8">
+      <div class="form-field">
+        {{ form.email }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.email.id_for_label }}"
+          >{{ form.email.label }}</label
+        >
+        {% if form.email.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.email.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3">
+      <div class="form-field">
+        {{ form.fecha_nacimiento }}
+        <label for="{{ form.fecha_nacimiento.id_for_label }}"
+          >{{ form.fecha_nacimiento.label }}</label
+        >
+        {% if form.fecha_nacimiento.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.fecha_nacimiento.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="form-field">
+        {{ form.sexo }}
+        <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
+        {% if form.sexo.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.sexo.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.nacionalidad }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.nacionalidad.id_for_label }}"
+          >{{ form.nacionalidad.label }}</label
+        >
+        {% if form.nacionalidad.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.nacionalidad.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.direccion }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.direccion.id_for_label }}"
+          >{{ form.direccion.label }}</label
+        >
+        {% if form.direccion.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.direccion.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="form-field">
+        {{ form.localidad }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.localidad.id_for_label }}"
+          >{{ form.localidad.label }}</label
+        >
+        {% if form.localidad.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.localidad.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="form-field">
+        {{ form.codigo_postal }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.codigo_postal.id_for_label }}"
+          >{{ form.codigo_postal.label }}</label
+        >
+        {% if form.codigo_postal.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.codigo_postal.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.altura }}
+        <label for="{{ form.altura.id_for_label }}"
+          >{{ form.altura.label }}</label
+        >
+        {% if form.altura.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.altura.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="form-field">
+        {{ form.peso }}
+        <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
+        {% if form.peso.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.peso.errors.as_text|striptags }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="form-field">
+    {{ form.edad }}
+    <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
+    {% if form.edad.errors %}
+    <div class="invalid-feedback d-block">
+      {{ form.edad.errors.as_text|striptags }}
+    </div>
+    {% endif %}
+  </div>
+  <div class="form-field">
+    {{ form.estado }}
+    <label for="{{ form.estado.id_for_label }}">{{ form.estado.label }}</label>
+    {% if form.estado.errors %}
+    <div class="invalid-feedback d-block">
+      {{ form.estado.errors.as_text|striptags }}
+    </div>
+    {% endif %}
+  </div>
+  <div class="form-field">
+    {{ form.notas }}
+    <label for="{{ form.notas.id_for_label }}">{{ form.notas.label }}</label>
+    {% if form.notas.errors %}
+    <div class="invalid-feedback d-block">
+      {{ form.notas.errors.as_text|striptags }}
+    </div>
+    {% endif %}
+  </div>
+  <button type="submit" class="btn btn-dark save-btn">Guardar</button>

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -129,6 +129,8 @@
                                         <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M7.926 10.898 15 7.727m-7.074 5.39L15 16.29M8 12a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm12 5.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm0-11a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Z" />
                                     </svg>
                                 </button>
+                                <a href="#" class="btn btn-dark btn-sm signup-member-btn" data-club-slug="{{ club.slug }}">Inscribirse</a>
+                                <a href="#" class="btn btn-outline-dark btn-sm booking-btn" data-club-slug="{{ club.slug }}">Reservar</a>
                             </div>
                             {% for photo in club.photos.all %}
                                 <div class="gallery-slide{% if forloop.first %} active{% endif %}">
@@ -629,6 +631,8 @@
     </div>
     {% include 'partials/_share_profile_modal.html' %}
     {% include 'partials/_register_modal.html' %}
+    {% include 'partials/_member_signup_modal.html' %}
+    {% include 'partials/_booking_modal.html' %}
     <div class="modal fade" id="reviewModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content p-3">
@@ -717,6 +721,8 @@
     <script src="{% static 'js/post-like.js' %}"></script>
     <script src="{% static 'js/gallery-slideshow.js' %}"></script>
     <script src="{% static 'js/schedule-status.js' %}"></script>
+    <script src="{% static 'js/member-signup-modal.js' %}"></script>
+    <script src="{% static 'js/booking-modal.js' %}"></script>
     <script src="{% static 'js/club-tabs.js' %}"></script>
     <script src="{% static 'js/post-media-preview.js' %}"></script>
 {% endblock %}

--- a/templates/partials/_booking_modal.html
+++ b/templates/partials/_booking_modal.html
@@ -1,0 +1,19 @@
+<div class="modal fade" id="bookingModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Reservar</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="booking-form">
+          <div class="mb-3">
+            <label for="booking-date" class="form-label">Fecha</label>
+            <input type="date" id="booking-date" class="form-control" required>
+          </div>
+          <button type="submit" class="btn btn-dark">Reservar</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/partials/_member_signup_modal.html
+++ b/templates/partials/_member_signup_modal.html
@@ -1,0 +1,11 @@
+<div class="modal fade" id="memberSignupModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Inscribirse</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add member signup modal, booking modal and related scripts
- allow public signup for new club members
- wire URLs for signup and booking
- expose buttons on club profile

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687d6d4e834c8321ac7edbea872a0202