### PR TITLE
Move club actions to reviews column

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -424,10 +424,17 @@
    align-items: center;
  }
 
- .review-filter-dropdown .select-arrow {
-   position: relative;
-   top: auto;
-   right: auto;
-   margin-left: 5px;
-   pointer-events: auto;
- }
+.review-filter-dropdown .select-arrow {
+  position: relative;
+  top: auto;
+  right: auto;
+  margin-left: 5px;
+  pointer-events: auto;
+}
+
+/* Action buttons in the reviews column */
+.club-actions > * {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.25rem;
+}

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -66,67 +66,7 @@
                              {% endif %}
                          </div> 
 
-                            <span class="d-flex align-items-start mb-2">
-                                <svg aria-hidden="true"
-                                     xmlns="http://www.w3.org/2000/svg"
-                                     width="35"
-                                     height="35"
-                                     fill="none"
-                                     viewBox="0 0 24 24">
-                                  <path stroke="currentColor"
-                                        stroke-linecap="round"
-                                        stroke-linejoin="round"
-                                        stroke-width="1.5"
-                                        d="M12 21s-6-5.2-6-10a6 6 0 1 1 12 0c0 4.8-6 10-6 10Z" />
-                                  <circle cx="12" cy="11" r="2" stroke="currentColor" stroke-width="2" />
-                                </svg>
 
-
-                            <a href="https://www.google.com/maps/search/?api=1&query={{ club.address|urlencode }}"
-                                   target="_blank"
-                                   class="ms-1 d-flex text-decoration-none  ">{{ club.address }} - {{ club.city }}
-
-                            </a>
-                        </span> 
-
-                        
-                          
-                        <button type="button"  
-                                onclick="location.href='{% url 'conversation' club.slug %}'">
-                          <i class="bi bi-chat-left-text"></i> Contacto
-                        </button>
-    <div class="d-block">
-
-
-        <button id="club-heart"
-            aria-label="Seguir"
-            data-url="{% url 'toggle_follow' 'club' club.id %}"
-        class="{% if club_followed %}liked{% endif %} d-inline-flex align-items-center gap-1">
-
-        <svg aria-hidden="true"
-             xmlns="http://www.w3.org/2000/svg"
-             width="20"
-             height="20"
-             fill="none"
-             viewBox="0 0 24 24">
-            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
-        </svg> 
-
-        Seguir
-
-        </button>
-        <button  class="ms-2 d-inline-flex align-items-center gap-1" id="club-share" aria-label="Compartir">
-        <svg aria-hidden="true"
-             xmlns="http://www.w3.org/2000/svg"
-             width="20"
-             height="20"
-             fill="none"
-             viewBox="0 0 24 24">
-            <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M7.926 10.898 15 7.727m-7.074 5.39L15 16.29M8 12a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm12 5.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm0-11a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Z" />
-        </svg> 
-        Compartir
-        </button>
-    </div>
             
                         
                     </div>
@@ -577,7 +517,57 @@
             </div>
             <!-- Columna Derecha: Valoraciones y Reseñas -->
             <div class="col-lg-2">
-              
+
+                <div class="club-actions d-flex flex-column align-items-start gap-2 mb-4">
+                    <a href="https://www.google.com/maps/search/?api=1&query={{ club.address|urlencode }}"
+                       target="_blank"
+                       class="d-flex align-items-start gap-1 text-decoration-none">
+                        <svg aria-hidden="true"
+                             xmlns="http://www.w3.org/2000/svg"
+                             width="20"
+                             height="20"
+                             fill="none"
+                             viewBox="0 0 24 24">
+                          <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 21s-6-5.2-6-10a6 6 0 1 1 12 0c0 4.8-6 10-6 10Z" />
+                          <circle cx="12" cy="11" r="2" stroke="currentColor" stroke-width="2" />
+                        </svg>
+                        <span>{{ club.address }} - {{ club.city }}</span>
+                    </a>
+
+                    <button type="button"
+                            onclick="location.href='{% url 'conversation' club.slug %}'"
+                            class="d-flex align-items-start gap-1 btn btn-link p-0">
+                        <i class="bi bi-chat-left-text"></i> Mensajes
+                    </button>
+
+                    <button id="club-heart"
+                            aria-label="Seguir"
+                            data-url="{% url 'toggle_follow' 'club' club.id %}"
+                            class="{% if club_followed %}liked{% endif %} d-flex align-items-start gap-1 btn btn-link p-0">
+                        <svg aria-hidden="true"
+                             xmlns="http://www.w3.org/2000/svg"
+                             width="20"
+                             height="20"
+                             fill="none"
+                             viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
+                        </svg>
+                        Seguir
+                    </button>
+
+                    <button class="d-flex align-items-start gap-1 btn btn-link p-0" id="club-share" aria-label="Compartir">
+                        <svg aria-hidden="true"
+                             xmlns="http://www.w3.org/2000/svg"
+                             width="20"
+                             height="20"
+                             fill="none"
+                             viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M7.926 10.898 15 7.727m-7.074 5.39L15 16.29M8 12a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm12 5.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm0-11a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Z" />
+                        </svg>
+                        Compartir
+                    </button>
+                </div>
+
                 <!-- Carrusel de reseñas -->
                 {% if reseñas %}
                     <div class="club-reviews">


### PR DESCRIPTION
## Summary
- relocate address, messages, follow and share actions to the reviews column
- remove old buttons from the club info column
- style club actions vertically

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68864123e08c8321a4988a2cb8575633