### PR TITLE
Implement booking class modal UX improvements

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -133,6 +133,7 @@ class BookingClassForm(forms.ModelForm):
     class Meta:
         model = models.BookingClass
         fields = ['titulo', 'precio', 'duracion', 'detalle', 'destacado']
+        labels = {'destacado': 'Destacar'}
         widgets = {
             'detalle': forms.Textarea(attrs={'rows': 2, 'maxlength': 400, 'class': 'form-control'}),
         }

--- a/static/js/booking-class-modal.js
+++ b/static/js/booking-class-modal.js
@@ -15,6 +15,15 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             addEl.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
             const form = addEl.querySelector('form');
+            const cancelBtn = form.querySelector('[data-bs-dismiss="modal"]');
+            if (cancelBtn) {
+              cancelBtn.addEventListener('click', e => {
+                e.preventDefault();
+                if (confirm('¿Seguro que deseas cancelar?')) {
+                  addModal.hide();
+                }
+              });
+            }
             form.addEventListener('submit', e => {
               e.preventDefault();
               const fd = new FormData(form);
@@ -22,7 +31,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 method: 'POST',
                 headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 body: fd
-              }).then(() => window.location.reload());
+              }).then(res => {
+                if (res.ok) {
+                  showToast('Clase añadida correctamente');
+                }
+                setTimeout(() => window.location.reload(), 500);
+              });
             });
             addModal.show();
           }
@@ -30,3 +44,19 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 });
+
+function showToast(message) {
+  let container = document.querySelector('.toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'toast-container position-fixed top-0 end-0 p-3';
+    document.body.appendChild(container);
+  }
+  const toast = document.createElement('div');
+  toast.className = 'toast bg-black text-bg-success border-0 mb-2';
+  toast.role = 'alert';
+  toast.innerHTML = `<div class="d-flex"><div class="toast-body">${message}</div>` +
+                    `<button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button></div>`;
+  container.appendChild(toast);
+  new bootstrap.Toast(toast).show();
+}


### PR DESCRIPTION
## Summary
- change `destacado` label to "Destacar"
- improve booking class modal UX with cancel confirmation and success toast

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68818ba4ef688321b5c3c44247a81cfa