### PR TITLE
Fix footer not showing on club profile

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -728,4 +728,5 @@
     <script src="{% static 'js/booking-modal.js' %}"></script>
     <script src="{% static 'js/club-tabs.js' %}"></script>
     <script src="{% static 'js/post-media-preview.js' %}"></script>
+    {% include 'partials/_footer.html' %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure the footer renders on `club_profile.html`

## Testing
- `python manage.py check` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882dcdd670c8321b8a2f78c598ef3cd