### PR TITLE
Fix schedule manager UI & copy

### DIFF
--- a/static/js/availability-manager.js
+++ b/static/js/availability-manager.js
@@ -263,10 +263,25 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!rowToCopy) return;
     const inputs = rowToCopy.querySelectorAll('input');
     const val = inputs[0] ? parseInt(inputs[0].value, 10) || 0 : 0;
+    const timeStr = inputs[0]?.dataset.time;
     inputs.forEach(input => {
       input.value = val;
       updateCellColor(input.closest('td'), val);
     });
+
+    if (timeStr) {
+      const iter = new Date(today);
+      while (iter <= endOfYear) {
+        const dateStr = iter.toISOString().split('T')[0];
+        if (!availability[dateStr]) availability[dateStr] = {};
+        availability[dateStr][timeStr] = val;
+        if (!hoursMap[dateStr]) hoursMap[dateStr] = [];
+        if (!hoursMap[dateStr].includes(timeStr)) hoursMap[dateStr].push(timeStr);
+        iter.setDate(iter.getDate() + 1);
+      }
+      localStorage.setItem('availability-' + clubSlug, JSON.stringify(availability));
+      saveHoursStorage();
+    }
     saveAvailability();
   }
 

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -948,7 +948,6 @@
       <div id="availability-manager" class="mb-4" data-club-slug="{{ club.slug }}">
         <h5 class="mb-3">Administrar disponibilidad</h5>
         <div id="schedule-manager" class="mb-3">
-          <h6 class="mb-3">Gestor de horario</h6>
           <!-- Removed legacy day and time pickers -->
           {{ horarios_json|json_script:"schedule-data" }}
         </div>
@@ -975,7 +974,7 @@
           </table>
         </div>
         <div class="d-flex gap-2">
-          <button id="availability-save" class="btn btn-dark btn-sm text-white">Guardar</button>
+          <button id="availability-save" class="btn btn-dark btn-sm text-white">Guardar cambios</button>
           <button type="button" id="availability-clear" class="btn btn-outline-danger btn-sm">Limpiar</button>
         </div>
       </div>
@@ -1254,7 +1253,7 @@
       <div class="modal-body">¿Copiar esta disponibilidad a todas las fechas?</div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-        <button type="button" class="btn btn-primary confirm-copy">Copiar</button>
+        <button type="button" class="btn btn-dark confirm-copy">Copiar</button>
       </div>
     </div>
   </div>
@@ -1271,7 +1270,7 @@
       <div class="modal-body">¿Seguro que deseas guardar la disponibilidad?</div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-        <button type="button" class="btn btn-primary confirm-save">Guardar</button>
+        <button type="button" class="btn btn-dark confirm-save">Guardar</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- clean up availability manager header
- tweak availability save button text
- darken confirm buttons in modals
- copy availability for entire year

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688126ce2d9c832184b633ff9f2ac0e9