### PR TITLE
Hide home search modal button & expand dropdown

### DIFF
--- a/static/css/_search-form.css
+++ b/static/css/_search-form.css
@@ -153,3 +153,7 @@
 
 
  
+#searchModal .modal-body {
+    overflow-y: visible;
+    min-height: 220px;
+}

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -4,6 +4,7 @@
 >
     <div class="container-fluid px-3">
         {% include 'partials/_header-logo.html' %}
+        {% if request.path != '/' %}
         <span class="vr mx-3 d-none d-lg-block m-4"></span>
         <div class="d-none d-lg-block me-3">
             <button
@@ -29,6 +30,7 @@
                 </svg>
             </button>
         </div>
+        {% endif %}
 
         <button
             class="navbar-toggler"


### PR DESCRIPTION
## Summary
- hide search button in header when on home page
- let search modal fit the autocomplete dropdown

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for PIL & Django)*

------
https://chatgpt.com/codex/tasks/task_e_6886f532b7d8832180f9359da4fc70b7