### PR TITLE
Implement emoji picker and update message UI

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -445,6 +445,13 @@ class ClubMessageForm(forms.ModelForm):
         model = models.ClubMessage
         fields = ['content']
         widgets = {
-            'content': EmojiPickerTextarea(attrs={'class': 'form-control', 'rows': 4})
+            'content': EmojiPickerTextarea(
+                attrs={
+                    'class': 'form-control form-control-sm w-100',
+                    'rows': 1,
+                    'style': 'height:30px;',
+                    'placeholder': 'Mensaje...'
+                }
+            )
         }
 

--- a/apps/clubs/views/messages.py
+++ b/apps/clubs/views/messages.py
@@ -60,11 +60,6 @@ def conversation(request, slug, user_id=None):
 
     if request.method == 'POST':
         form = ClubMessageForm(request.POST)
-        form.fields['content'].widget.attrs.update({
-            'rows': 1,
-            'class': 'form-control form-control-sm',
-            'placeholder': 'Escribe un mensaje...'
-        })
         if form.is_valid():
             msg = form.save(commit=False)
             msg.club = club
@@ -76,11 +71,6 @@ def conversation(request, slug, user_id=None):
             return redirect('conversation', slug=club.slug)
     else:
         form = ClubMessageForm()
-        form.fields['content'].widget.attrs.update({
-            'rows': 1,
-            'class': 'form-control form-control-sm',
-            'placeholder': 'Escribe un mensaje...'
-        })
 
     context = {
         'club': club,

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -172,3 +172,13 @@
   padding-bottom: 0.125rem;
   font-size: 0.75rem;
 }
+
+/* Message likes */
+.message-like.liked svg path {
+  fill: #e63946;
+  stroke: #e63946;
+}
+
+.message-like svg path {
+  stroke: #000;
+}

--- a/static/js/emoji-picker.js
+++ b/static/js/emoji-picker.js
@@ -1,0 +1,16 @@
+// Simple emoji picker using EmojiButton library
+// Requires EmojiButton via CDN
+
+document.addEventListener('DOMContentLoaded', () => {
+  const button = document.getElementById('emoji-button');
+  const textarea = document.getElementById('id_content');
+  if (!button || !textarea) return;
+
+  const picker = new EmojiButton({ position: 'top-end' });
+  picker.on('emoji', selection => {
+    textarea.value += selection.emoji;
+    textarea.focus();
+  });
+
+  button.addEventListener('click', () => picker.togglePicker(button));
+});

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -49,7 +49,6 @@
                   <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
                     <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
                   </svg>
-                  <span class="like-count ms-1">{{ m.likes.count }}</span>
                 </button>
                 <span class="text-muted small">{{ m.created_at|timesince }} atrás</span>
               </div>
@@ -61,7 +60,7 @@
       </div>
       <form method="post" class="input-group">
         {% csrf_token %}
-        <button type="button" class="btn btn-outline-secondary">😀</button>
+        <button type="button" id="emoji-button" class="btn btn-outline-secondary">😀</button>
         {{ form.content }}
         <button type="submit" class="btn btn-dark">Enviar</button>
       </form>
@@ -72,4 +71,6 @@
 
 {% block extra_js %}
 <script src="{% static 'js/message-like.js' %}"></script>
+<script src="https://cdn.jsdelivr.net/npm/@joeattardi/emoji-button@4/dist/index.min.js"></script>
+<script src="{% static 'js/emoji-picker.js' %}"></script>
 {% endblock %}

--- a/templates/partials/_messages_modal.html
+++ b/templates/partials/_messages_modal.html
@@ -14,12 +14,11 @@
                 <div><strong>{% if m.sender_is_club %}{{ m.club.name }}{% else %}Tú{% endif %}</strong></div>
                 <div>{{ m.content }}</div>
                 <div class="d-flex align-items-center gap-1 mt-1">
-                  <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
-                    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
-                      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
-                    </svg>
-                    <span class="like-count ms-1">{{ m.likes.count }}</span>
-                  </button>
+                    <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
+                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
+                      </svg>
+                    </button>
                   <small class="text-muted">{{ m.created_at|date:'d/m/Y H:i' }}</small>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- style `ClubMessageForm` text area
- simplify conversation view form setup
- update conversation template for smaller input and emoji menu
- remove like counts from message components
- add message-like CSS and emoji picker script

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688508ac323483219fd4fadb7d0991d9