### PR TITLE
Fix login redirect

### DIFF
--- a/templates/partials/_login-form.html
+++ b/templates/partials/_login-form.html
@@ -1,7 +1,7 @@
  {% load socialaccount %}
  
             <form method="post" action="{% url 'login' %}" class="profile-form">
-                <input type="hidden" name="next" value="{% url 'home' %}">
+                <input type="hidden" name="next" value="{{ request.get_full_path }}">
                 {% csrf_token %}
 
                 <div class="form-field">


### PR DESCRIPTION
## Summary
- preserve current page when logging in from login modal

## Testing
- `python manage.py test` *(fails: Could not import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68830005ef4c8321be6ecd9e08b37702