### PR TITLE
Modify message UI

### DIFF
--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -4,7 +4,7 @@
 <div class="container my-4">
   <div class="row">
     <div class="col-md-4 mb-3">
-      <h5 class="mb-3">Remitentes</h5>
+      <h5 class="mb-3">Mensajes</h5>
       <div class="list-group">
         {% for conv in conversations %}
           {% if user == conv.club.owner %}
@@ -40,7 +40,7 @@
       <div class="mb-3">
         {% for m in messages %}
           <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2">
-            <div class="p-1 rounded {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-primary text-white{% else %}bg-light{% endif %}">
+            <div class="p-1 rounded {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}bg-light{% endif %}">
               <div>{{ m.content }}</div>
               <div class="d-flex align-items-center gap-1 mt-1">
                 <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
@@ -48,10 +48,10 @@
                     <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
                   </svg>
                 </button>
-                <span class="text-muted small">{{ m.created_at|timesince }} atrás</span>
               </div>
             </div>
           </div>
+          <div class="text-center text-muted small">{{ m.created_at|date:'H:i' }}</div>
         {% empty %}
           <p>No hay mensajes.</p>
         {% endfor %}


### PR DESCRIPTION
## Summary
- tweak conversation screen layout
  - rename sidebar title to "Mensajes"
  - darken outgoing message bubbles
  - show message time centered below each entry

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==5.1.2)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6888a31a24bc83218162e27f4aa395c5