### PR TITLE
Remove schedule date/time inputs and style table pickers

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -133,3 +133,11 @@
   background-color: #000;
   border-color: #000;
 }
+
+/* Reduced height for schedule time pickers */
+#schedule-manager input[type="time"].form-control-sm {
+  height: 1rem;
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+  font-size: 0.75rem;
+}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -949,30 +949,7 @@
         <h5 class="mb-3">Administrar disponibilidad</h5>
         <div id="schedule-manager" class="mb-3">
           <h6 class="mb-3">Gestor de horario</h6>
-          <form id="schedule-hours-form" class="row g-2 mt-2">
-            <div class="col-auto">
-              <input
-                type="date"
-                id="schedule-date"
-                class="form-control form-control-sm"
-                required
-              />
-            </div>
-            <div class="col-auto">
-              <input
-                type="time"
-                id="schedule-time"
-                class="form-control form-control-sm"
-                required
-              />
-            </div>
-            <div class="col-auto">
-              <button type="submit" class="btn btn-dark btn-sm">Añadir</button>
-            </div>
-            <div class="col-auto">
-              <button type="button" id="schedule-hours-clear" class="btn btn-outline-danger btn-sm">Limpiar</button>
-            </div>
-          </form>
+          <!-- Removed legacy day and time pickers -->
           {{ horarios_json|json_script:"schedule-data" }}
         </div>
         <div class="d-flex align-items-center gap-2 mb-2">


### PR DESCRIPTION
## Summary
- remove outdated date and time pickers from dashboard schedule manager
- shrink time picker height in schedule table

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68805d713e1c8321a2d3b17382a689ea