### PR TITLE
Add next_url redirect for login

### DIFF
--- a/apps/users/context_processors.py
+++ b/apps/users/context_processors.py
@@ -1,6 +1,14 @@
 from .forms import LoginForm
 
 
+def _current_path(request):
+    """Return a reasonable URL to redirect to after login."""
+    return request.get_full_path()
+
+
 def login_form(request):
-    """Provide a login form instance for use in templates."""
-    return {'login_form': LoginForm()}
+    """Provide a login form instance and next URL for templates."""
+    return {
+        'login_form': LoginForm(),
+        'next_url': _current_path(request),
+    }


### PR DESCRIPTION
## Summary
- populate `next_url` with the current page for login forms

## Testing
- `python manage.py test apps/users/tests/test_user.py --verbosity 2` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688cb7d5542083218310600eb19d4a17