### PR TITLE
Fix toast display on messages page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,9 @@
     </div>
 
     {% include 'partials/_header.html' %}
+    {% if request.path != '/mensajes/' %}
     {% include 'partials/_messages.html' %}
+    {% endif %}
  
       {% if request.path != '/' %}
         {% include 'partials/_search_modal.html' %}


### PR DESCRIPTION
## Summary
- hide toast notifications on `/mensajes/`

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6888a957e088832182dd1d5943b8aac7