### PR TITLE
Improve availability manager date handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ config/db.sqlite4
 staticfiles/
 media/
 
+venv/

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -64,11 +64,14 @@ def dashboard(request, slug):
         'F': members.filter(sexo='F').count(),
     }
     today = timezone.now().date()
-    months = [
+    months_full = [
         'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
         'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'
     ]
-    years = [today.year, today.year + 1]
+    # Only include months from the current month to December
+    months = [(i, months_full[i]) for i in range(today.month - 1, 12)]
+    # Availability is limited to the current year
+    years = [today.year]
     miembros_pagados = members.filter(
         pagos__fecha__year=today.year,
         pagos__fecha__month=today.month,

--- a/static/js/availability-manager.js
+++ b/static/js/availability-manager.js
@@ -7,7 +7,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const nextBtn = document.getElementById('availability-next');
 
   const DAYS_STEP = 10;
-  let startDay = 1;
+  const today = new Date();
+  let startDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const endOfYear = new Date(today.getFullYear(), 11, 31);
+
+  function updateSelectors() {
+    monthSelect.value = startDate.getMonth();
+    yearSelect.value = startDate.getFullYear();
+  }
 
   function updateCellColor(td, value) {
     td.classList.toggle('bg-danger', value === 0);
@@ -15,12 +22,12 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function buildTable() {
+    updateSelectors();
     const dayNames = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
-    const month = parseInt(monthSelect.value, 10);
-    const year = parseInt(yearSelect.value, 10);
-    const daysInMonth = new Date(year, month + 1, 0).getDate();
-    if (startDay > daysInMonth) startDay = 1;
-    const maxDays = Math.min(daysInMonth - startDay + 1, DAYS_STEP);
+    const maxDays = Math.min(
+      DAYS_STEP,
+      Math.floor((endOfYear - startDate) / (24 * 60 * 60 * 1000)) + 1
+    );
 
     const thead = table.querySelector('thead');
     thead.innerHTML = '';
@@ -28,15 +35,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const empty = document.createElement('th');
     headRow.appendChild(empty);
     for (let i = 0; i < maxDays; i++) {
-      const d = startDay + i;
-      const date = new Date(year, month, d);
+      const date = new Date(startDate);
+      date.setDate(startDate.getDate() + i);
       const dow = dayNames[date.getDay()];
       const th = document.createElement('th');
       const dayDiv = document.createElement('div');
       dayDiv.className = 'small';
       dayDiv.textContent = dow;
       const numDiv = document.createElement('div');
-      numDiv.textContent = d;
+      numDiv.textContent = date.getDate();
       th.appendChild(dayDiv);
       th.appendChild(numDiv);
       headRow.appendChild(th);
@@ -70,17 +77,36 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function changeDays(step) {
-    const month = parseInt(monthSelect.value, 10);
-    const year = parseInt(yearSelect.value, 10);
-    const daysInMonth = new Date(year, month + 1, 0).getDate();
-    startDay += step * DAYS_STEP;
-    if (startDay < 1) startDay = 1;
-    if (startDay > daysInMonth) startDay = Math.max(1, daysInMonth - DAYS_STEP + 1);
+    const newDate = new Date(startDate);
+    newDate.setDate(newDate.getDate() + step * DAYS_STEP);
+    if (newDate < today) {
+      startDate = new Date(today);
+    } else if (newDate > endOfYear) {
+      startDate = new Date(endOfYear);
+      startDate.setDate(endOfYear.getDate() - DAYS_STEP + 1);
+      if (startDate < today) startDate = new Date(today);
+    } else {
+      startDate = newDate;
+    }
     buildTable();
   }
 
-  monthSelect.addEventListener('change', () => { startDay = 1; buildTable(); });
-  yearSelect.addEventListener('change', () => { startDay = 1; buildTable(); });
+  monthSelect.addEventListener('change', () => {
+    const month = parseInt(monthSelect.value, 10);
+    const year = parseInt(yearSelect.value, 10);
+    startDate = new Date(year, month, 1);
+    if (startDate < today) startDate = new Date(today);
+    buildTable();
+  });
+
+  yearSelect.addEventListener('change', () => {
+    const month = parseInt(monthSelect.value, 10);
+    const year = parseInt(yearSelect.value, 10);
+    startDate = new Date(year, month, 1);
+    if (startDate < today) startDate = new Date(today);
+    buildTable();
+  });
+
   if (prevBtn) prevBtn.addEventListener('click', () => changeDays(-1));
   if (nextBtn) nextBtn.addEventListener('click', () => changeDays(1));
   buildTable();

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -952,14 +952,12 @@
             <i class="bi bi-chevron-left"></i>
           </button>
           <select id="availability-month" class="form-select form-select-sm" style="width:auto;">
-            {% for m in months %}
-              <option value="{{ forloop.counter0 }}" {% if forloop.counter0 == today.month|add:'-1' %}selected{% endif %}>{{ m }}</option>
+            {% for idx, label in months %}
+              <option value="{{ idx }}" {% if idx == today.month|add:'-1' %}selected{% endif %}>{{ label }}</option>
             {% endfor %}
           </select>
           <select id="availability-year" class="form-select form-select-sm" style="width:auto;">
-            {% for y in years %}
-              <option value="{{ y }}" {% if y == today.year %}selected{% endif %}>{{ y }}</option>
-            {% endfor %}
+            <option value="{{ today.year }}" selected>{{ today.year }}</option>
           </select>
           <button id="availability-next" class="btn btn-light btn-sm">
             <i class="bi bi-chevron-right"></i>


### PR DESCRIPTION
## Summary
- slice months list from current month
- restrict availability year to current year
- update dashboard template for new month/year options
- overhaul JS to iterate days across months
- ignore local venv

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687dbe605fa08321b0b2ab8dad4cc2f4