### PR TITLE
Remove obsolete schedule table

### DIFF
--- a/static/js/schedule-manager.js
+++ b/static/js/schedule-manager.js
@@ -2,7 +2,6 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   const table = document.getElementById('schedule-table');
-  if (!table) return;
   const dataEl = document.getElementById('schedule-data');
   const monthSelect = document.getElementById('schedule-month');
   const yearSelect = document.getElementById('schedule-year');
@@ -119,11 +118,13 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function updateSelectors() {
+    if (!monthSelect || !yearSelect) return;
     monthSelect.value = startDate.getMonth();
     yearSelect.value = startDate.getFullYear();
   }
 
   function buildTable() {
+    if (!table) return;
     updateSelectors();
     const maxDays = Math.min(
       DAYS_STEP,
@@ -216,29 +217,31 @@ document.addEventListener('DOMContentLoaded', () => {
     syncAvailability();
   }
 
-  monthSelect.addEventListener('change', () => {
-    const month = parseInt(monthSelect.value, 10);
-    const year = parseInt(yearSelect.value, 10);
-    startDate = new Date(year, month, 1);
-    if (startDate < today) startDate = new Date(today);
-    loadHours();
-    renderHours();
-    saveHours();
-    buildTable();
-    syncAvailability();
-  });
+  if (monthSelect)
+    monthSelect.addEventListener('change', () => {
+      const month = parseInt(monthSelect.value, 10);
+      const year = parseInt(yearSelect.value, 10);
+      startDate = new Date(year, month, 1);
+      if (startDate < today) startDate = new Date(today);
+      loadHours();
+      renderHours();
+      saveHours();
+      buildTable();
+      syncAvailability();
+    });
 
-  yearSelect.addEventListener('change', () => {
-    const month = parseInt(monthSelect.value, 10);
-    const year = parseInt(yearSelect.value, 10);
-    startDate = new Date(year, month, 1);
-    if (startDate < today) startDate = new Date(today);
-    loadHours();
-    renderHours();
-    saveHours();
-    buildTable();
-    syncAvailability();
-  });
+  if (yearSelect)
+    yearSelect.addEventListener('change', () => {
+      const month = parseInt(monthSelect.value, 10);
+      const year = parseInt(yearSelect.value, 10);
+      startDate = new Date(year, month, 1);
+      if (startDate < today) startDate = new Date(today);
+      loadHours();
+      renderHours();
+      saveHours();
+      buildTable();
+      syncAvailability();
+    });
 
   if (prevBtn) prevBtn.addEventListener('click', () => changeDays(-1));
   if (nextBtn) nextBtn.addEventListener('click', () => changeDays(1));

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -963,12 +963,6 @@
             <i class="bi bi-chevron-right"></i>
           </button>
         </div>
-        <div class="table-responsive">
-          <table id="schedule-table" class="table table-bordered table-sm text-center">
-            <thead></thead>
-            <tbody></tbody>
-          </table>
-        </div>
         <form id="schedule-hours-form" class="row g-2 mt-2">
           <div class="col">
             <input type="time" id="schedule-hours-start" class="form-control form-control-sm" required />


### PR DESCRIPTION
## Summary
- drop unused schedule table in club dashboard
- adjust schedule-manager JS so form works without table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687f947b82dc8321bb01fd65aaa9f201