### PR TITLE
Add table scroll in dashboard bookings

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -978,7 +978,8 @@
           <button type="button" id="availability-clear" class="btn btn-outline-danger btn-sm">Limpiar</button>
         </div>
       </div>
-      <table class="table table-sm">
+      <div class="table-responsive">
+      <table class="table table-sm mb-0" style="min-width:600px">
         <thead>
           <tr>
             <th>Usuario</th>
@@ -1017,6 +1018,7 @@
           {% endfor %}
         </tbody>
       </table>
+      </div>
     </div>
     <div id="tab-matchmaker" class="profile-section">
       <div class="row mb-3">


### PR DESCRIPTION
## Summary
- enable responsive horizontal scroll for club dashboard bookings table

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68815f0e28288321b425173ed874fb59