### PR TITLE
Improve header search form

### DIFF
--- a/static/css/_header.css
+++ b/static/css/_header.css
@@ -17,3 +17,36 @@
     justify-content: center;
     font-weight: 600;
 }
+
+/* Búsqueda en el header */
+.header-vr {
+    height: 25px;
+    opacity: 1;
+    background-color: #ccc;
+}
+
+.header-search-form {
+    border: none;
+    height: 40px;
+}
+
+.header-search-form .search-input {
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid #ccc;
+    color: #000;
+}
+
+.header-search-form .search-input:focus {
+    box-shadow: none;
+}
+
+.header-search-form .search-button {
+    background: transparent;
+    color: #000;
+    width: 40px;
+}
+
+.header-search-form .search-button svg {
+    color: currentColor;
+}

--- a/static/js/dropdown.js
+++ b/static/js/dropdown.js
@@ -1,9 +1,13 @@
  document.addEventListener("DOMContentLoaded", function () {
-    const dropdown = document.getElementById("category-dropdown");
-    const selectedText = dropdown.querySelector(".selected-text");
-    const hiddenInput = document.getElementById("category-input");
-    const menu = document.getElementById("category-menu");
-    const items = menu.querySelectorAll(".dropdown-item");
+    const forms = document.querySelectorAll('#main-search-form');
+
+    forms.forEach(form => {
+        const dropdown = form.querySelector("#category-dropdown");
+        if (!dropdown) return;
+        const selectedText = dropdown.querySelector(".selected-text");
+        const hiddenInput = form.querySelector("#category-input");
+        const menu = form.querySelector("#category-menu");
+        const items = menu.querySelectorAll(".dropdown-item");
 
     // Mostrar u ocultar menú
     dropdown.addEventListener("click", function (e) {
@@ -24,11 +28,12 @@
     });
 
     // Cerrar menú al hacer click fuera
-    document.addEventListener("click", function (e) {
-        if (!dropdown.contains(e.target)) {
-            menu.style.display = "none";
-            dropdown.classList.remove("active");
-        }
+        document.addEventListener("click", function (e) {
+            if (!dropdown.contains(e.target)) {
+                menu.style.display = "none";
+                dropdown.classList.remove("active");
+            }
+        });
     });
 
 

--- a/static/js/geolocator.js
+++ b/static/js/geolocator.js
@@ -2,10 +2,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 
     //geolocator
-    const input = document.getElementById('search-input');
-    const wrapper = document.querySelector('.autocomplete-wrapper');
-    const locationOption = document.getElementById('use-location-option');
-    const list = document.getElementById('autocomplete-list');
+    const forms = document.querySelectorAll('#main-search-form');
 
     const suggestions = [
         "A Coruña", "Álava", "Albacete", "Alicante", "Almería", "Asturias", "Ávila", "Badajoz", "Baleares", "Barcelona",
@@ -16,74 +13,75 @@ document.addEventListener('DOMContentLoaded', function () {
         "Ceuta", "Melilla"
     ];
 
-    function showSuggestions(query) {
-        list.innerHTML = ''; // Limpiar lista
+    forms.forEach(form => {
+        const input = form.querySelector('#search-input');
+        const wrapper = form.querySelector('.autocomplete-wrapper');
+        const locationOption = form.querySelector('#use-location-option');
+        const list = form.querySelector('#autocomplete-list');
+        if (!input || !wrapper || !locationOption || !list) return;
 
-        if (query.length === 0) {
-            // No mostrar ciudades si no escribe nada
-            return;
+        function showSuggestions(query) {
+            list.innerHTML = '';
+
+            if (query.length === 0) {
+                return;
+            }
+
+            const matches = suggestions.filter(city => city.toLowerCase().startsWith(query));
+
+            matches.forEach(match => {
+                const li = document.createElement('li');
+                li.textContent = match;
+                li.addEventListener('click', () => {
+                    input.value = match;
+                    wrapper.style.display = 'none';
+                });
+                list.appendChild(li);
+            });
         }
 
-        const matches = suggestions.filter(city => city.toLowerCase().startsWith(query));
-
-        matches.forEach(match => {
-            const li = document.createElement('li');
-            li.textContent = match;
-            li.addEventListener('click', () => {
-                input.value = match;
-                wrapper.style.display = 'none';
-            });
-            list.appendChild(li);
+        input.addEventListener('focus', () => {
+            wrapper.style.display = 'block';
+            list.innerHTML = '';
         });
-    }
 
-    // Abrir dropdown al hacer click en el input
-    input.addEventListener('focus', () => {
-        wrapper.style.display = 'block';
-        list.innerHTML = ''; // Aseguramos que no haya ciudades si no escribe
-    });
+        input.addEventListener('input', () => {
+            const query = input.value.trim().toLowerCase();
+            list.innerHTML = '';
+            showSuggestions(query);
+        });
 
-    // Al escribir
-    input.addEventListener('input', () => {
-        const query = input.value.trim().toLowerCase();
-        list.innerHTML = '';
-        showSuggestions(query);
-    });
-
-    // Cerrar dropdown si mueve el mouse fuera del wrapper
-    wrapper.addEventListener('mouseleave', () => {
-        wrapper.style.display = 'none';
-    });
-
-
-
-    // Geolocalización al click
-    locationOption.addEventListener('click', () => {
-        if (navigator.geolocation) {
-            navigator.geolocation.getCurrentPosition(async (position) => {
-                const lat = position.coords.latitude;
-                const lon = position.coords.longitude;
-
-                try {
-                    const response = await fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}`);
-                    const data = await response.json();
-                    const city = data.address.city || data.address.town || data.address.village || '';
-
-                    input.value = city;
-                } catch (err) {
-                    console.error('Error obteniendo ciudad:', err);
-                    input.value = `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
-                }
-
-                wrapper.style.display = 'none';
-            }, () => {
-                alert("No se pudo obtener tu ubicación.");
-                wrapper.style.display = 'none';
-            });
-        } else {
-            alert("Geolocalización no soportada en este navegador.");
+        wrapper.addEventListener('mouseleave', () => {
             wrapper.style.display = 'none';
-        }
+        });
+
+        locationOption.addEventListener('click', () => {
+            if (navigator.geolocation) {
+                navigator.geolocation.getCurrentPosition(async (position) => {
+                    const lat = position.coords.latitude;
+                    const lon = position.coords.longitude;
+
+                    try {
+                        const response = await fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}`);
+                        const data = await response.json();
+                        const city = data.address.city || data.address.town || data.address.village || '';
+
+                        input.value = city;
+                    } catch (err) {
+                        console.error('Error obteniendo ciudad:', err);
+                        input.value = `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+                    }
+
+                    wrapper.style.display = 'none';
+                }, () => {
+                    alert("No se pudo obtener tu ubicación.");
+                    wrapper.style.display = 'none';
+                });
+            } else {
+                alert("Geolocalización no soportada en este navegador.");
+                wrapper.style.display = 'none';
+            }
+        });
     });
     
 

--- a/static/js/search-results.js
+++ b/static/js/search-results.js
@@ -1,19 +1,22 @@
 document.addEventListener("DOMContentLoaded", function () {
-    const form = document.getElementById("main-search-form");
-    const input = document.getElementById("search-input");
-
+    const forms = document.querySelectorAll("#main-search-form");
     const stopWords = ["a", "de", "la", "el", "en", "y"];
 
-    form.addEventListener("submit", function (e) {
-        const text = input.value.trim().toLowerCase();
-        const isValid = text.length >= 3 && !stopWords.includes(text);
+    forms.forEach(form => {
+        const input = form.querySelector("#search-input");
+        if (!input) return;
 
-        if (!isValid) {
-            e.preventDefault();
-            form.classList.add("form-error");
-            setTimeout(() => {
-                form.classList.remove("form-error");
-            }, 600);
-        }
+        form.addEventListener("submit", function (e) {
+            const text = input.value.trim().toLowerCase();
+            const isValid = text.length >= 3 && !stopWords.includes(text);
+
+            if (!isValid) {
+                e.preventDefault();
+                form.classList.add("form-error");
+                setTimeout(() => {
+                    form.classList.remove("form-error");
+                }, 600);
+            }
+        });
     });
 });

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -4,35 +4,9 @@
 >
     <div class="container-fluid px-3">
         {% include 'partials/_header-logo.html' %} {% if request.path != '/' %}
-        <span class="vr mx-3 d-none d-lg-block"></span>
-        <div class="searchbox-expandable d-none d-lg-block me-3">
-            <form action="{% url 'search_results' %}" method="get">
-                <input
-                    id="header-search"
-                    class="searchbox-input"
-                    type="search"
-                    name="q"
-                    placeholder="Buscar"
-                />
-                <label for="header-search" class="searchbox-button">
-                    <svg
-                        class="w-6 h-6 text-gray-800 dark:text-white"
-                        aria-hidden="true"
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="24"
-                        height="24"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                    >
-                        <path
-                            stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-width="2"
-                            d="m21 21-3.5-3.5M17 10a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z"
-                        />
-                    </svg>
-                </label>
-            </form>
+        <span class="vr header-vr mx-3 d-none d-lg-block"></span>
+        <div class="d-none d-lg-block me-3">
+            {% include 'partials/_search_form.html' with header=True %}
         </div>
 
         {% endif %}

--- a/templates/partials/_search_form.html
+++ b/templates/partials/_search_form.html
@@ -1,25 +1,25 @@
  
 <form method="GET" action="{% url 'search_results' %}" id="main-search-form"
-      class=" d-flex align-items-center my-3 position-relative  {% if header %}header-search-form{% endif %}" 
+      class="main-search-form d-flex align-items-center my-3 position-relative {% if header %}header-search-form{% endif %}"
       style="max-width:  600px;  margin: 0 auto; z-index:10;"
-      > 
-        <input 
+      >
+        <input
             type="text"
             name="q"
             id="search-input"
-            class="form-control border-0"
+            class="search-input form-control border-0"
             placeholder="Buscar por ciudad o nombre"
             autocomplete="off"
-            
-        > 
+
+        >
 
     <!-- Dropdown personalizado -->
-    <div class="custom-dropdown" id="category-dropdown">
+    <div class="custom-dropdown category-dropdown" id="category-dropdown">
         <div class="selected">
             <span class="selected-text">Clubs</span>
             <span class="select-arrow"></span>
         </div>
-        <div class="dropdown-menu" id="category-menu">
+        <div class="dropdown-menu category-menu" id="category-menu">
             <div class="dropdown-item" data-value="club">Clubs</div>
             <div class="dropdown-item" data-value="entrenador">Entrenadores</div>
             <div class="dropdown-item" data-value="promotor">Promotores</div>
@@ -28,7 +28,7 @@
     </div>
 
     <!-- Input oculto -->
-    <input type="hidden" name="category" id="category-input" value="club">
+    <input type="hidden" name="category" id="category-input" class="category-input" value="club">
 
     <!-- Autocomplete -->
     <div class="autocomplete-wrapper bg-white position-absolute start-0 text-start"
@@ -37,11 +37,11 @@
             <span class="me-1"><svg  style="width:20px;" id="Icons" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><defs><style>.cls-1{fill:#000000;}</style></defs><path class="cls-1" d="M2,10c0,8.491,9.126,13.658,9.514,13.874a1,1,0,0,0,.972,0C12.874,23.658,22,18.491,22,10A10,10,0,0,0,2,10ZM12,2a8.009,8.009,0,0,1,8,8c0,6.274-6.2,10.68-8,11.83C10.2,20.68,4,16.274,4,10A8.009,8.009,0,0,1,12,2Z"/><path class="cls-1" d="M12,15a5,5,0,1,0-5-5A5.006,5.006,0,0,0,12,15Zm0-8a3,3,0,1,1-3,3A3,3,0,0,1,12,7Z"/></svg></span>
             <span>Más cercanos a ti</span>
         </div>
-        <ul id="autocomplete-list" class="list-unstyled" style="max-height:150px;"></ul>
+        <ul id="autocomplete-list" class="autocomplete-list list-unstyled" style="max-height:150px;"></ul>
     </div>
 
     <!-- Botón búsqueda -->
-    <button type="submit" id="search-button" class=" px-2 py-1 ms-2">
+    <button type="submit" id="search-button" class="search-button px-2 py-1 ms-2">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none"
              viewBox="0 0 24 24" stroke="currentColor"  >
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"


### PR DESCRIPTION
## Summary
- use the full search form component inside header
- style header search box with grey divider and transparent fields
- support multiple search forms in JS

## Testing
- `python manage.py test -v0` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6886dc4d35a883218b6bc099cf5a2474