### PR TITLE
Add verified badge next to club name

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -24,14 +24,20 @@
        border-radius: 6px;
  }
 
- .badge-outline {
+.badge-outline {
        font-size: 0.75rem;
        background-color: transparent;
        color: #000000;
        border-radius: 6px;
        padding: 0px 2px 0 2px;
        border: 1px solid black;
- }
+}
+
+/* Verified label next to club name */
+.verificado-badge {
+       font-size: 0.75rem;
+       font-weight: 600;
+}
 
 
  /* List groups */

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -43,16 +43,18 @@
             </div>
                
                 <div class="p-4 d-flex align-items-start mt-2 mb-4 gap-3 ">
-                    <div> 
-                         <h1 class="h3 mb-2" style="font-weight:900;">{{ club.name }}</h1>
+                    <div>
+                        <h1 class="h3 mb-2 d-flex align-items-center" style="font-weight:900;">
+                            {{ club.name }}
+                            {% if club.verified %}
+                                <span class="ms-2 verificado-badge d-flex align-items-center" title="Verificado">
+                                    Verificado<svg class="ms-1" style="width:20px;" data-name="Layer 1" id="Layer_1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title/><path d="M22.41,10.59,20.36,8.54V5.63a2,2,0,0,0-2-2H15.46l-2.05-2a2,2,0,0,0-2.82,0L8.54,3.64H5.63a2,2,0,0,0-2,2V8.54l-2,2.05A2,2,0,0,0,1,12a2,2,0,0,0,.58,1.41l2.06,2.05v2.91a2,2,0,0,0,2,2H8.54l2.05,2.05A2,2,0,0,0,12,23a2,2,0,0,0,1.41-.58l2.05-2.06h2.91a2,2,0,0,0,2-2V15.46l2.05-2.05a2,2,0,0,0,0-2.82Zm-4.05,4.05v3.72H14.64L12,21,9.36,18.36H5.64V14.64L3,12,5.64,9.36V5.64H9.36L12,3l2.64,2.64h3.72V9.36L21,12Z"/><polygon points="11 12.73 8.71 10.44 7.29 11.85 11 15.56 16.71 9.85 15.29 8.44 11 12.73"/></svg>
+                                </span>
+                            {% endif %}
+                        </h1>
                         <div class="d-flex align-items-start mb-3">
-                             <span class="badge-outline  ">{{ club.get_category_display }}</span>
-                             {% if club.verified %}
-                                 <span class="ms-2" title="Verificado">
-                                     <svg style="width:20px;" data-name="Layer 1" id="Layer_1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title/><path d="M22.41,10.59,20.36,8.54V5.63a2,2,0,0,0-2-2H15.46l-2.05-2a2,2,0,0,0-2.82,0L8.54,3.64H5.63a2,2,0,0,0-2,2V8.54l-2,2.05A2,2,0,0,0,1,12a2,2,0,0,0,.58,1.41l2.06,2.05v2.91a2,2,0,0,0,2,2H8.54l2.05,2.05A2,2,0,0,0,12,23a2,2,0,0,0,1.41-.58l2.05-2.06h2.91a2,2,0,0,0,2-2V15.46l2.05-2.05a2,2,0,0,0,0-2.82Zm-4.05,4.05v3.72H14.64L12,21,9.36,18.36H5.64V14.64L3,12,5.64,9.36V5.64H9.36L12,3l2.64,2.64h3.72V9.36L21,12Z"/><polygon points="11 12.73 8.71 10.44 7.29 11.85 11 15.56 16.71 9.85 15.29 8.44 11 12.73"/></svg>
-                                 </span>
-                             {% endif %}
-                         </div> 
+                            <span class="badge-outline">{{ club.get_category_display }}</span>
+                        </div>
 
                         <div class="club-actions d-flex flex-column align-items-start gap-2 mb-4">
                              


### PR DESCRIPTION
## Summary
- show 'Verificado' text with icon beside the club name
- tweak club profile CSS for new label

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68878986c34c83218d982a4d43d090e9