### PR TITLE
Sync schedule hours with availability

### DIFF
--- a/static/js/availability-manager.js
+++ b/static/js/availability-manager.js
@@ -37,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
     buildTable();
+    saveAvailability();
   });
 
   function updateSelectors() {
@@ -125,6 +126,17 @@ document.addEventListener('DOMContentLoaded', () => {
     );
   }
 
+  function saveAvailability() {
+    table.querySelectorAll('tbody input').forEach(input => {
+      const date = input.dataset.date;
+      const time = input.dataset.time;
+      const val = parseInt(input.value, 10) || 0;
+      if (!availability[date]) availability[date] = {};
+      availability[date][time] = val;
+    });
+    localStorage.setItem('availability-' + clubSlug, JSON.stringify(availability));
+  }
+
   function changeDays(step) {
     const newDate = new Date(startDate);
     newDate.setDate(newDate.getDate() + step * DAYS_STEP);
@@ -159,18 +171,12 @@ document.addEventListener('DOMContentLoaded', () => {
   if (prevBtn) prevBtn.addEventListener('click', () => changeDays(-1));
   if (nextBtn) nextBtn.addEventListener('click', () => changeDays(1));
   buildTable();
+  saveAvailability();
 
   const saveBtn = document.getElementById('availability-save');
   if (saveBtn) {
     saveBtn.addEventListener('click', () => {
-      table.querySelectorAll('tbody input').forEach(input => {
-        const date = input.dataset.date;
-        const time = input.dataset.time;
-        const val = parseInt(input.value, 10) || 0;
-        if (!availability[date]) availability[date] = {};
-        availability[date][time] = val;
-      });
-      localStorage.setItem('availability-' + clubSlug, JSON.stringify(availability));
+      saveAvailability();
       alert('Cambios guardados');
     });
   }

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -973,8 +973,7 @@
               <button type="button" id="schedule-hours-clear" class="btn btn-outline-danger btn-sm">Limpiar</button>
             </div>
           </form>
-          <ul id="schedule-hours-list" class="list-unstyled mt-2"></ul>
-            {{ horarios_json|json_script:"schedule-data" }}
+          {{ horarios_json|json_script:"schedule-data" }}
         </div>
         <div class="d-flex align-items-center gap-2 mb-2">
           <button id="availability-prev" class="btn btn-light btn-sm">


### PR DESCRIPTION
## Summary
- remove unused hours list element from dashboard
- keep availability in sync with schedule changes

## Testing
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_688058a50ea88321b80c384469562ee2