### PR TITLE
Improve message timestamp display

### DIFF
--- a/apps/clubs/views/messages.py
+++ b/apps/clubs/views/messages.py
@@ -15,6 +15,14 @@ def conversation(request):
     slug = request.GET.get('club')
     user_id = request.GET.get('user')
 
+    ClubMessage.objects.filter(
+        (
+            Q(user=request.user, sender_is_club=True)
+            | Q(club__owner=request.user, sender_is_club=False)
+        )
+        & Q(is_read=False)
+    ).update(is_read=True)
+
     latest_ids = (
         ClubMessage.objects.filter(
             Q(user=request.user) | Q(club__owner=request.user)
@@ -30,13 +38,6 @@ def conversation(request):
     )
 
     if not slug:
-        ClubMessage.objects.filter(
-            (
-                Q(user=request.user, sender_is_club=True)
-                | Q(club__owner=request.user, sender_is_club=False)
-            )
-            & Q(is_read=False)
-        ).update(is_read=True)
         return render(request, 'clubs/message_inbox.html', {'conversations': conversations})
 
     club = get_object_or_404(Club, slug=slug)

--- a/apps/core/templatetags/utils_filters.py
+++ b/apps/core/templatetags/utils_filters.py
@@ -99,3 +99,39 @@ def get_list(querydict, key):
         return querydict.getlist(key)
     except AttributeError:
         return []
+
+
+@register.filter
+def message_timestamp(value):
+    """Return a friendly timestamp for chat messages."""
+    if not value:
+        return ""
+
+    from django.utils import timezone
+
+    value = timezone.localtime(value)
+    now = timezone.localtime(timezone.now())
+
+    if value.date() == now.date():
+        return value.strftime("%H:%M")
+
+    start_of_week = now - timezone.timedelta(days=now.weekday())
+    if value.date() >= start_of_week.date():
+        days = ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"]
+        return f"{days[value.weekday()]} {value.strftime('%H:%M')}"
+
+    months = [
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec",
+    ]
+    return f"{months[value.month - 1]} {value.day}, {value.year}, {value.strftime('%H:%M')}"

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load utils_filters %}
 {% block content %}
 <div class="container my-4">
   <div class="row">
@@ -51,7 +52,7 @@
               </div>
             </div>
           </div>
-          <div class="text-center text-muted small">{{ m.created_at|date:'H:i' }}</div>
+          <div class="text-center text-muted small">{{ m.created_at|message_timestamp }}</div>
         {% empty %}
           <p>No hay mensajes.</p>
         {% endfor %}

--- a/templates/partials/_messages_modal.html
+++ b/templates/partials/_messages_modal.html
@@ -1,3 +1,4 @@
+{% load utils_filters %}
 <div class="modal fade" id="messagesModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
@@ -44,7 +45,7 @@
                     </svg>
                   </button>
                   <small class="text-muted"
-                    >{{ m.created_at|date:'d/m/Y H:i' }}</small
+                    >{{ m.created_at|message_timestamp }}</small
                   >
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- show readable timestamps for chat messages
- mark all messages as read when visiting the conversation view
- update templates to load new tag and use the filter

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6888a77e954483219ae7e94da54e787d