### PR TITLE
Update message form style

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -449,7 +449,7 @@ class ClubMessageForm(forms.ModelForm):
                 attrs={
                     'class': 'form-control form-control-sm w-100',
                     'rows': 1,
-                    'style': 'height:30px;',
+                    'style': 'height:30px; max-height:30px;',
                     'placeholder': 'Mensaje...'
                 }
             )

--- a/static/css/conversation.css
+++ b/static/css/conversation.css
@@ -1,0 +1,11 @@
+#message-form {
+  background-color: #f8f9fa;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+}
+#message-form textarea {
+  max-height: 30px;
+}
+#emoji-button {
+  margin-left: auto;
+}

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -57,10 +57,12 @@
           <p>No hay mensajes.</p>
         {% endfor %}
       </div>
-      <form method="post" class="d-flex gap-2">
+      <form method="post" id="message-form" class="d-flex gap-2 align-items-end bg-light p-2 rounded">
         {% csrf_token %}
         {{ form.content }}
-        <button type="submit" class="btn btn-primary">Enviar</button>
+        <button type="submit" class="btn btn-primary d-flex align-items-center">
+          <i class="bi bi-send-fill"></i>
+        </button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- style the message form in conversation page
- show paper airplane icon for send button
- ensure textarea max-height is 30px
- add conversation page CSS

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6888abf778f88321bd4c4eb2d248520d