### PR TITLE
Fix missing save_availability import

### DIFF
--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -14,6 +14,7 @@ from apps.clubs.views import (
     booking_confirm,
     booking_cancel_admin,
     booking_delete,
+    save_availability,
 )
 from apps.clubs.views.dashboard import (
     dashboard,


### PR DESCRIPTION
## Summary
- import `save_availability` in club URLs to resolve NameError

## Testing
- `python manage.py migrate` *(fails: ImportError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==5.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_6880ee0eb7888321bf564ffddd5099c2