### PR TITLE
Update booking modal and dashboard

### DIFF
--- a/apps/clubs/migrations/0030_booking_tipo_clase.py
+++ b/apps/clubs/migrations/0030_booking_tipo_clase.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('clubs', '0029_booking_extra_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='booking',
+            name='tipo_clase',
+            field=models.CharField(choices=[('privada','Privada'),('prueba','Prueba')], default='privada', max_length=20),
+        ),
+    ]

--- a/apps/clubs/models/booking.py
+++ b/apps/clubs/models/booking.py
@@ -15,6 +15,11 @@ class Booking(models.Model):
     evento = models.ForeignKey(ClubPost, on_delete=models.CASCADE, null=True, blank=True, related_name='bookings')
     fecha = models.DateField(null=True, blank=True)
     hora = models.TimeField(null=True, blank=True)
+    TIPO_CLASE_CHOICES = [
+        ('privada', 'Privada'),
+        ('prueba', 'Prueba'),
+    ]
+    tipo_clase = models.CharField(max_length=20, choices=TIPO_CLASE_CHOICES, default='privada')
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='active')
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -22,7 +27,7 @@ class Booking(models.Model):
         if self.evento:
             item = self.evento.titulo
         else:
-            item = 'Sin referencia'
+            item = self.get_tipo_clase_display()
         fecha = self.fecha.isoformat() if self.fecha else 'sin fecha'
         hora = self.hora.strftime('%H:%M') if self.hora else '--:--'
         return f"{self.user.username} - {item} {fecha} {hora} ({self.status})"

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -11,6 +11,8 @@ from apps.clubs.views import (
     post_toggle_like,
     cancel_booking,
     create_booking,
+    booking_confirm,
+    booking_cancel_admin,
 )
 from apps.clubs.views.dashboard import (
     dashboard,
@@ -80,6 +82,8 @@ urlpatterns = [
 
     path('reserva/<int:pk>/cancelar/', cancel_booking, name='cancel_booking'),
     path('<slug:slug>/reservar/crear/', create_booking, name='create_booking'),
+    path('booking/<int:pk>/confirmar/', booking_confirm, name='booking_confirm'),
+    path('booking/<int:pk>/cancelar-admin/', booking_cancel_admin, name='booking_cancel_admin'),
 
     # El perfil público ahora se maneja desde config.urls con la ruta '@slug'
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -127,3 +127,9 @@
   color: #000;
   margin: 0 0.5rem;
 }
+
+/* Booking modal radio color */
+#bookingModal .form-check-input:checked {
+  background-color: #000;
+  border-color: #000;
+}

--- a/static/js/booking-modal.js
+++ b/static/js/booking-modal.js
@@ -204,6 +204,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const data = new URLSearchParams();
       data.append('date', dayCard.dataset.date);
       data.append('time', slotBtn.textContent);
+      const tipoRadio = modalEl.querySelector('input[name="tipo_clase"]:checked');
+      if (tipoRadio) data.append('tipo_clase', tipoRadio.value);
       await fetch(`/clubs/${clubSlug}/reservar/crear/`, {
         method: 'POST',
         headers: {

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -949,22 +949,33 @@
         <thead>
           <tr>
             <th>Usuario</th>
-            <th>Evento</th>
+            <th>Clase</th>
             <th>Reserva</th>
             <th>Estado</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
           {% for b in bookings %}
           <tr>
             <td>{{ b.user.username }}</td>
-            <td>{{ b.evento.titulo|default:'-' }}</td>
+            <td>{{ b.get_tipo_clase_display }}</td>
             <td>{{ b.fecha }} {{ b.hora|default:'' }}</td>
             <td>{{ b.get_status_display }}</td>
+            <td class="d-flex gap-1">
+              <form method="post" action="{% url 'booking_confirm' b.id %}">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-success btn-sm">Confirmar</button>
+              </form>
+              <form method="post" action="{% url 'booking_cancel_admin' b.id %}">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-danger btn-sm">Cancelar</button>
+              </form>
+            </td>
           </tr>
           {% empty %}
           <tr>
-            <td colspan="4" class="text-muted">No hay reservas.</td>
+            <td colspan="5" class="text-muted">No hay reservas.</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/templates/partials/_booking_modal.html
+++ b/templates/partials/_booking_modal.html
@@ -62,8 +62,7 @@
               </div>
             </div>
           </div>
-          <div class="mt-3">
-            <label class="form-label">Concepto de clase</label>
+          <div class="mt-3 d-flex flex-column align-items-center gap-2">
             <div class="form-check">
               <input class="form-check-input" type="radio" name="tipo_clase" id="clase_privada" value="privada" checked>
               <label class="form-check-label" for="clase_privada">Clase privada - 30€ - 60min</label>
@@ -92,9 +91,9 @@
       <div class="modal-body">
         ¿Seguro que quieres cancelar la reserva? Los cambios no guardados se perderán.
       </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Continuar reserva</button>
-        <button type="button" class="btn btn-danger confirm-cancel">Si, descartar</button>
+      <div class="modal-footer d-flex flex-column gap-2">
+        <button type="button" class="btn btn-secondary w-100" data-bs-dismiss="modal">Continuar reserva</button>
+        <button type="button" class="btn btn-danger w-100 confirm-cancel">Si, descartar</button>
       </div>
     </div>
   </div>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -70,11 +70,7 @@
                 {% for b in bookings %}
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                     <span>
-                        {% if b.evento %}
-                            Evento: {{ b.evento.titulo }}
-                        {% else %}
-                            Reserva sin referencia
-                        {% endif %}
+                        {{ b.get_tipo_clase_display }}
                     </span>
                     {% if b.status != 'cancelled' %}
                     <form action="{% url 'cancel_booking' b.id %}" method="post" class="ms-2">


### PR DESCRIPTION
## Summary
- add `tipo_clase` field to `Booking` model with migration
- allow booking creation with class type
- update booking modal layout and submit logic
- display bookings with class type and action buttons in dashboard
- style radio buttons and confirmation modal
- show class type in user profile

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687da676bc3c8321b7086efa0bdd4330