### PR TITLE
Add expandable search box next to header logo

### DIFF
--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -4,6 +4,17 @@
 >
     <div class="container-fluid px-3">
         {% include 'partials/_header-logo.html' %}
+        <span class="vr mx-3 d-none d-lg-block"></span>
+        <div class="searchbox-expandable d-none d-lg-block me-3">
+            <form action="{% url 'search_results' %}" method="get">
+                <input id="header-search" class="searchbox-input" type="search" name="q" placeholder="Buscar" />
+                <label for="header-search" class="searchbox-button">
+                    <svg class="w-6 h-6 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="m21 21-3.5-3.5M17 10a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z"/>
+                    </svg>
+                </label>
+            </form>
+        </div>
         <button
             class="navbar-toggler"
             type="button"


### PR DESCRIPTION
## Summary
- add expandable search box with search icon next to the site logo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_6886ca913fd88321bc3ac506fa38fce3