### PR TITLE
Fix footer overlap on club profile

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -174,6 +174,11 @@ textarea.form-control {
   padding-top: 1rem;
 }
 
+.review-user-container {
+  position: absolute;
+  bottom: 0;
+}
+
 .review-avatar {
   min-width: 35px;
    min-height: 35px;

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -574,7 +574,7 @@
                             {% for reseña in reseñas %}
                                 <div class="p-4 review-slide{% if forloop.first %} active{% endif %}">
                                     <p class="review-text">“{{ reseña.comentario }}”</p>
-                                    <div class="review-user-container d-flex align-items-center position-fixed bottom-0  mb-4 ">
+                                    <div class="review-user-container d-flex align-items-center position-absolute bottom-0 mb-4 ">
                                         {% if reseña.usuario.profile.avatar %}
                                             <img src="{{ reseña.usuario.profile.avatar.url }}"
                                                  alt="{{ reseña.usuario.username }}"


### PR DESCRIPTION
## Summary
- ensure the review user container doesn't cover the footer

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6882fc49e71c832194faab36b9352a78