### PR TITLE
Implement booking filtering on dashboard

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -189,7 +189,14 @@ def dashboard(request, slug):
     elif orden == 'newest':
         members = members.order_by('-fecha_inscripcion', '-id')
 
+    booking_filter = request.GET.get('booking_filter')
     bookings = Booking.objects.filter(club=club).select_related('user', 'evento')
+    if booking_filter == 'newest':
+        bookings = bookings.order_by('-created_at')
+    elif booking_filter == 'oldest':
+        bookings = bookings.order_by('created_at')
+    elif booking_filter in ['active', 'confirmed', 'cancelled']:
+        bookings = bookings.filter(status=booking_filter)
 
     form = ClubForm(instance=club)
 

--- a/static/js/booking-filter.js
+++ b/static/js/booking-filter.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const dropdown = document.getElementById('booking-sort-dropdown');
+  if (!dropdown) return;
+  const selected = dropdown.querySelector('.selected-text');
+  const menu = document.getElementById('booking-sort-menu');
+  const input = document.getElementById('booking-sort-input');
+
+  dropdown.querySelector('.selected').addEventListener('click', (e) => {
+    e.stopPropagation();
+    menu.style.display = menu.style.display === 'block' ? 'none' : 'block';
+  });
+
+  menu.querySelectorAll('.dropdown-item').forEach(item => {
+    item.addEventListener('click', () => {
+      selected.textContent = item.textContent;
+      input.value = item.dataset.value;
+      menu.style.display = 'none';
+      dropdown.closest('form').submit();
+    });
+  });
+
+  document.addEventListener('click', () => {
+    menu.style.display = 'none';
+  });
+});

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -365,7 +365,7 @@
         <tbody>
           {% for c in booking_classes %}
           <tr>
-            <td class="d-flex gap-1">
+            <td class="d-flex gap-1 actions-column">
               <button type="button" class="bi bi-pencil-square icon-large btn btn-link p-0 edit-booking-class-btn text-dark" data-class-id="{{ c.id }}"></button>
               <form method="post" action="{% url 'booking_class_delete' c.id %}" class="m-0 p-0 delete-profile-form">
                 {% csrf_token %}
@@ -1027,22 +1027,29 @@
       </div>
     </div>
     <div id="tab-bookings" class="profile-section">
- 
-
+      <div class="row mb-3">
+        <div class="col-12 d-flex justify-content-end">
+          {% include 'partials/_booking-filter.html' %}
+        </div>
+      </div>
        <div class="table-responsive">
       <table class="table table-sm mb-0" style="min-width:600px">
         <thead>
           <tr>
-            <th></th>
             <th>Usuario</th>
             <th>Clase</th>
             <th>Reserva</th>
             <th>Estado</th>
+            <th class="actions-column">Opciones</th>
           </tr>
         </thead>
         <tbody>
           {% for b in bookings %}
           <tr>
+            <td>{{ b.user.username }}</td>
+            <td>{{ b.class_type.titulo }}</td>
+            <td>{{ b.fecha|date:"d/m/y" }} {{ b.hora|time:"H:i"|default:'' }}</td>
+            <td>{{ b.get_status_display }}</td>
             <td class="d-flex gap-1">
               <form method="post" action="{% url 'booking_confirm' b.id %}">
                 {% csrf_token %}
@@ -1057,10 +1064,6 @@
                 <button type="submit" class="bi bi-dash-circle icon-large btn btn-link text-danger p-0"></button>
               </form>
             </td>
-            <td>{{ b.user.username }}</td>
-            <td>{{ b.class_type.titulo }}</td>
-            <td>{{ b.fecha }} {{ b.hora|default:'' }}</td>
-            <td>{{ b.get_status_display }}</td>
           </tr>
           {% empty %}
           <tr>
@@ -1513,6 +1516,7 @@
 <script src="{% static 'js/range-slider.js' %}"></script>
 <script src="{% static 'js/matchmaker-filter.js' %}"></script>
 <script src="{% static 'js/member-table-filters.js' %}"></script>
+<script src="{% static 'js/booking-filter.js' %}"></script>
 <script src="{% static 'js/availability-manager.js' %}"></script>
 <script src="{% static 'js/schedule-manager.js' %}"></script>
 {% endblock %}

--- a/templates/partials/_booking-filter.html
+++ b/templates/partials/_booking-filter.html
@@ -1,0 +1,18 @@
+<form method="get" id="booking-filter-form" class="d-flex align-items-center" style="gap: 10px;">
+    <input type="hidden" name="booking_filter" id="booking-sort-input" value="{{ request.GET.booking_filter|default:'' }}">
+    <div class="custom-dropdown small" id="booking-sort-dropdown">
+        <div class="selected">
+            <span class="selected-text">
+                {% if request.GET.booking_filter == 'newest' %}Más recientes primero{% elif request.GET.booking_filter == 'oldest' %}Más antiguas primero{% elif request.GET.booking_filter == 'active' %}Activas{% elif request.GET.booking_filter == 'confirmed' %}Confirmadas{% elif request.GET.booking_filter == 'cancelled' %}Canceladas{% else %}Filtrar{% endif %}
+            </span>
+            <span class="select-arrow"></span>
+        </div>
+        <div class="dropdown-menu" id="booking-sort-menu">
+            <div class="dropdown-item" data-value="newest">Más recientes primero</div>
+            <div class="dropdown-item" data-value="oldest">Más antiguas primero</div>
+            <div class="dropdown-item" data-value="active">Activas</div>
+            <div class="dropdown-item" data-value="confirmed">Confirmadas</div>
+            <div class="dropdown-item" data-value="cancelled">Canceladas</div>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
## Summary
- add booking filter dropdown and JS handler
- show booking options column on dashboard
- display booking date/time in Spanish format
- filter bookings in `dashboard` view

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_688274a64c18832193b57de7c494f820