### PR TITLE
Add club messaging

### DIFF
--- a/apps/clubs/context_processors.py
+++ b/apps/clubs/context_processors.py
@@ -1,0 +1,9 @@
+from .models import ClubMessage
+
+
+def user_messages(request):
+    if request.user.is_authenticated:
+        msgs = ClubMessage.objects.filter(user=request.user).select_related('club')
+    else:
+        msgs = []
+    return {'user_messages': msgs}

--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -438,3 +438,12 @@ class PagoForm(forms.ModelForm):
             )):
                 field.widget.attrs.setdefault('placeholder', ' ')
 
+
+class ClubMessageForm(forms.ModelForm):
+    class Meta:
+        model = models.ClubMessage
+        fields = ['content']
+        widgets = {
+            'content': forms.Textarea(attrs={'class': 'form-control', 'rows': 4})
+        }
+

--- a/apps/clubs/models/__init__.py
+++ b/apps/clubs/models/__init__.py
@@ -12,3 +12,4 @@ from .booking_class import BookingClass
 from .member import Miembro
 from .payment import Pago
 from .schedule_hour import ScheduleHour
+from .message import ClubMessage

--- a/apps/clubs/models/message.py
+++ b/apps/clubs/models/message.py
@@ -1,0 +1,19 @@
+from django.db import models
+from django.contrib.auth.models import User
+
+from .club import Club
+from apps.core.models import TimeStampedModel
+
+
+class ClubMessage(TimeStampedModel):
+    club = models.ForeignKey(Club, related_name='messages', on_delete=models.CASCADE)
+    user = models.ForeignKey(User, related_name='club_messages', on_delete=models.CASCADE)
+    content = models.TextField()
+    sender_is_club = models.BooleanField(default=False)
+
+    class Meta:
+        ordering = ['created_at']
+
+    def __str__(self):
+        sender = self.club.name if self.sender_is_club else self.user.username
+        return f"{sender}: {self.content[:20]}"

--- a/apps/clubs/urls.py
+++ b/apps/clubs/urls.py
@@ -85,6 +85,8 @@ urlpatterns = [
     path('posts/<int:pk>/responder/', post_reply, name='clubpost_reply'),
     path('posts/<int:pk>/like/', post_toggle_like, name='clubpost_like'),
 
+    path('<slug:slug>/mensaje/', public.send_message, name='club_send_message'),
+
     path('reserva/<int:pk>/cancelar/', cancel_booking, name='cancel_booking'),
     path('<slug:slug>/reservar/crear/', create_booking, name='create_booking'),
     path('booking/<int:pk>/confirmar/', booking_confirm, name='booking_confirm'),

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -112,6 +112,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'django.template.context_processors.static',
                 'apps.users.context_processors.login_form',
+                'apps.clubs.context_processors.user_messages',
             ],
         },
     },

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,9 @@
 
     {% include 'partials/_header.html' %}
     {% include 'partials/_messages.html' %}
+    {% if user.is_authenticated %}
+        {% include 'partials/_messages_modal.html' %}
+    {% endif %}
  
       {% if request.path != '/' %}
         {% include 'partials/_search_modal.html' %}

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -101,6 +101,11 @@
                             <a href="mailto:{{ club.email }}"
                                class="text-decoration-none text-reset">{{ club.email }}</a>
                         </p>
+                        <p>
+                            <button type="button" class="btn btn-outline-dark btn-sm" data-bs-toggle="modal" data-bs-target="#clubMessageModal">
+                                Mensaje privado
+                            </button>
+                        </p>
                     </div>
                 </div>
             </div>
@@ -642,6 +647,7 @@
     {% include 'partials/_share_profile_modal.html' %}
     {% include 'partials/_register_modal.html' %}
     {% include 'partials/_member_signup_modal.html' %}
+    {% include 'partials/_club_message_modal.html' %}
     {% include 'partials/_booking_modal.html' %}
     </div>
 

--- a/templates/partials/_club_message_modal.html
+++ b/templates/partials/_club_message_modal.html
@@ -1,0 +1,19 @@
+<div class="modal fade" id="clubMessageModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{% url 'club_send_message' club.slug %}">
+        <div class="modal-header">
+          <h5 class="modal-title">Enviar mensaje a {{ club.name }}</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body">
+          {% csrf_token %}
+          {{ message_form.content }}
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-dark btn-sm">Enviar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -33,6 +33,11 @@
                 {% endif %}
                 {% endif %}
                 {% if user.is_authenticated %}
+                    <li class="nav-item ms-2">
+                        <button class="btn nav-link text-dark p-0" data-bs-toggle="modal" data-bs-target="#messagesModal" title="Mensajes">
+                            <i class="bi bi-send-fill"></i>
+                        </button>
+                    </li>
                     <li class="nav-item ">
                         <div class="custom-dropdown small" id="user-dropdown">
                            <div class="selected d-flex align-items-center">
@@ -45,6 +50,7 @@
                            <div class="dropdown-menu" id="user-menu">
                             <a href="{% url 'profile' %}" class="dropdown-item text-light">Mi perfil</a> 
                             <a href="{% url 'feed' %}" class="dropdown-item text-light">Feed</a>
+                            <a href="#" class="dropdown-item text-light" data-bs-toggle="modal" data-bs-target="#messagesModal">Mensajes</a>
 
                             <a href="#" class="dropdown-item text-light" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
                                 Cerrar sesión

--- a/templates/partials/_messages_modal.html
+++ b/templates/partials/_messages_modal.html
@@ -1,0 +1,27 @@
+<div class="modal fade" id="messagesModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable modal-xl">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Mensajes</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <div class="modal-body">
+        <div class="container-fluid">
+          {% for m in user_messages %}
+          <div class="row mb-3">
+            <div class="col-12 d-flex {% if m.sender_is_club %}justify-content-start{% else %}justify-content-end{% endif %}">
+              <div class="p-2 rounded {% if m.sender_is_club %}bg-light{% else %}bg-dark text-white{% endif %}">
+                <div><strong>{% if m.sender_is_club %}{{ m.club.name }}{% else %}Tú{% endif %}</strong></div>
+                <div>{{ m.content }}</div>
+                <div><small class="text-muted">{{ m.created_at|date:'d/m/Y H:i' }}</small></div>
+              </div>
+            </div>
+          </div>
+          {% empty %}
+          <p>No hay mensajes.</p>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- enable simple private messaging between users and clubs
- display inbox/outbox chat in a new messages modal
- include message forms on club profile
- show new plane icon and dropdown item for messages
- wire up context processor for messages in base settings

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68844111f0a0832190618edae955a747