### PR TITLE
Add edit class modal in dashboard

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -685,10 +685,21 @@ def booking_class_update(request, pk):
         if form.is_valid():
             form.save()
             messages.success(request, 'Clase actualizada correctamente.')
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+                return HttpResponse(status=204)
             return redirect('club_dashboard', slug=obj.club.slug)
     else:
         form = BookingClassForm(instance=obj)
-    return render(request, 'clubs/booking_class_form.html', {'form': form, 'club': obj.club, 'booking_class': obj})
+    template = (
+        'clubs/_booking_class_form.html'
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest'
+        else 'clubs/booking_class_form.html'
+    )
+    return render(request, template, {
+        'form': form,
+        'club': obj.club,
+        'booking_class': obj,
+    })
 
 
 @login_required

--- a/static/js/booking-class-modal.js
+++ b/static/js/booking-class-modal.js
@@ -1,11 +1,16 @@
 document.addEventListener('DOMContentLoaded', () => {
   const addEl = document.getElementById('addBookingClassModal');
+  const editEl = document.getElementById('editBookingClassModal');
   const addModal = addEl ? new bootstrap.Modal(addEl) : null;
-  const btn = document.querySelector('.add-booking-class-btn');
-  if (btn) {
-    btn.addEventListener('click', () => {
-      const slug = btn.dataset.clubSlug;
-      fetch(`/clubs/${slug}/clase/nueva/`, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+  const editModal = editEl ? new bootstrap.Modal(editEl) : null;
+
+  const addBtn = document.querySelector('.add-booking-class-btn');
+  if (addBtn) {
+    addBtn.addEventListener('click', () => {
+      const slug = addBtn.dataset.clubSlug;
+      fetch(`/clubs/${slug}/clase/nueva/`, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+      })
         .then(res => res.text())
         .then(html => {
           if (addEl) {
@@ -25,9 +30,44 @@ document.addEventListener('DOMContentLoaded', () => {
                 }).then(() => window.location.reload());
               });
             }
-            addModal.show();
+            addModal && addModal.show();
           }
         });
     });
   }
+
+  function bindEditButtons() {
+    document.querySelectorAll('.edit-booking-class-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset.classId;
+        fetch(`/clubs/clase/${id}/editar/`, {
+          headers: { 'X-Requested-With': 'XMLHttpRequest' }
+        })
+          .then(res => res.text())
+          .then(html => {
+            if (editEl) {
+              editEl.querySelector('.modal-body').innerHTML = html;
+              if (window.initSelectLabels) {
+                window.initSelectLabels(editEl);
+              }
+              const form = editEl.querySelector('form');
+              if (form) {
+                form.addEventListener('submit', e => {
+                  e.preventDefault();
+                  const fd = new FormData(form);
+                  fetch(form.action, {
+                    method: 'POST',
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                    body: fd
+                  }).then(() => window.location.reload());
+                });
+              }
+              editModal && editModal.show();
+            }
+          });
+      });
+    });
+  }
+
+  bindEditButtons();
 });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1047,7 +1047,7 @@
             <td>{{ c.duracion }} min</td>
             <td>{% if c.destacado %}Sí{% else %}No{% endif %}</td>
             <td class="d-flex gap-1">
-              <a class="btn btn-sm btn-secondary" href="{% url 'booking_class_update' c.id %}">Editar</a>
+              <button type="button" class="btn btn-sm btn-secondary edit-booking-class-btn" data-class-id="{{ c.id }}">Editar</button>
               <a class="btn btn-sm btn-danger" href="{% url 'booking_class_delete' c.id %}">Eliminar</a>
             </td>
           </tr>
@@ -1449,6 +1449,19 @@
           data-bs-dismiss="modal"
           aria-label="Close"
         ></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>
+
+<!-- Edit Booking Class Modal -->
+<div class="modal fade" id="editBookingClassModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Editar clase</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body"></div>
     </div>


### PR DESCRIPTION
## Summary
- allow editing booking classes in a modal like adding
- support AJAX requests in `booking_class_update`
- load edit modal markup
- handle edit modal behaviour in JS

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68819c21748c83219b696cb5624c2ce8