### PR TITLE
Add offer badge to highlighted booking class

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -119,6 +119,7 @@
 #bookingModal .class-card {
   cursor: pointer;
   flex: 0 0 calc((100% - 2rem) / 3);
+  position: relative;
 }
 #bookingModal .class-card .form-check-input {
   display: none;
@@ -128,8 +129,12 @@
   color: #fff;
 }
 #bookingModal .class-card.highlighted {
-  transform: scale(1.2);
-  margin: 0 0.5rem;
+  /* Highlighted card no longer scaled */
+}
+
+/* Offer badge inside highlighted card */
+#bookingModal .offer-badge {
+  font-size: 0.75rem;
 }
 
 /* Hover effect for booking button */

--- a/templates/partials/_booking_modal.html
+++ b/templates/partials/_booking_modal.html
@@ -68,8 +68,11 @@
           </button>
           <div id="class-cards-container" class="d-flex flex-nowrap gap-3">
             {% for c in booking_classes %}
-            <div class="form-check class-card border rounded text-center p-3 {% if c.destacado %}highlighted{% endif %}">
-               {% if c.detalle %}
+            <div class="form-check class-card border rounded text-center p-3 {% if c.destacado %}highlighted{% endif %} position-relative">
+              {% if c.destacado %}
+              <span class="offer-badge position-absolute top-0 end-0 m-1 text-danger">Oferta <i class="bi bi-fire"></i></span>
+              {% endif %}
+              {% if c.detalle %}
               <span class="d-block">
                 <i class="bi bi-info-circle" data-bs-toggle="tooltip" title="{{ c.detalle }}"></i>
               </span>


### PR DESCRIPTION
## Summary
- make booking highlighted cards same size as others
- show an "Oferta" badge with fire icon on highlighted cards

## Testing
- `python manage.py test -v 0` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6881b421f5708321a7573d71eabaafcc