### PR TITLE
Improve mobile user dropdown

### DIFF
--- a/static/css/_header.css
+++ b/static/css/_header.css
@@ -41,3 +41,16 @@
 #user-dropdown .burger-icon {
     color: #fff;
 }
+
+/* Overlay for dropdown menu */
+#dropdown-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.7);
+    z-index: 90;
+}
+
+#dropdown-overlay.show {
+    display: block;
+}

--- a/static/js/user-dropdown.js
+++ b/static/js/user-dropdown.js
@@ -1,18 +1,34 @@
- document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener("DOMContentLoaded", function () {
     const dropdown = document.getElementById("user-dropdown");
     if (!dropdown) return;
     const menu = document.getElementById("user-menu");
+    const overlay = document.getElementById("dropdown-overlay");
 
     dropdown.addEventListener("click", function (e) {
         e.stopPropagation();
         dropdown.classList.toggle("active");
-        menu.style.display = menu.style.display === "block" ? "none" : "block";
+        const isOpen = menu.style.display === "block";
+        menu.style.display = isOpen ? "none" : "block";
+        if (overlay) {
+            overlay.classList.toggle("show", !isOpen);
+        }
     });
+
+    if (overlay) {
+        overlay.addEventListener("click", function () {
+            menu.style.display = "none";
+            dropdown.classList.remove("active");
+            overlay.classList.remove("show");
+        });
+    }
 
     document.addEventListener("click", function (e) {
         if (!dropdown.contains(e.target)) {
             menu.style.display = "none";
             dropdown.classList.remove("active");
+            if (overlay) {
+                overlay.classList.remove("show");
+            }
         }
     });
- });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,7 @@
     </div>
 
     {% include 'partials/_header.html' %}
+    <div id="dropdown-overlay" class="dropdown-overlay"></div>
     {% if request.path != '/mensajes/' %}
     {% include 'partials/_messages.html' %}
     {% endif %}


### PR DESCRIPTION
## Summary
- add overlay container for user dropdown
- show overlay when dropdown is open
- style overlay and keep burger and avatar visible

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688cdd7758588321831a469accd546bd