### PR TITLE
Remove white background from search modal

### DIFF
--- a/static/css/_search-form.css
+++ b/static/css/_search-form.css
@@ -157,3 +157,10 @@
     overflow-y: visible;
     min-height: 220px;
 }
+
+/* Remove default white background from the search modal */
+#searchModal .modal-content {
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+}


### PR DESCRIPTION
## Summary
- make the search modal transparent so it blends in with the background

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6886f81c4ba48321ab6d199049496294