### PR TITLE
Fix booking class edit behavior

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -566,3 +566,22 @@ select option[value="España"] {
   font-size: 1rem;
   font-weight: 500;
 }
+
+/* Booking class table adjustments */
+.booking-class-title {
+  text-transform: uppercase;
+}
+
+.booking-class-title-col {
+  text-transform: uppercase;
+}
+
+.booking-class-detail {
+  width: 50%;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.booking-class-detail-col {
+  width: 50%;
+}

--- a/templates/clubs/_booking_class_form.html
+++ b/templates/clubs/_booking_class_form.html
@@ -1,4 +1,5 @@
-<form method="post" class="profile-form" action="{% url 'booking_class_create' club.slug %}">
+<form method="post" class="profile-form"
+      action="{% if booking_class %}{% url 'booking_class_update' booking_class.id %}{% else %}{% url 'booking_class_create' club.slug %}{% endif %}">
   {% csrf_token %}
  
   <div class="form-field">

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -355,8 +355,8 @@
         <thead>
           <tr>
             <th></th>
-            <th>Título</th>
-            <th>Detalle</th>
+            <th class="booking-class-title-col">Título</th>
+            <th class="booking-class-detail-col">Detalle</th>
             <th>Precio</th>
             <th>Duración</th>
             <th>Destacada</th>
@@ -372,8 +372,8 @@
                 <button type="submit" class="bi bi-dash-circle icon-large btn btn-link text-danger p-0"></button>
               </form>
             </td>
-            <td>{{ c.titulo }}</td>
-            <td>{{ c.detalle }}</td>
+            <td class="booking-class-title">{{ c.titulo|upper }}</td>
+            <td class="booking-class-detail">{{ c.detalle }}</td>
             <td>{% if c.precio == 0 %}Gratis{% else %}{{ c.precio }} €{% endif %}</td>
             <td>{{ c.duracion }} min</td>
             <td>{% if c.destacado %}Sí{% else %}No{% endif %}</td>


### PR DESCRIPTION
## Summary
- keep form action context-aware when editing classes
- show class titles uppercased in dashboard
- wrap details column and limit its width

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6881b7a251b48321b39f27a33e86c603