### PR TITLE
Add deletion confirmation and persist schedule changes

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1226,6 +1226,23 @@
   </div>
 </div>
 
+<!-- Confirm Time Delete Modal -->
+<div class="modal fade" id="confirmTimeDeleteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Eliminar hora</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">¿Seguro que deseas eliminar este rango horario?</div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-danger confirm-time-delete">Eliminar</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Payment History Modal -->
 <div
   class="modal fade"


### PR DESCRIPTION
## Summary
- add modal for deleting availability hours
- update JS to handle hour removal with modal and ensure persistence
- sync schedule hours to local storage on save and reset

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6880f62c8a6c832191ef96e669544e9d