### PR TITLE
Add booking day selection

### DIFF
--- a/apps/clubs/migrations/0029_booking_extra_fields.py
+++ b/apps/clubs/migrations/0029_booking_extra_fields.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0028_competidor_apellidos_edad'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='booking',
+            name='club',
+            field=models.ForeignKey(null=True, blank=True, on_delete=django.db.models.deletion.CASCADE, related_name='bookings', to='clubs.club'),
+        ),
+        migrations.AddField(
+            model_name='booking',
+            name='fecha',
+            field=models.DateField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='booking',
+            name='hora',
+            field=models.TimeField(null=True, blank=True),
+        ),
+    ]

--- a/apps/clubs/models/booking.py
+++ b/apps/clubs/models/booking.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import User
 from .post import ClubPost
+from .club import Club
 
 
 class Booking(models.Model):
@@ -10,7 +11,10 @@ class Booking(models.Model):
     ]
 
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='bookings')
+    club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='bookings', null=True, blank=True)
     evento = models.ForeignKey(ClubPost, on_delete=models.CASCADE, null=True, blank=True, related_name='bookings')
+    fecha = models.DateField(null=True, blank=True)
+    hora = models.TimeField(null=True, blank=True)
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='active')
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -19,4 +23,6 @@ class Booking(models.Model):
             item = self.evento.titulo
         else:
             item = 'Sin referencia'
-        return f"{self.user.username} - {item} ({self.status})"
+        fecha = self.fecha.isoformat() if self.fecha else 'sin fecha'
+        hora = self.hora.strftime('%H:%M') if self.hora else '--:--'
+        return f"{self.user.username} - {item} {fecha} {hora} ({self.status})"

--- a/apps/clubs/views/booking.py
+++ b/apps/clubs/views/booking.py
@@ -2,6 +2,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 
+from django.utils.dateparse import parse_date, parse_time
 from ..models import ClubPost, Booking, Club
 from ..forms import BookingForm, CancelBookingForm
 
@@ -27,5 +28,7 @@ def create_booking(request, slug):
         return JsonResponse({'error': 'invalid method'}, status=400)
 
     club = get_object_or_404(Club, slug=slug)
-    Booking.objects.create(user=request.user)
+    fecha = parse_date(request.POST.get('date', ''))
+    hora = parse_time(request.POST.get('time', ''))
+    Booking.objects.create(user=request.user, club=club, fecha=fecha, hora=hora)
     return JsonResponse({'success': True})

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -164,9 +164,7 @@ def dashboard(request, slug):
     elif orden == 'newest':
         members = members.order_by('-fecha_inscripcion', '-id')
 
-    bookings = Booking.objects.filter(
-        Q(evento__club=club)
-    ).select_related('user', 'evento')
+    bookings = Booking.objects.filter(club=club).select_related('user', 'evento')
 
     form = ClubForm(instance=club)
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -95,6 +95,10 @@
   min-width: 60px;
   cursor: pointer;
 }
+#booking-days .day-card.disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
 #booking-days .badge {
   width: 30px;
   height: 4px;

--- a/static/js/booking-modal.js
+++ b/static/js/booking-modal.js
@@ -61,12 +61,16 @@ document.addEventListener('DOMContentLoaded', () => {
         `<div class="small">${dayName.charAt(0).toUpperCase() + dayName.slice(1)}</div>` +
         `<div class="fw-bold">${i}</div>` +
         `<span class="badge ${badgeClass}"></span>`;
+      card.dataset.date = date.toISOString().split('T')[0];
       const badge = card.querySelector('.badge');
-      card.addEventListener('click', () => {
-        if (!badge.classList.contains('bg-success')) return;
-        modalEl.querySelectorAll('.day-card.active').forEach(d => d.classList.remove('active'));
-        card.classList.add('active');
-      });
+      if (!badge.classList.contains('bg-success')) {
+        card.classList.add('disabled');
+      } else {
+        card.addEventListener('click', () => {
+          modalEl.querySelectorAll('.day-card.active').forEach(d => d.classList.remove('active'));
+          card.classList.add('active');
+        });
+      }
       days.push(card);
     }
     renderDays();
@@ -129,14 +133,20 @@ document.addEventListener('DOMContentLoaded', () => {
     form.addEventListener('submit', async e => {
       e.preventDefault();
       const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
-      if (!clubSlug) return;
+      const dayCard = modalEl.querySelector('.day-card.active');
+      const slotBtn = modalEl.querySelector('.slot-btn.active');
+      if (!clubSlug || !dayCard || !slotBtn) return;
+      const data = new URLSearchParams();
+      data.append('date', dayCard.dataset.date);
+      data.append('time', slotBtn.textContent);
       await fetch(`/clubs/${clubSlug}/reservar/crear/`, {
         method: 'POST',
         headers: {
           'X-CSRFToken': csrftoken,
           'X-Requested-With': 'XMLHttpRequest'
         },
-        credentials: 'same-origin'
+        credentials: 'same-origin',
+        body: data
       });
       modal.hide();
     });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -950,7 +950,7 @@
           <tr>
             <th>Usuario</th>
             <th>Evento</th>
-            <th>Fecha</th>
+            <th>Reserva</th>
             <th>Estado</th>
           </tr>
         </thead>
@@ -959,7 +959,7 @@
           <tr>
             <td>{{ b.user.username }}</td>
             <td>{{ b.evento.titulo|default:'-' }}</td>
-            <td>{{ b.created_at|date:'Y-m-d H:i' }}</td>
+            <td>{{ b.fecha }} {{ b.hora|default:'' }}</td>
             <td>{{ b.get_status_display }}</td>
           </tr>
           {% empty %}

--- a/templates/partials/_booking_modal.html
+++ b/templates/partials/_booking_modal.html
@@ -1,5 +1,5 @@
 <div class="modal fade" id="bookingModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-sm">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content">
       <form id="booking-form">
         <div class="modal-header">


### PR DESCRIPTION
## Summary
- enlarge booking modal
- allow booking only from green days and record date/time
- show reservation date in dashboard
- track bookings per club

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687d9f7908748321b7fcdc8f0f0f4686