### PR TITLE
Implement social-style messaging inbox

### DIFF
--- a/apps/clubs/views/__init__.py
+++ b/apps/clubs/views/__init__.py
@@ -6,3 +6,4 @@ from .dashboard import (
     dashboard,
     club_edit,
 )
+from .messages import message_inbox, conversation

--- a/apps/clubs/views/messages.py
+++ b/apps/clubs/views/messages.py
@@ -1,0 +1,63 @@
+from django.shortcuts import render, get_object_or_404, redirect
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
+from django.db.models import Max
+
+from ..models import Club, ClubMessage
+from ..forms import ClubMessageForm
+
+
+@login_required
+def message_inbox(request):
+    """Display the latest message of each conversation."""
+    latest_ids = (
+        ClubMessage.objects.filter(user=request.user)
+        .values('club')
+        .annotate(last_id=Max('id'))
+        .values_list('last_id', flat=True)
+    )
+    conversations = (
+        ClubMessage.objects.filter(id__in=latest_ids)
+        .select_related('club')
+        .order_by('-created_at')
+    )
+    return render(request, 'clubs/message_inbox.html', {'conversations': conversations})
+
+
+@login_required
+def conversation(request, slug, user_id=None):
+    """Conversation between a user and a club."""
+    club = get_object_or_404(Club, slug=slug)
+
+    if request.user == club.owner and user_id is not None:
+        conversant = get_object_or_404(User, pk=user_id)
+    else:
+        conversant = request.user
+
+    messages_qs = (
+        ClubMessage.objects.filter(club=club, user=conversant)
+        .select_related('user')
+        .order_by('created_at')
+    )
+
+    if request.method == 'POST':
+        form = ClubMessageForm(request.POST)
+        if form.is_valid():
+            msg = form.save(commit=False)
+            msg.club = club
+            msg.user = conversant
+            msg.sender_is_club = request.user == club.owner
+            msg.save()
+            if request.user == club.owner:
+                return redirect('club_conversation', slug=club.slug, user_id=conversant.id)
+            return redirect('conversation', slug=club.slug)
+    else:
+        form = ClubMessageForm()
+
+    context = {
+        'club': club,
+        'messages': messages_qs,
+        'form': form,
+        'conversant': conversant,
+    }
+    return render(request, 'clubs/conversation.html', context)

--- a/config/urls.py
+++ b/config/urls.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
 from apps.clubs.views import public as club_public
+from apps.clubs.views import messages as club_messages
 from apps.clubs.views.dashboard import dashboard
 from apps.users.views import profile as user_profile
   
@@ -26,6 +27,11 @@ urlpatterns = [
 
     # Perfil público de usuarios
     path('profile/<str:username>/', user_profile.profile_detail, name='user_profile'),
+
+    # Bandeja y conversaciones de mensajes
+    path('mensajes/', club_messages.message_inbox, name='message_inbox'),
+    path('mensajes/<slug:slug>/', club_messages.conversation, name='conversation'),
+    path('@<slug:slug>/mensajes/<int:user_id>/', club_messages.conversation, name='club_conversation'),
 
     # Clubs: Gestión de Clubs y búsqueda
     path('clubs/', include('apps.clubs.urls')),

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,9 +19,6 @@
 
     {% include 'partials/_header.html' %}
     {% include 'partials/_messages.html' %}
-    {% if user.is_authenticated %}
-        {% include 'partials/_messages_modal.html' %}
-    {% endif %}
  
       {% if request.path != '/' %}
         {% include 'partials/_search_modal.html' %}

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -102,9 +102,9 @@
                                class="text-decoration-none text-reset">{{ club.email }}</a>
                         </p>
                         <p>
-                            <button type="button" class="btn btn-outline-dark btn-sm" data-bs-toggle="modal" data-bs-target="#clubMessageModal">
+                            <a href="{% url 'conversation' club.slug %}" class="btn btn-outline-dark btn-sm">
                                 Mensaje privado
-                            </button>
+                            </a>
                         </p>
                     </div>
                 </div>
@@ -647,7 +647,6 @@
     {% include 'partials/_share_profile_modal.html' %}
     {% include 'partials/_register_modal.html' %}
     {% include 'partials/_member_signup_modal.html' %}
-    {% include 'partials/_club_message_modal.html' %}
     {% include 'partials/_booking_modal.html' %}
     </div>
 

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block content %}
+<div class="container my-4">
+  <h2 class="mb-4">Conversación con {{ club.name }}</h2>
+  <div class="mb-3">
+    {% for m in messages %}
+      <div class="d-flex {% if m.sender_is_club %}justify-content-start{% else %}justify-content-end{% endif %} mb-2">
+        <div class="p-2 rounded {% if m.sender_is_club %}bg-light{% else %}bg-dark text-white{% endif %}">
+          <div class="fw-bold">{% if m.sender_is_club %}{{ club.name }}{% else %}{{ m.user.username }}{% endif %}</div>
+          <div>{{ m.content }}</div>
+          <div class="text-muted small">{{ m.created_at|timesince }} atrás</div>
+        </div>
+      </div>
+    {% empty %}
+      <p>No hay mensajes.</p>
+    {% endfor %}
+  </div>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.content }}
+    <button type="submit" class="btn btn-dark btn-sm mt-2">Enviar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/clubs/message_inbox.html
+++ b/templates/clubs/message_inbox.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block content %}
+<div class="container my-4">
+  <h2 class="mb-4">Mensajes</h2>
+  <div class="list-group">
+    {% for m in conversations %}
+      <a href="{% url 'conversation' m.club.slug %}" class="list-group-item list-group-item-action d-flex align-items-center">
+        {% if m.club.logo %}
+          <img src="{{ m.club.logo.url }}" class="rounded-circle me-3" style="width:40px;height:40px;object-fit:cover;" alt="{{ m.club.name }}">
+        {% else %}
+          <div class="rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center me-3" style="width:40px;height:40px;">
+            {{ m.club.name|first|upper }}
+          </div>
+        {% endif %}
+        <div class="flex-grow-1">
+          <div class="fw-bold">{{ m.club.name }}</div>
+          <div class="text-muted small">{{ m.content|truncatechars:40 }}</div>
+        </div>
+        <small class="text-muted ms-3">{{ m.created_at|timesince }} atrás</small>
+      </a>
+    {% empty %}
+      <p>No hay mensajes.</p>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -34,9 +34,9 @@
                 {% endif %}
                 {% if user.is_authenticated %}
                     <li class="nav-item ms-2">
-                        <button class="btn nav-link text-dark p-0" data-bs-toggle="modal" data-bs-target="#messagesModal" title="Mensajes">
+                        <a href="{% url 'message_inbox' %}" class="nav-link text-dark p-0" title="Mensajes">
                             <i class="bi bi-send-fill"></i>
-                        </button>
+                        </a>
                     </li>
                     <li class="nav-item ">
                         <div class="custom-dropdown small" id="user-dropdown">
@@ -50,7 +50,7 @@
                            <div class="dropdown-menu" id="user-menu">
                             <a href="{% url 'profile' %}" class="dropdown-item text-light">Mi perfil</a> 
                             <a href="{% url 'feed' %}" class="dropdown-item text-light">Feed</a>
-                            <a href="#" class="dropdown-item text-light" data-bs-toggle="modal" data-bs-target="#messagesModal">Mensajes</a>
+                            <a href="{% url 'message_inbox' %}" class="dropdown-item text-light">Mensajes</a>
 
                             <a href="#" class="dropdown-item text-light" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
                                 Cerrar sesión


### PR DESCRIPTION
## Summary
- allow viewing last conversations in an inbox page
- support full conversation thread and replies
- switch header icons to link to new inbox
- link to conversation from club profile
- remove obsolete modal from base template
- wire URLs for new messaging views

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6884522e4a3083218f1cec0a6a4af93a