### PR TITLE
UI tweaks for messages and login redirect

### DIFF
--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -2,24 +2,62 @@
 {% load static %}
 {% block content %}
 <div class="container my-4">
-  <h2 class="mb-4">Conversación con {{ club.name }}</h2>
-  <div class="mb-3">
-    {% for m in messages %}
-      <div class="d-flex {% if m.sender_is_club %}justify-content-start{% else %}justify-content-end{% endif %} mb-2">
-        <div class="p-2 rounded {% if m.sender_is_club %}bg-light{% else %}bg-dark text-white{% endif %}">
-          <div class="fw-bold">{% if m.sender_is_club %}{{ club.name }}{% else %}{{ m.user.username }}{% endif %}</div>
-          <div>{{ m.content }}</div>
-          <div class="text-muted small">{{ m.created_at|timesince }} atrás</div>
-        </div>
+  <div class="row">
+    <div class="col-md-4 mb-3">
+      <h5 class="mb-3">Remitentes</h5>
+      <div class="list-group">
+        {% for conv in conversations %}
+          {% if user == conv.club.owner %}
+            <a href="{% url 'club_conversation' conv.club.slug conv.user.id %}" class="list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club and conv.user == conversant %}active text-white{% endif %}">
+          {% else %}
+            <a href="{% url 'conversation' conv.club.slug %}" class="list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club %}active text-white{% endif %}">
+          {% endif %}
+            {% if conv.club.logo %}
+              <img src="{{ conv.club.logo.url }}" class="rounded-circle me-3" style="width:40px;height:40px;object-fit:cover;" alt="{{ conv.club.name }}">
+            {% else %}
+              <div class="rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center me-3" style="width:40px;height:40px;">
+                {{ conv.club.name|first|upper }}
+              </div>
+            {% endif %}
+            <div class="flex-grow-1">
+              <div class="fw-bold">
+                {% if user == conv.club.owner %}
+                  {{ conv.user.username }} - {{ conv.club.name }}
+                {% else %}
+                  {{ conv.club.name }}
+                {% endif %}
+              </div>
+              <div class="text-muted small">{{ conv.content|truncatechars:40 }}</div>
+            </div>
+            <small class="text-muted ms-3">{{ conv.created_at|timesince }} atrás</small>
+          </a>
+        {% empty %}
+          <p>No hay mensajes.</p>
+        {% endfor %}
       </div>
-    {% empty %}
-      <p>No hay mensajes.</p>
-    {% endfor %}
+    </div>
+    <div class="col-md-8">
+      <h5 class="mb-3">Conversación con {{ club.name }}</h5>
+      <div class="mb-3">
+        {% for m in messages %}
+          <div class="d-flex {% if m.sender_is_club %}justify-content-start{% else %}justify-content-end{% endif %} mb-2">
+            <div class="p-2 rounded {% if m.sender_is_club %}bg-light{% else %}bg-dark text-white{% endif %}">
+              <div class="fw-bold">{% if m.sender_is_club %}{{ club.name }}{% else %}{{ m.user.username }}{% endif %}</div>
+              <div>{{ m.content }}</div>
+              <div class="text-muted small">{{ m.created_at|timesince }} atrás</div>
+            </div>
+          </div>
+        {% empty %}
+          <p>No hay mensajes.</p>
+        {% endfor %}
+      </div>
+      <form method="post" class="input-group">
+        {% csrf_token %}
+        <button type="button" class="btn btn-outline-secondary">😀</button>
+        {{ form.content }}
+        <button type="submit" class="btn btn-dark">Enviar</button>
+      </form>
+    </div>
   </div>
-  <form method="post">
-    {% csrf_token %}
-    {{ form.content }}
-    <button type="submit" class="btn btn-dark btn-sm mt-2">Enviar</button>
-  </form>
 </div>
 {% endblock %}

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -62,15 +62,6 @@
                     </a>
                 </li>
                 {% endif %} {% endif %} {% if user.is_authenticated %}
-                <li class="nav-item ms-2">
-                    <a
-                        href="{% url 'message_inbox' %}"
-                        class="nav-link text-dark p-0"
-                        title="Mensajes"
-                    >
-                        <i class="bi bi-send-fill"></i>
-                    </a>
-                </li>
                 <li class="nav-item">
                     <div
                         class="custom-dropdown p-0 small ms-4"
@@ -127,9 +118,8 @@
 
                 {% else %}
                 <li class="nav-item">
-                    <a href="{% url 'login' %}" class="nav-link text-dark"
-                        >Iniciar Sesión</a
-                    >
+                    <a href="{% url 'login' %}?next={{ request.get_full_path }}" class="nav-link text-dark"
+                        >Iniciar Sesión</a>
                 </li>
                 <li class="nav-item">
                     <a


### PR DESCRIPTION
## Summary
- remove plane icon from header
- keep current page when going to login
- show conversation list and messages side-by-side
- improve message form layout

## Testing
- `pip install -r requirements.txt` *(fails: Could not find Django)*

------
https://chatgpt.com/codex/tasks/task_e_6884f737ad148321a1bcd7cce48d9c5c