### PR TITLE
Add reply hover actions and send icon

### DIFF
--- a/static/css/conversation.css
+++ b/static/css/conversation.css
@@ -1,8 +1,34 @@
 #message-form {
+  position: relative;
   background-color: #f8f9fa;
   padding: 0.25rem;
   border-radius: 0.25rem;
 }
 #message-form textarea {
   max-height: 30px;
+  padding-right: 2rem;
+}
+#message-form button[type="submit"] {
+  position: absolute;
+  top: 50%;
+  right: 0.25rem;
+  transform: translateY(-50%);
+}
+
+.message-bubble {
+  position: relative;
+  padding-right: 2rem;
+}
+
+.message-bubble .message-actions {
+  position: absolute;
+  top: 50%;
+  right: 0.25rem;
+  transform: translateY(-50%);
+  display: none;
+  gap: 0.25rem;
+}
+
+.message-bubble:hover .message-actions {
+  display: flex;
 }

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -41,9 +41,12 @@
       <div class="mb-3">
         {% for m in messages %}
           <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2">
-            <div class="p-1 rounded {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}bg-light{% endif %}">
+            <div class="p-1 rounded message-bubble {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}bg-light{% endif %}">
               <div>{{ m.content }}</div>
-              <div class="d-flex align-items-center gap-1 mt-1">
+              <div class="message-actions">
+                <button class="btn p-0 reply-btn">
+                  <i class="bi bi-reply"></i>
+                </button>
                 <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
                   <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
                     <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
@@ -57,7 +60,7 @@
           <p>No hay mensajes.</p>
         {% endfor %}
       </div>
-      <form method="post" id="message-form" class="d-flex gap-2 align-items-end bg-light p-2 rounded">
+      <form method="post" id="message-form" class="bg-light p-2 rounded">
         {% csrf_token %}
         {{ form.content }}
         <button type="submit" class="btn btn-primary d-flex align-items-center">


### PR DESCRIPTION
## Summary
- style message form with inline send icon
- show like & reply icons on hover for messages

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6888b8e2fb8483218e803af46f4b0b97