### PR TITLE
Move buttons above club slideshow

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -103,6 +103,10 @@
             <div class="col-lg-8">
                 <div class="mb-4   rounded">
                     {% if club.photos.all %}
+                        <div class="d-flex justify-content-end gap-2 mb-2">
+                            <a href="#" class="btn btn-dark btn-sm signup-member-btn" data-club-slug="{{ club.slug }}">Inscribirse</a>
+                            <a href="#" class="btn btn-outline-dark btn-sm booking-btn" data-club-slug="{{ club.slug }}">Reservar</a>
+                        </div>
                         <div class="mb-4 gallery-slideshow position-relative">
                             <div class="gallery-actions">
                                 <!-- Heart and Share buttons -->
@@ -129,8 +133,6 @@
                                         <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M7.926 10.898 15 7.727m-7.074 5.39L15 16.29M8 12a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm12 5.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm0-11a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Z" />
                                     </svg>
                                 </button>
-                                <a href="#" class="btn btn-dark btn-sm signup-member-btn" data-club-slug="{{ club.slug }}">Inscribirse</a>
-                                <a href="#" class="btn btn-outline-dark btn-sm booking-btn" data-club-slug="{{ club.slug }}">Reservar</a>
                             </div>
                             {% for photo in club.photos.all %}
                                 <div class="gallery-slide{% if forloop.first %} active{% endif %}">


### PR DESCRIPTION
## Summary
- on the club profile page, move the **Inscribirse** and **Reservar** buttons above the slideshow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687d71385ac0832198cb4dd70dacd8d3