### PR TITLE
Add booking availability model and management

### DIFF
--- a/apps/clubs/migrations/0031_availability_slot.py
+++ b/apps/clubs/migrations/0031_availability_slot.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0030_booking_tipo_clase'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AvailabilitySlot',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('date', models.DateField()),
+                ('time', models.TimeField()),
+                ('slots', models.PositiveIntegerField(default=1)),
+                ('club', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='availability', to='clubs.club')),
+            ],
+            options={
+                'ordering': ['date', 'time'],
+                'unique_together': {('club', 'date', 'time')},
+            },
+        ),
+    ]

--- a/apps/clubs/models/__init__.py
+++ b/apps/clubs/models/__init__.py
@@ -10,3 +10,4 @@ from .post import ClubPost
 from .booking import Booking
 from .member import Miembro
 from .payment import Pago
+from .availability import AvailabilitySlot

--- a/apps/clubs/models/availability.py
+++ b/apps/clubs/models/availability.py
@@ -1,0 +1,15 @@
+from django.db import models
+from .club import Club
+
+class AvailabilitySlot(models.Model):
+    club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='availability')
+    date = models.DateField()
+    time = models.TimeField()
+    slots = models.PositiveIntegerField(default=1)
+
+    class Meta:
+        unique_together = ('club', 'date', 'time')
+        ordering = ['date', 'time']
+
+    def __str__(self):
+        return f"{self.club.name} {self.date} {self.time} ({self.slots})"

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -13,6 +13,8 @@ from apps.clubs.views import (
     create_booking,
     booking_confirm,
     booking_cancel_admin,
+    availability_json,
+    availability_save,
 )
 from apps.clubs.views.dashboard import (
     dashboard,
@@ -84,6 +86,8 @@ urlpatterns = [
     path('<slug:slug>/reservar/crear/', create_booking, name='create_booking'),
     path('booking/<int:pk>/confirmar/', booking_confirm, name='booking_confirm'),
     path('booking/<int:pk>/cancelar-admin/', booking_cancel_admin, name='booking_cancel_admin'),
+    path('<slug:slug>/availability/json/', availability_json, name='availability_json'),
+    path('<slug:slug>/availability/save/', availability_save, name='availability_save'),
 
     # El perfil público ahora se maneja desde config.urls con la ruta '@slug'
 

--- a/apps/clubs/views/booking.py
+++ b/apps/clubs/views/booking.py
@@ -3,7 +3,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 
 from django.utils.dateparse import parse_date, parse_time
-from ..models import ClubPost, Booking, Club
+from ..models import ClubPost, Booking, Club, AvailabilitySlot
 from ..forms import BookingForm, CancelBookingForm
 
 
@@ -31,14 +31,19 @@ def create_booking(request, slug):
     fecha = parse_date(request.POST.get('date', ''))
     hora = parse_time(request.POST.get('time', ''))
     tipo_clase = request.POST.get('tipo_clase', 'privada')
-    Booking.objects.create(
-        user=request.user,
-        club=club,
-        fecha=fecha,
-        hora=hora,
-        tipo_clase=tipo_clase,
-    )
-    return JsonResponse({'success': True})
+    slot = AvailabilitySlot.objects.filter(club=club, date=fecha, time=hora).first()
+    if slot and slot.slots > 0:
+        Booking.objects.create(
+            user=request.user,
+            club=club,
+            fecha=fecha,
+            hora=hora,
+            tipo_clase=tipo_clase,
+        )
+        slot.slots -= 1
+        slot.save()
+        return JsonResponse({'success': True})
+    return JsonResponse({'error': 'no slot'}, status=400)
 
 
 @login_required
@@ -59,3 +64,41 @@ def booking_confirm(request, pk):
 
 def booking_cancel_admin(request, pk):
     return booking_set_status(request, pk, 'cancelled')
+
+@login_required
+def availability_json(request, slug):
+    club = get_object_or_404(Club, slug=slug)
+    if club.owner != request.user:
+        return JsonResponse({}, status=403)
+    slots = club.availability.all()
+    data = {}
+    for slot in slots:
+        date_str = slot.date.isoformat()
+        time_str = slot.time.strftime('%H:%M')
+        data.setdefault(date_str, {})[time_str] = slot.slots
+    return JsonResponse(data)
+
+@login_required
+def availability_save(request, slug):
+    if request.method != 'POST':
+        return JsonResponse({'error': 'invalid method'}, status=400)
+    club = get_object_or_404(Club, slug=slug)
+    if club.owner != request.user:
+        return JsonResponse({}, status=403)
+    try:
+        import json
+        payload = json.loads(request.body.decode('utf-8'))
+    except Exception:
+        return JsonResponse({'error': 'invalid payload'}, status=400)
+    club.availability.all().delete()
+    objs = []
+    for date_str, times in payload.items():
+        for time_str, slots in times.items():
+            objs.append(AvailabilitySlot(
+                club=club,
+                date=parse_date(date_str),
+                time=parse_time(time_str),
+                slots=slots or 0,
+            ))
+    AvailabilitySlot.objects.bulk_create(objs)
+    return JsonResponse({'success': True})

--- a/static/js/booking-modal.js
+++ b/static/js/booking-modal.js
@@ -129,10 +129,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function populateModal() {
+  async function populateModal() {
     if (!modalEl) return;
+    availability = {};
     try {
-      availability = JSON.parse(localStorage.getItem('availability-' + clubSlug)) || {};
+      const res = await fetch(`/clubs/${clubSlug}/availability/json/`, {credentials: 'same-origin'});
+      if (res.ok) {
+        availability = await res.json();
+      }
     } catch { availability = {}; }
 
     currentDate = new Date(today.getFullYear(), today.getMonth(), 1);
@@ -145,9 +149,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (modal) {
     bookingBtns.forEach(btn => {
-      btn.addEventListener('click', () => {
+      btn.addEventListener('click', async () => {
         clubSlug = btn.dataset.clubSlug;
-        populateModal();
+        await populateModal();
         modal.show();
       });
     });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1010,6 +1010,7 @@
         <div class="d-flex gap-2">
           <button id="availability-save" class="btn btn-primary btn-sm">Guardar cambios</button>
           <button type="button" id="availability-clear" class="btn btn-outline-danger btn-sm">Limpiar</button>
+          <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
         </div>
       </div>
       <table class="table table-sm">


### PR DESCRIPTION
## Summary
- add `AvailabilitySlot` model and migration
- update `booking` views to check slots
- expose availability endpoints in URLs
- persist availability with new JS logic
- load availability in booking modal
- keep csrf token on dashboard page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68804f80e7348321821244e07453f277