### PR TITLE
Add per-day schedule hours

### DIFF
--- a/static/js/availability-manager.js
+++ b/static/js/availability-manager.js
@@ -23,7 +23,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const endOfYear = new Date(today.getFullYear(), 11, 31);
 
   document.addEventListener('scheduleHoursUpdate', e => {
-    hours = e.detail?.hours || [];
+    if (e.detail?.hours) {
+      hours = e.detail.hours;
+    } else if (e.detail?.hoursMap) {
+      hours = Array.from(
+        new Set(Object.values(e.detail.hoursMap).reduce((a, v) => a.concat(v || []), []))
+      ).sort();
+    }
     buildTable();
   });
 

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -977,6 +977,12 @@
             </div>
           </form>
           <ul id="schedule-hours-list" class="list-unstyled mt-2"></ul>
+          <div class="table-responsive mt-3">
+            <table id="schedule-table" class="table table-bordered table-sm text-center">
+              <thead></thead>
+              <tbody></tbody>
+            </table>
+          </div>
           {{ horarios_json|json_script:"schedule-data" }}
         </div>
         <div class="d-flex align-items-center gap-2 mb-2">


### PR DESCRIPTION
## Summary
- allow storing hours per day in `schedule-manager.js`
- integrate new daily hours UI inside dashboard availability
- adjust `availability-manager.js` to work with union of hours
- add table markup for daily schedule view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6880464a66e88321a8182725dd1a4428