### PR TITLE
Show initials when no club logo

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -30,14 +30,7 @@
                     alt="{{ club.name }}">
             {% else %}
                 <div class="d-flex align-items-center justify-content-center w-100 h-100 bg-dark">
-  <span class="d-flex flex-column align-items-center text-white">
-                    <svg fill="#fff" width="50px" height="50px" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"> <g data-name="Layer 28" id="Layer_28"> 
-                        <path d="M32,3A29,29,0,1,0,61,32,29,29,0,0,0,32,3Zm0,56A27,27,0,1,1,59,32,27,27,0,0,1,32,59ZM43,37a1,1,0,0,1-1,1H22a1,1,0,0,1,0-2H42A1,1,0,0,1,43,37Zm5.71-19.29L44.41,22l4.3,4.29a1,1,0,0,1,0,1.42,1,1,0,0,1-1.42,0L43,23.41l-4.29,4.3a1,1,0,0,1-1.42,0,1,1,0,0,1,0-1.42L41.59,22l-4.3-4.29a1,1,0,0,1,1.42-1.42L43,20.59l4.29-4.3a1,1,0,0,1,1.42,1.42ZM23,23.41l-4.29,4.3a1,1,0,0,1-1.42,0,1,1,0,0,1,0-1.42L21.59,22l-4.3-4.29a1,1,0,0,1,1.42-1.42L23,20.59l4.29-4.3a1,1,0,0,1,1.42,1.42L24.41,22l4.3,4.29a1,1,0,0,1,0,1.42,1,1,0,0,1-1.42,0Z"/>
-
-                        </g>
-
-                        </svg>
-                    <small class="mt-2">Sin logo</small></span>
+                    <span class="text-white fw-bold display-4">{{ club.name|initials }}</span>
                 </div>
             {% endif %}
             </div>

--- a/templates/clubs/search_results.html
+++ b/templates/clubs/search_results.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static %}
+{% load static utils_filters %}
 
 {% block body_class %}search-result-page{% endblock %}
 
@@ -22,15 +22,7 @@
                         <img src="{{ club.logo.url }}" class="card-img-top object-fit-contain" style="height: 200px;" alt="{{ club.name }}">
                     {% else %}
                         <div class="card-img-top d-flex align-items-center justify-content-center bg-dark" style="height: 200px;">
-                                <span class="d-flex flex-column align-items-center text-white">
-                        <svg fill="#fff" width="50px" height="50px" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"> <g data-name="Layer 28" id="Layer_28">
-
-                            <path d="M32,3A29,29,0,1,0,61,32,29,29,0,0,0,32,3Zm0,56A27,27,0,1,1,59,32,27,27,0,0,1,32,59ZM43,37a1,1,0,0,1-1,1H22a1,1,0,0,1,0-2H42A1,1,0,0,1,43,37Zm5.71-19.29L44.41,22l4.3,4.29a1,1,0,0,1,0,1.42,1,1,0,0,1-1.42,0L43,23.41l-4.29,4.3a1,1,0,0,1-1.42,0,1,1,0,0,1,0-1.42L41.59,22l-4.3-4.29a1,1,0,0,1,1.42-1.42L43,20.59l4.29-4.3a1,1,0,0,1,1.42,1.42ZM23,23.41l-4.29,4.3a1,1,0,0,1-1.42,0,1,1,0,0,1,0-1.42L21.59,22l-4.3-4.29a1,1,0,0,1,1.42-1.42L23,20.59l4.29-4.3a1,1,0,0,1,1.42,1.42L24.41,22l4.3,4.29a1,1,0,0,1,0,1.42,1,1,0,0,1-1.42,0Z"/>
-
-                            </g>
-
-                            </svg>
-                        <small class="mt-2">Sin logo</small></span>
+                            <span class="text-white fw-bold display-4">{{ club.name|initials }}</span>
                         </div>
                     {% endif %}
 

--- a/templates/users/favorites.html
+++ b/templates/users/favorites.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static %}
+{% load static utils_filters %}
 
 {% block body_class %}search-result-page{% endblock %}
 
@@ -18,8 +18,8 @@
                     {% if club.logo %}
                         <img src="{{ club.logo.url }}" class="card-img-top object-fit-cover" style="height: 200px;" alt="{{ club.name }}">
                     {% else %}
-                        <div class="card-img-top d-flex align-items-center justify-content-center bg-light" style="height: 200px;">
-                            <span class="text-muted">Sin logo</span>
+                        <div class="card-img-top d-flex align-items-center justify-content-center bg-dark" style="height: 200px;">
+                            <span class="text-white fw-bold display-4">{{ club.name|initials }}</span>
                         </div>
                     {% endif %}
 

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static %}
+{% load static utils_filters %}
 
 {% block content %}
 <div class="d-flex mt-5 container-fluid col-12">
@@ -100,8 +100,8 @@
                             {% if club.logo %}
                                 <img src="{{ club.logo.url }}" class="card-img-top object-fit-cover" style="height:200px" alt="{{ club.name }}">
                             {% else %}
-                                <div class="card-img-top d-flex align-items-center justify-content-center bg-light" style="height:200px;">
-                                    <span class="text-muted">Sin logo</span>
+                                <div class="card-img-top d-flex align-items-center justify-content-center bg-dark" style="height:200px;">
+                                    <span class="text-white fw-bold display-4">{{ club.name|initials }}</span>
                                 </div>
                             {% endif %}
                             <div class="card-body">


### PR DESCRIPTION
## Summary
- display club initials instead of "Sin logo" placeholders
- load `utils_filters` where the initials filter is used

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688ce0c254cc8321a787da0d95c02412