### PR TITLE
Translate dashboard profile form labels

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -183,6 +183,23 @@ class ClubForm(forms.ModelForm):
             css = logo_widget.widget.attrs.get('class', '')
             logo_widget.widget.attrs['class'] = (css + ' d-none').strip()
 
+        # Translate field labels to Spanish
+        label_map = {
+            'owner': 'Propietario',
+            'category': 'Categoría',
+            'name': 'Nombre',
+            'about': 'Bio',
+            'city': 'Ciudad',
+            'address': 'Dirección',
+            'phone': 'Teléfono',
+            'whatsapp_link': 'WhatsApp',
+            'email': 'Correo electrónico',
+            'features': 'Características',
+        }
+        for field_name, label in label_map.items():
+            if field_name in self.fields:
+                self.fields[field_name].label = label
+
 
 class CancelBookingForm(forms.Form):
     """Simple form used to confirm cancellation."""


### PR DESCRIPTION
## Summary
- translate all dashboard profile form labels to Spanish
- change the "about" label to "Bio"

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6882d7d7fc6c83219818c1d3419a20b5