### PR TITLE
Implement copy availability and booking delete

### DIFF
--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -13,6 +13,7 @@ from apps.clubs.views import (
     create_booking,
     booking_confirm,
     booking_cancel_admin,
+    booking_delete,
 )
 from apps.clubs.views.dashboard import (
     dashboard,
@@ -84,6 +85,7 @@ urlpatterns = [
     path('<slug:slug>/reservar/crear/', create_booking, name='create_booking'),
     path('booking/<int:pk>/confirmar/', booking_confirm, name='booking_confirm'),
     path('booking/<int:pk>/cancelar-admin/', booking_cancel_admin, name='booking_cancel_admin'),
+    path('booking/<int:pk>/eliminar/', booking_delete, name='booking_delete'),
 
     # El perfil público ahora se maneja desde config.urls con la ruta '@slug'
 

--- a/apps/clubs/views/__init__.py
+++ b/apps/clubs/views/__init__.py
@@ -1,7 +1,7 @@
 from .search import search_results
 from .public import club_profile, coach_profile, ajax_reviews
 from .post import post_create, post_update, post_delete, post_reply, post_toggle_like
-from .booking import cancel_booking, create_booking, booking_confirm, booking_cancel_admin
+from .booking import cancel_booking, create_booking, booking_confirm, booking_cancel_admin, booking_delete
 from .dashboard import (
     dashboard,
     club_edit,

--- a/apps/clubs/views/booking.py
+++ b/apps/clubs/views/booking.py
@@ -5,6 +5,7 @@ from django.http import JsonResponse
 from django.utils.dateparse import parse_date, parse_time
 from ..models import ClubPost, Booking, Club
 from ..forms import BookingForm, CancelBookingForm
+from django.contrib import messages
 
 
 @login_required
@@ -59,3 +60,16 @@ def booking_confirm(request, pk):
 
 def booking_cancel_admin(request, pk):
     return booking_set_status(request, pk, 'cancelled')
+
+
+@login_required
+def booking_delete(request, pk):
+    booking = get_object_or_404(Booking, pk=pk)
+    if booking.club and booking.club.owner != request.user:
+        return redirect('home')
+    if request.method == 'POST':
+        slug = booking.club.slug
+        booking.delete()
+        messages.success(request, 'Reserva eliminada correctamente.')
+        return redirect('club_dashboard', slug=slug)
+    return render(request, 'clubs/booking_confirm_delete.html', {'booking': booking})

--- a/static/js/availability-manager.js
+++ b/static/js/availability-manager.js
@@ -125,12 +125,30 @@ document.addEventListener('DOMContentLoaded', () => {
       const th = document.createElement('th');
       const label = document.createElement('span');
       label.textContent = t;
+      const copyBtn = document.createElement('button');
+      copyBtn.type = 'button';
+      copyBtn.className = 'btn btn-link btn-sm text-secondary ms-1';
+      copyBtn.innerHTML = '<i class="bi bi-copy"></i>';
+      copyBtn.addEventListener('click', () => {
+        if (!confirm('¿Copiar disponibilidad a todas las fechas?')) return;
+        const inputs = row.querySelectorAll('input');
+        const val = inputs[0] ? parseInt(inputs[0].value, 10) || 0 : 0;
+        inputs.forEach(input => {
+          input.value = val;
+          updateCellColor(input.closest('td'), val);
+        });
+        saveAvailability();
+      });
+
       const delBtn = document.createElement('button');
       delBtn.type = 'button';
       delBtn.className = 'btn btn-link btn-sm text-danger ms-1';
       delBtn.innerHTML = '<i class="bi bi-dash-circle"></i>';
-      delBtn.addEventListener('click', () => removeTime(t));
+      delBtn.addEventListener('click', () => {
+        if (confirm('¿Eliminar hora?')) removeTime(t);
+      });
       th.appendChild(label);
+      th.appendChild(copyBtn);
       th.appendChild(delBtn);
       row.appendChild(th);
       for (let i = 0; i < maxDays; i++) {
@@ -237,13 +255,13 @@ document.addEventListener('DOMContentLoaded', () => {
   buildTable();
   saveAvailability();
 
-  const saveBtn = document.getElementById('availability-save');
-  if (saveBtn) {
-    saveBtn.addEventListener('click', () => {
-      saveAvailability();
-      alert('Cambios guardados');
-    });
-  }
+    const saveBtn = document.getElementById('availability-save');
+    if (saveBtn) {
+      saveBtn.addEventListener('click', () => {
+        saveAvailability();
+        showToast('Disponibilidad guardada');
+      });
+    }
 
   if (clearBtn) {
     clearBtn.addEventListener('click', () => {
@@ -256,4 +274,20 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 });
+
+function showToast(message) {
+  let container = document.querySelector('.toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'toast-container position-fixed top-0 end-0 p-3';
+    document.body.appendChild(container);
+  }
+  const toast = document.createElement('div');
+  toast.className = 'toast bg-black text-bg-success border-0 mb-2';
+  toast.role = 'alert';
+  toast.innerHTML = `<div class="d-flex"><div class="toast-body">${message}</div>` +
+                    `<button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button></div>`;
+  container.appendChild(toast);
+  new bootstrap.Toast(toast).show();
+}
 

--- a/templates/clubs/booking_confirm_delete.html
+++ b/templates/clubs/booking_confirm_delete.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">Eliminar reserva</h1>
+  <p>¿Seguro que deseas eliminar esta reserva?</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Eliminar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -975,7 +975,7 @@
           </table>
         </div>
         <div class="d-flex gap-2">
-          <button id="availability-save" class="btn btn-primary btn-sm">Guardar cambios</button>
+          <button id="availability-save" class="btn btn-dark btn-sm text-white">Guardar</button>
           <button type="button" id="availability-clear" class="btn btn-outline-danger btn-sm">Limpiar</button>
         </div>
       </div>
@@ -1004,6 +1004,10 @@
               <form method="post" action="{% url 'booking_cancel_admin' b.id %}">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-danger btn-sm">Cancelar</button>
+              </form>
+              <form method="post" action="{% url 'booking_delete' b.id %}" class="delete-profile-form">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-outline-danger btn-sm">Eliminar</button>
               </form>
             </td>
           </tr>


### PR DESCRIPTION
## Summary
- add copy and delete confirmations to availability manager
- add toast notification when saving availability
- allow club owners to delete bookings
- update dashboard templates for new buttons

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688060a7255883219497550bd8e9e969