### PR TITLE
Improve header search form UX

### DIFF
--- a/static/css/_header.css
+++ b/static/css/_header.css
@@ -104,7 +104,6 @@
     left: 49px;
     width: 0;
     height: 100%;
-    border-bottom: 1px solid #cfcfcf !important;
     border: none;
     outline: none;
     padding: 0;
@@ -120,4 +119,15 @@
 .searchbox-input:focus+.searchbox-button {
     background-color: white;
     color: black;
+}
+
+/* Hide dropdown and button until the input expands */
+.header-search-form #category-dropdown,
+.header-search-form #search-button {
+    display: none;
+}
+
+.header-search-form .searchbox-input:focus ~ #category-dropdown,
+.header-search-form .searchbox-input:focus ~ #search-button {
+    display: flex;
 }

--- a/static/css/_search-form.css
+++ b/static/css/_search-form.css
@@ -101,8 +101,9 @@
 
 #search-button {
     height: 100%;
-    width:80px;
-    background:#000;
+    width: 80px;
+    background: transparent;
+    color: #000;
     border: none;
     display: flex;
     align-items: center;
@@ -112,14 +113,13 @@
     border-top-right-radius: 7px 7px;
     border-bottom-right-radius: 7px 7px;
     z-index: 0 !important;
-
 }
 
  #search-button svg {
     width: 24px;
     height: 24px;
     transition: transform 0.2s ease;
-    color: white;
+    color: #000;
 }
 
 #search-button:hover svg {

--- a/static/js/dropdown.js
+++ b/static/js/dropdown.js
@@ -4,6 +4,7 @@
     const hiddenInput = document.getElementById("category-input");
     const menu = document.getElementById("category-menu");
     const items = menu.querySelectorAll(".dropdown-item");
+    const searchInput = document.getElementById("header-search");
 
     // Mostrar u ocultar menú
     dropdown.addEventListener("click", function (e) {
@@ -11,6 +12,13 @@
         dropdown.classList.toggle("active");
         menu.style.display = menu.style.display === "block" ? "none" : "block";
     });
+
+    if (searchInput) {
+        searchInput.addEventListener("input", function () {
+            dropdown.classList.add("active");
+            menu.style.display = "block";
+        });
+    }
 
     // Seleccionar opción
     items.forEach(item => {

--- a/static/js/geolocator.js
+++ b/static/js/geolocator.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 
     //geolocator
-    const input = document.getElementById('search-input');
+    const input = document.getElementById('search-input') || document.getElementById('header-search');
     const wrapper = document.querySelector('.autocomplete-wrapper');
     const locationOption = document.getElementById('use-location-option');
     const list = document.getElementById('autocomplete-list');

--- a/templates/partials/_search_form_mini.html
+++ b/templates/partials/_search_form_mini.html
@@ -93,7 +93,7 @@
     </div>
 
     <!-- Botón búsqueda -->
-    <button type="submit" id="search-button" class="px-2 py-1 ms-2 text-white">
-        Buscar
+    <button type="submit" id="search-button" class="px-2 py-1 ms-2 text-black">
+        buscar
     </button>
 </form>


### PR DESCRIPTION
## Summary
- tweak mini search form styles
- update dropdown logic to open when typing
- support geolocation autocomplete for header search

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6886e80c9c688321b28ec9d1ad080f13