### PR TITLE
Add booking class manager

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -129,6 +129,15 @@ class BookingForm(forms.ModelForm):
         fields = []
 
 
+class BookingClassForm(forms.ModelForm):
+    class Meta:
+        model = models.BookingClass
+        fields = ['titulo', 'precio', 'duracion', 'detalle', 'destacado']
+        widgets = {
+            'detalle': forms.Textarea(attrs={'rows': 2, 'maxlength': 400, 'class': 'form-control'}),
+        }
+
+
 class ClubForm(forms.ModelForm):
     class Meta:
         model = models.Club

--- a/apps/clubs/migrations/0032_booking_class_model.py
+++ b/apps/clubs/migrations/0032_booking_class_model.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('clubs', '0031_schedule_hours_model'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BookingClass',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('titulo', models.CharField(max_length=100)),
+                ('precio', models.DecimalField(max_digits=6, decimal_places=2)),
+                ('duracion', models.PositiveIntegerField()),
+                ('detalle', models.CharField(blank=True, max_length=400)),
+                ('destacado', models.BooleanField(default=False)),
+                ('club', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='booking_classes', to='clubs.club')),
+            ],
+            options={'ordering': ['-destacado', 'titulo']},
+        ),
+        migrations.AddField(
+            model_name='booking',
+            name='class_type',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='bookings', to='clubs.bookingclass'),
+        ),
+        migrations.RemoveField(
+            model_name='booking',
+            name='tipo_clase',
+        ),
+    ]
+

--- a/apps/clubs/models/__init__.py
+++ b/apps/clubs/models/__init__.py
@@ -8,6 +8,7 @@ from .competidor import Competidor
 from .entrenador import Entrenador, EntrenadorPhoto, TrainingLevel
 from .post import ClubPost
 from .booking import Booking
+from .booking_class import BookingClass
 from .member import Miembro
 from .payment import Pago
 from .schedule_hour import ScheduleHour

--- a/apps/clubs/models/booking.py
+++ b/apps/clubs/models/booking.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.contrib.auth.models import User
 from .post import ClubPost
 from .club import Club
+from .booking_class import BookingClass
 
 
 class Booking(models.Model):
@@ -15,11 +16,13 @@ class Booking(models.Model):
     evento = models.ForeignKey(ClubPost, on_delete=models.CASCADE, null=True, blank=True, related_name='bookings')
     fecha = models.DateField(null=True, blank=True)
     hora = models.TimeField(null=True, blank=True)
-    TIPO_CLASE_CHOICES = [
-        ('privada', 'Privada'),
-        ('prueba', 'Prueba'),
-    ]
-    tipo_clase = models.CharField(max_length=20, choices=TIPO_CLASE_CHOICES, default='privada')
+    class_type = models.ForeignKey(
+        BookingClass,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='bookings'
+    )
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='active')
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -27,7 +30,7 @@ class Booking(models.Model):
         if self.evento:
             item = self.evento.titulo
         else:
-            item = self.get_tipo_clase_display()
+            item = self.class_type.titulo if self.class_type else 'Clase'
         fecha = self.fecha.isoformat() if self.fecha else 'sin fecha'
         hora = self.hora.strftime('%H:%M') if self.hora else '--:--'
         return f"{self.user.username} - {item} {fecha} {hora} ({self.status})"

--- a/apps/clubs/models/booking_class.py
+++ b/apps/clubs/models/booking_class.py
@@ -1,0 +1,15 @@
+from django.db import models
+
+class BookingClass(models.Model):
+    club = models.ForeignKey('Club', on_delete=models.CASCADE, related_name='booking_classes')
+    titulo = models.CharField(max_length=100)
+    precio = models.DecimalField(max_digits=6, decimal_places=2)
+    duracion = models.PositiveIntegerField(help_text='Duración en minutos')
+    detalle = models.CharField(max_length=400, blank=True)
+    destacado = models.BooleanField(default=False)
+
+    class Meta:
+        ordering = ['-destacado', 'titulo']
+
+    def __str__(self):
+        return self.titulo

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -41,6 +41,9 @@ from apps.clubs.views.dashboard import (
     pago_delete,
     schedule_hours,
     miembros_json,
+    booking_class_create,
+    booking_class_update,
+    booking_class_delete,
 )
 
 urlpatterns = [
@@ -88,6 +91,9 @@ urlpatterns = [
     path('booking/<int:pk>/cancelar-admin/', booking_cancel_admin, name='booking_cancel_admin'),
     path('booking/<int:pk>/eliminar/', booking_delete, name='booking_delete'),
     path('<slug:slug>/schedule-hours/', schedule_hours, name='schedule_hours'),
+    path('<slug:slug>/clase/nueva/', booking_class_create, name='booking_class_create'),
+    path('clase/<int:pk>/editar/', booking_class_update, name='booking_class_update'),
+    path('clase/<int:pk>/eliminar/', booking_class_delete, name='booking_class_delete'),
 
     # El perfil público ahora se maneja desde config.urls con la ruta '@slug'
 

--- a/apps/clubs/views/booking.py
+++ b/apps/clubs/views/booking.py
@@ -3,7 +3,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 
 from django.utils.dateparse import parse_date, parse_time
-from ..models import ClubPost, Booking, Club
+from ..models import ClubPost, Booking, Club, BookingClass
 from ..forms import BookingForm, CancelBookingForm
 from django.contrib import messages
 
@@ -31,13 +31,16 @@ def create_booking(request, slug):
     club = get_object_or_404(Club, slug=slug)
     fecha = parse_date(request.POST.get('date', ''))
     hora = parse_time(request.POST.get('time', ''))
-    tipo_clase = request.POST.get('tipo_clase', 'privada')
+    clase_id = request.POST.get('clase_id')
+    booking_class = None
+    if clase_id:
+        booking_class = get_object_or_404(BookingClass, pk=clase_id, club=club)
     Booking.objects.create(
         user=request.user,
         club=club,
         fecha=fecha,
         hora=hora,
-        tipo_clase=tipo_clase,
+        class_type=booking_class,
     )
     return JsonResponse({'success': True})
 

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -99,6 +99,7 @@ def club_profile(request, slug):
         'club_followed': club_followed,
         'register_form': register_form,
         'schedule_data': schedule_data,
+        'booking_classes': club.booking_classes.all(),
 
     })
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -126,6 +126,9 @@
   background-color: #000;
   color: #fff;
 }
+#bookingModal .class-card.highlighted {
+  transform: scale(1.1);
+}
 
 /* Hover effect for booking button */
 .booking-btn:hover {

--- a/static/js/booking-modal.js
+++ b/static/js/booking-modal.js
@@ -285,8 +285,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const data = new URLSearchParams();
       data.append('date', dayCard.dataset.date);
       data.append('time', slotBtn.textContent);
-      const tipoRadio = modalEl.querySelector('input[name="tipo_clase"]:checked');
-      if (tipoRadio) data.append('tipo_clase', tipoRadio.value);
+      const tipoRadio = modalEl.querySelector('input[name="clase_id"]:checked');
+      if (tipoRadio) data.append('clase_id', tipoRadio.value);
       const res = await fetch(`/clubs/${clubSlug}/reservar/crear/`, {
         method: 'POST',
         headers: {

--- a/templates/clubs/booking_class_confirm_delete.html
+++ b/templates/clubs/booking_class_confirm_delete.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">Eliminar clase</h1>
+  <p>¿Seguro que deseas eliminar esta clase?</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Eliminar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/clubs/booking_class_form.html
+++ b/templates/clubs/booking_class_form.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">{% if booking_class %}Editar{% else %}Nueva{% endif %} clase</h1>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-dark">Guardar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -993,7 +993,7 @@
           {% for b in bookings %}
           <tr>
             <td>{{ b.user.username }}</td>
-            <td>{{ b.get_tipo_clase_display }}</td>
+            <td>{{ b.class_type.titulo }}</td>
             <td>{{ b.fecha }} {{ b.hora|default:'' }}</td>
             <td>{{ b.get_status_display }}</td>
             <td class="d-flex gap-1">
@@ -1019,6 +1019,37 @@
         </tbody>
       </table>
       </div>
+      <h5 class="mt-4">Tipos de clase</h5>
+      <div class="mb-2">
+        <a href="{% url 'booking_class_create' club.slug %}" class="btn btn-sm btn-primary">Añadir clase</a>
+      </div>
+      <table class="table table-sm" style="min-width:600px">
+        <thead>
+          <tr>
+            <th>Título</th>
+            <th>Precio</th>
+            <th>Duración</th>
+            <th>Destacada</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for c in booking_classes %}
+          <tr>
+            <td>{{ c.titulo }}</td>
+            <td>{{ c.precio }} €</td>
+            <td>{{ c.duracion }} min</td>
+            <td>{% if c.destacado %}Sí{% else %}No{% endif %}</td>
+            <td class="d-flex gap-1">
+              <a class="btn btn-sm btn-secondary" href="{% url 'booking_class_update' c.id %}">Editar</a>
+              <a class="btn btn-sm btn-danger" href="{% url 'booking_class_delete' c.id %}">Eliminar</a>
+            </td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="5" class="text-muted">No hay clases.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
     <div id="tab-matchmaker" class="profile-section">
       <div class="row mb-3">

--- a/templates/partials/_booking_modal.html
+++ b/templates/partials/_booking_modal.html
@@ -62,26 +62,18 @@
               </div>
             </div>
           </div>
-        <div class="mt-3 d-flex flex-row justify-content-center gap-3">
-
-            <div class="form-check class-card border rounded text-center p-3">
-              <input class="form-check-input" type="radio" name="tipo_clase" id="clase_privada" value="privada">
-              <label class="form-check-label fw-bold text-uppercase" for="clase_privada">Clase privada <i class="bi bi-info-square"></i></label>
-              <span class="d-block text-center">30 €</span>
-              <span class="d-block text-center fst-italic fw-light"><small><i class="bi bi-clock"></i> 60 minutos</small></span>
+        <div class="mt-3 d-flex flex-row justify-content-center gap-3 flex-wrap">
+            {% for c in booking_classes %}
+            <div class="form-check class-card border rounded text-center p-3 {% if c.destacado %}highlighted{% endif %}">
+              <input class="form-check-input" type="radio" name="clase_id" id="clase_{{ c.id }}" value="{{ c.id }}">
+              <label class="form-check-label fw-bold text-uppercase" for="clase_{{ c.id }}">{{ c.titulo }}</label>
+              <span class="d-block text-center">{{ c.precio }} €</span>
+              <span class="d-block text-center fst-italic fw-light"><small><i class="bi bi-clock"></i> {{ c.duracion }} minutos</small></span>
+              {% if c.detalle %}<div class="small">{{ c.detalle }}</div>{% endif %}
             </div>
-            <div class="form-check class-card border rounded text-center p-3">
-              <input class="form-check-input" type="radio" name="tipo_clase" id="clase_prueba" value="prueba">
-              <label class="form-check-label fw-bold text-uppercase" for="clase_prueba">Clase de prueba </label>
-              <span class="d-block text-center">Gratis</span>
-              <span class="d-block text-center fst-italic fw-light"></i><small><i class="bi bi-clock"></i> 60 minutos</small></span>
-            </div>
-             <div class="form-check class-card border rounded text-center p-3">
-              <input class="form-check-input" type="radio" name="tipo_clase" id="clase_prueba" value="prueba">
-              <label class="form-check-label fw-bold text-uppercase" for="clase_prueba">Bono 10 Clases</label>
-              <span class="d-block text-center">280 €</span>
-              <span class="d-block text-center fst-italic fw-light"></i><small><i class="bi bi-clock"></i> 60 minutos</small></span>
-            </div>
+            {% empty %}
+            <p>No hay clases disponibles.</p>
+            {% endfor %}
           </div>
         </div>
         <div class="modal-footer border-0">

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -70,7 +70,7 @@
                 {% for b in bookings %}
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                     <span>
-                        {{ b.get_tipo_clase_display }}
+                        {{ b.class_type.titulo }}
                     </span>
                     {% if b.status != 'cancelled' %}
                     <form action="{% url 'cancel_booking' b.id %}" method="post" class="ms-2">


### PR DESCRIPTION
## Summary
- allow clubs to manage custom booking class cards
- store booking class details in new model `BookingClass`
- load booking classes dynamically in booking modal
- manage booking classes in dashboard
- adjust booking creation logic

## Testing
- `python -m py_compile apps/clubs/forms.py apps/clubs/models/__init__.py apps/clubs/models/booking.py apps/clubs/models/booking_class.py apps/clubs/urls.py apps/clubs/views/booking.py apps/clubs/views/dashboard.py apps/clubs/views/public.py apps/clubs/migrations/0032_booking_class_model.py`

------
https://chatgpt.com/codex/tasks/task_e_68817efe0d5083218368fd68da7289ac