### PR TITLE
Fix club messaging inbox

### DIFF
--- a/apps/clubs/context_processors.py
+++ b/apps/clubs/context_processors.py
@@ -1,9 +1,16 @@
+from django.db.models import Q
+
 from .models import ClubMessage
 
 
 def user_messages(request):
-    if request.user.is_authenticated:
-        msgs = ClubMessage.objects.filter(user=request.user).select_related('club')
-    else:
-        msgs = []
-    return {'user_messages': msgs}
+    if not request.user.is_authenticated:
+        return {"user_messages": []}
+
+    msgs = (
+        ClubMessage.objects.filter(
+            Q(user=request.user) | Q(club__owner=request.user)
+        )
+        .select_related("club", "user")
+    )
+    return {"user_messages": msgs}

--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -233,3 +233,20 @@ class DashboardMatchmakerTests(TestCase):
         res = self.client.get(url, {'mm_sexo': 'M'})
         self.assertContains(res, 'Bob')
         self.assertNotContains(res, 'Alice')
+
+
+class MessageInboxTests(TestCase):
+    def setUp(self):
+        Group.objects.get_or_create(name='ClubOwner')
+        self.owner = User.objects.create_user(username='owner', password='pass')
+        self.user = User.objects.create_user(username='user', password='pass')
+        self.club = Club.objects.create(
+            name='Club', city='C', address='A', phone='1', email='e@e.com', owner=self.owner
+        )
+        ClubMessage.objects.create(club=self.club, user=self.user, content='hola')
+
+    def test_user_message_appears_in_owner_inbox(self):
+        self.client.login(username='owner', password='pass')
+        url = reverse('message_inbox')
+        res = self.client.get(url)
+        self.assertContains(res, 'hola')

--- a/templates/clubs/message_inbox.html
+++ b/templates/clubs/message_inbox.html
@@ -5,7 +5,11 @@
   <h2 class="mb-4">Mensajes</h2>
   <div class="list-group">
     {% for m in conversations %}
+      {% if user == m.club.owner %}
+      <a href="{% url 'club_conversation' m.club.slug m.user.id %}" class="list-group-item list-group-item-action d-flex align-items-center">
+      {% else %}
       <a href="{% url 'conversation' m.club.slug %}" class="list-group-item list-group-item-action d-flex align-items-center">
+      {% endif %}
         {% if m.club.logo %}
           <img src="{{ m.club.logo.url }}" class="rounded-circle me-3" style="width:40px;height:40px;object-fit:cover;" alt="{{ m.club.name }}">
         {% else %}
@@ -14,7 +18,13 @@
           </div>
         {% endif %}
         <div class="flex-grow-1">
-          <div class="fw-bold">{{ m.club.name }}</div>
+          <div class="fw-bold">
+            {% if user == m.club.owner %}
+              {{ m.user.username }} - {{ m.club.name }}
+            {% else %}
+              {{ m.club.name }}
+            {% endif %}
+          </div>
           <div class="text-muted small">{{ m.content|truncatechars:40 }}</div>
         </div>
         <small class="text-muted ms-3">{{ m.created_at|timesince }} atrás</small>


### PR DESCRIPTION
## Summary
- show user-club messages in club owner's inbox
- show user info for club owners and link to conversation correctly
- update context processor to include club owner messages
- test that inbox shows user->club messages

## Testing
- `python manage.py test` *(fails: ImportError: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_688454abb3748321a307e32a17c1d216