### PR TITLE
Add clear button for availability manager

### DIFF
--- a/static/js/availability-manager.js
+++ b/static/js/availability-manager.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const yearSelect = document.getElementById('availability-year');
   const prevBtn = document.getElementById('availability-prev');
   const nextBtn = document.getElementById('availability-next');
+  const clearBtn = document.getElementById('availability-clear');
 
 
   let availability = {};
@@ -171,6 +172,17 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       localStorage.setItem('availability-' + clubSlug, JSON.stringify(availability));
       alert('Cambios guardados');
+    });
+  }
+
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      availability = {};
+      table.querySelectorAll('tbody input').forEach(input => {
+        input.value = 0;
+        updateCellColor(input.closest('td'), 0);
+      });
+      localStorage.removeItem('availability-' + clubSlug);
     });
   }
 });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1009,6 +1009,7 @@
         </div>
         <div class="d-flex gap-2">
           <button id="availability-save" class="btn btn-primary btn-sm">Guardar cambios</button>
+          <button type="button" id="availability-clear" class="btn btn-outline-danger btn-sm">Limpiar</button>
         </div>
       </div>
       <table class="table table-sm">


### PR DESCRIPTION
## Summary
- add a `Limpiar` button to availability manager section
- implement JS logic to clear availability data and localStorage

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*
- `pip install -r requirements.txt` *(fails: Could not find a version due to missing internet)*

------
https://chatgpt.com/codex/tasks/task_e_68804b37e7dc8321b2578f8dc43966a2