### PR TITLE
Fix conversation UX

### DIFF
--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -39,9 +39,8 @@
     <div class="col-md-8"> 
       <div class="mb-3">
         {% for m in messages %}
-          <div class="d-flex {% if m.sender_is_club %}justify-content-start{% else %}justify-content-end{% endif %} mb-2">
-            <div class="p-2 rounded {% if m.sender_is_club %}bg-light{% else %}bg-dark text-white{% endif %}">
-              <div class="fw-bold">{% if m.sender_is_club %}{{ club.name }}{% else %}{{ m.user.username }}{% endif %}</div>
+          <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2">
+            <div class="p-1 rounded {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-primary text-white{% else %}bg-light{% endif %}">
               <div>{{ m.content }}</div>
               <div class="d-flex align-items-center gap-1 mt-1">
                 <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
@@ -57,11 +56,10 @@
           <p>No hay mensajes.</p>
         {% endfor %}
       </div>
-      <form method="post" class="input-group">
+      <form method="post" class="d-flex gap-2">
         {% csrf_token %}
-        <button type="button" id="emoji-button" class="btn btn-outline-secondary">😀</button>
         {{ form.content }}
-        <button type="submit" class="btn btn-dark">Enviar</button>
+        <button type="submit" class="btn btn-primary">Enviar</button>
       </form>
     </div>
   </div>
@@ -70,6 +68,4 @@
 
 {% block extra_js %}
 <script src="{% static 'js/message-like.js' %}"></script>
-<script src="https://cdn.jsdelivr.net/npm/@joeattardi/emoji-button@4/dist/index.min.js"></script>
-<script src="{% static 'js/emoji-picker.js' %}"></script>
 {% endblock %}

--- a/templates/partials/_messages_modal.html
+++ b/templates/partials/_messages_modal.html
@@ -15,17 +15,11 @@
           {% for m in user_messages %}
           <div class="row mb-3">
             <div
-              class="col-12 d-flex {% if m.sender_is_club %}justify-content-start{% else %}justify-content-end{% endif %}"
+              class="col-12 d-flex {% if user == m.club.owner and m.sender_is_club or user != m.club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %}"
             >
               <div
-                class="p-2 rounded {% if m.sender_is_club %}bg-light{% else %}bg-dark text-white{% endif %}"
+                class="p-1 rounded {% if user == m.club.owner and m.sender_is_club or user != m.club.owner and not m.sender_is_club %}bg-primary text-white{% else %}bg-light{% endif %}"
               >
-                <div>
-                  <strong
-                    >{% if m.sender_is_club %}{{ m.club.name }}{% else %}Tú{%
-                    endif %}</strong
-                  >
-                </div>
                 <div>{{ m.content }}</div>
                 <div class="d-flex align-items-center gap-1 mt-1">
                   <button


### PR DESCRIPTION
## Summary
- align outgoing messages to the right with bg-primary
- align incoming messages to the left with bg-light
- remove sender name from conversation messages
- simplify message form layout and remove emoji picker

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_688523726d088321b60896be9d683ec7