### PR TITLE
Update header search layout

### DIFF
--- a/static/css/_header.css
+++ b/static/css/_header.css
@@ -17,3 +17,10 @@
     justify-content: center;
     font-weight: 600;
 }
+
+/* Divider next to header logo */
+.header-divider {
+    height: 30px;
+    margin: 0 10px;
+    border-left: 1px solid #dee2e6;
+}

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -5,7 +5,7 @@
     <div class="container-fluid px-3">
         {% include 'partials/_header-logo.html' %}
         {% if request.path != '/' %}
-        <span class="vr mx-3 d-none d-lg-block m-4"></span>
+        <span class="vr header-divider d-none d-lg-block"></span>
         <div class="d-none d-lg-block me-3">
             <button
                 class="btn nav-link text-dark me-5"


### PR DESCRIPTION
## Summary
- tweak header layout for search button
- style new header divider

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*
- `DJANGO_SETTINGS_MODULE=config.settings.dev python -m pytest -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_688ce2bfd0688321a97aebf381b995bb