### PR TITLE
Improve availability table navigation

### DIFF
--- a/static/js/availability-manager.js
+++ b/static/js/availability-manager.js
@@ -3,6 +3,8 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!table) return;
   const monthSelect = document.getElementById('availability-month');
   const yearSelect = document.getElementById('availability-year');
+  const prevBtn = document.getElementById('availability-prev');
+  const nextBtn = document.getElementById('availability-next');
 
   function updateCellColor(td, value) {
     td.classList.toggle('bg-danger', value === 0);
@@ -10,20 +12,17 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function buildTable() {
-    const daysOfWeek = [
-      'Lunes',
-      'Martes',
-      'Miércoles',
-      'Jueves',
-      'Viernes',
-      'Sábado',
-      'Domingo',
-    ];
+    const dayNames = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
+    const month = parseInt(monthSelect.value, 10);
+    const year = parseInt(yearSelect.value, 10);
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
     const thead = table.querySelector('thead');
     thead.innerHTML = '<tr><th></th>';
-    daysOfWeek.forEach((day) => {
-      thead.innerHTML += `<th>${day}</th>`;
-    });
+    for (let d = 1; d <= daysInMonth; d++) {
+      const date = new Date(year, month, d);
+      const dow = dayNames[date.getDay()];
+      thead.innerHTML += `<th><div class="small">${dow}</div><div>${d}</div></th>`;
+    }
     thead.innerHTML += '</tr>';
 
     const tbody = table.querySelector('tbody');
@@ -33,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const th = document.createElement('th');
       th.textContent = `${String(h).padStart(2, '0')}:00`;
       row.appendChild(th);
-      for (let d = 0; d < daysOfWeek.length; d++) {
+      for (let d = 1; d <= daysInMonth; d++) {
         const td = document.createElement('td');
         const input = document.createElement('input');
         input.type = 'number';
@@ -52,8 +51,33 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function changeMonth(offset) {
+    let month = parseInt(monthSelect.value, 10);
+    let year = parseInt(yearSelect.value, 10);
+    month += offset;
+    if (month < 0) {
+      month = 11;
+      year -= 1;
+    } else if (month > 11) {
+      month = 0;
+      year += 1;
+    }
+    monthSelect.value = month;
+    let yearOption = Array.from(yearSelect.options).find((o) => parseInt(o.value, 10) === year);
+    if (!yearOption) {
+      yearOption = document.createElement('option');
+      yearOption.value = year;
+      yearOption.textContent = year;
+      yearSelect.appendChild(yearOption);
+    }
+    yearSelect.value = year;
+    buildTable();
+  }
+
   monthSelect.addEventListener('change', buildTable);
   yearSelect.addEventListener('change', buildTable);
+  if (prevBtn) prevBtn.addEventListener('click', () => changeMonth(-1));
+  if (nextBtn) nextBtn.addEventListener('click', () => changeMonth(1));
   buildTable();
 
   const saveBtn = document.getElementById('availability-save');

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -947,7 +947,10 @@
     <div id="tab-bookings" class="profile-section">
       <div id="availability-manager" class="mb-4">
         <h5 class="mb-3">Administrar disponibilidad</h5>
-        <div class="d-flex gap-2 mb-2">
+        <div class="d-flex align-items-center gap-2 mb-2">
+          <button id="availability-prev" class="btn btn-light btn-sm">
+            <i class="bi bi-chevron-left"></i>
+          </button>
           <select id="availability-month" class="form-select form-select-sm" style="width:auto;">
             {% for m in months %}
               <option value="{{ forloop.counter0 }}" {% if forloop.counter0 == today.month|add:'-1' %}selected{% endif %}>{{ m }}</option>
@@ -958,6 +961,9 @@
               <option value="{{ y }}" {% if y == today.year %}selected{% endif %}>{{ y }}</option>
             {% endfor %}
           </select>
+          <button id="availability-next" class="btn btn-light btn-sm">
+            <i class="bi bi-chevron-right"></i>
+          </button>
         </div>
         <div class="table-responsive">
           <table id="availability-table" class="table table-bordered table-sm text-center">


### PR DESCRIPTION
## Summary
- add month navigation buttons
- show all days of a month in availability table

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687db0d89ad48321874d995790898325