### PR TITLE
Limit booking modal scroll

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -118,6 +118,7 @@
 /* Booking modal class cards */
 #bookingModal .class-card {
   cursor: pointer;
+  flex: 0 0 calc((100% - 2rem) / 3);
 }
 #bookingModal .class-card .form-check-input {
   display: none;
@@ -148,8 +149,9 @@
 
 /* Scroll area for booking class cards */
 #bookingModal #class-cards-container {
-  overflow-x: auto;
+  overflow: hidden;
   scroll-behavior: smooth;
+  width: 100%;
 }
 
 /* Booking modal radio color */


### PR DESCRIPTION
## Summary
- in the booking modal, hide the scroll area and only show three cards at a time

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6881b20a39d08321b86d1aa319ab0582