### PR TITLE
Save availability to DB and adjust table width

### DIFF
--- a/apps/clubs/migrations/0031_availability.py
+++ b/apps/clubs/migrations/0031_availability.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0030_booking_tipo_clase'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Availability',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('date', models.DateField()),
+                ('time', models.TimeField()),
+                ('slots', models.PositiveIntegerField(default=0)),
+                ('club', models.ForeignKey(on_delete=models.deletion.CASCADE, related_name='availabilities', to='clubs.club')),
+            ],
+            options={
+                'ordering': ['date', 'time'],
+                'unique_together': {('club', 'date', 'time')},
+            },
+        ),
+    ]

--- a/apps/clubs/models/__init__.py
+++ b/apps/clubs/models/__init__.py
@@ -10,3 +10,4 @@ from .post import ClubPost
 from .booking import Booking
 from .member import Miembro
 from .payment import Pago
+from .availability import Availability

--- a/apps/clubs/models/availability.py
+++ b/apps/clubs/models/availability.py
@@ -1,0 +1,16 @@
+from django.db import models
+from .club import Club
+
+
+class Availability(models.Model):
+    club = models.ForeignKey(Club, on_delete=models.CASCADE, related_name='availabilities')
+    date = models.DateField()
+    time = models.TimeField()
+    slots = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        unique_together = ('club', 'date', 'time')
+        ordering = ['date', 'time']
+
+    def __str__(self):
+        return f"{self.club.name} {self.date} {self.time} ({self.slots})"

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -83,6 +83,7 @@ urlpatterns = [
 
     path('reserva/<int:pk>/cancelar/', cancel_booking, name='cancel_booking'),
     path('<slug:slug>/reservar/crear/', create_booking, name='create_booking'),
+    path('<slug:slug>/availability/save/', save_availability, name='availability_save'),
     path('booking/<int:pk>/confirmar/', booking_confirm, name='booking_confirm'),
     path('booking/<int:pk>/cancelar-admin/', booking_cancel_admin, name='booking_cancel_admin'),
     path('booking/<int:pk>/eliminar/', booking_delete, name='booking_delete'),

--- a/apps/clubs/views/__init__.py
+++ b/apps/clubs/views/__init__.py
@@ -1,7 +1,7 @@
 from .search import search_results
 from .public import club_profile, coach_profile, ajax_reviews
 from .post import post_create, post_update, post_delete, post_reply, post_toggle_like
-from .booking import cancel_booking, create_booking, booking_confirm, booking_cancel_admin, booking_delete
+from .booking import cancel_booking, create_booking, booking_confirm, booking_cancel_admin, booking_delete, save_availability
 from .dashboard import (
     dashboard,
     club_edit,

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -85,6 +85,12 @@ def dashboard(request, slug):
     months = [(i, months_full[i]) for i in range(today.month - 1, 12)]
     # Availability is limited to the current year
     years = [today.year]
+
+    availability_qs = club.availabilities.filter(date__year=today.year)
+    availability_data = defaultdict(dict)
+    for a in availability_qs:
+        availability_data[a.date.isoformat()][a.time.strftime('%H:%M')] = a.slots
+
     miembros_pagados = members.filter(
         pagos__fecha__year=today.year,
         pagos__fecha__month=today.month,
@@ -209,6 +215,7 @@ def dashboard(request, slug):
             'months': months,
             'years': years,
             'today': today,
+            'availability_json': availability_data,
         },
     )
 @login_required

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -145,6 +145,6 @@
 /* Availability table column width */
 #availability-table th,
 #availability-table td {
-  width: 40px;
+  width: 30px;
   padding: 0.25rem;
 }

--- a/static/js/availability-manager.js
+++ b/static/js/availability-manager.js
@@ -11,8 +11,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
   let availability = {};
+  const dataEl = document.getElementById('availability-data');
   try {
-    availability = JSON.parse(localStorage.getItem('availability-' + clubSlug)) || {};
+    availability = JSON.parse(dataEl?.textContent || localStorage.getItem('availability-' + clubSlug)) || {};
   } catch {
     availability = {};
   }
@@ -261,20 +262,42 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const saveBtn = document.getElementById('availability-save');
     if (saveBtn) {
-      saveBtn.addEventListener('click', () => {
+      saveBtn.addEventListener('click', async () => {
         saveAvailability();
+        const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
+        await fetch(`/clubs/${clubSlug}/availability/save/`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': csrftoken,
+            'X-Requested-With': 'XMLHttpRequest'
+          },
+          credentials: 'same-origin',
+          body: JSON.stringify({ availability })
+        });
         showToast('Disponibilidad guardada');
       });
     }
 
   if (clearBtn) {
-    clearBtn.addEventListener('click', () => {
+    clearBtn.addEventListener('click', async () => {
       availability = {};
       table.querySelectorAll('tbody input').forEach(input => {
         input.value = 0;
         updateCellColor(input.closest('td'), 0);
       });
       localStorage.removeItem('availability-' + clubSlug);
+      const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
+      await fetch(`/clubs/${clubSlug}/availability/save/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrftoken,
+          'X-Requested-With': 'XMLHttpRequest'
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({ availability })
+      });
     });
   }
 });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -947,9 +947,10 @@
     <div id="tab-bookings" class="profile-section">
       <div id="availability-manager" class="mb-4" data-club-slug="{{ club.slug }}">
         <h5 class="mb-3">Administrar disponibilidad</h5>
-        <div id="schedule-manager" class="mb-3"> 
+        <div id="schedule-manager" class="mb-3">
           <!-- Removed legacy day and time pickers -->
           {{ horarios_json|json_script:"schedule-data" }}
+          {{ availability_json|json_script:"availability-data" }}
         </div>
         <div class="d-flex align-items-center gap-2 mb-2">
           <button id="availability-prev" class="btn btn-light btn-sm ">


### PR DESCRIPTION
## Summary
- add `Availability` model and migrations
- expose availability data in dashboard
- persist availability via new endpoint and AJAX
- initialize JS availability from DB data
- reduce availability table column width for 14-day view

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6880683b736883219308876e15e2ea3b