### PR TITLE
Adjust burger button placement

### DIFF
--- a/static/css/_header.css
+++ b/static/css/_header.css
@@ -17,3 +17,9 @@
     justify-content: center;
     font-weight: 600;
 }
+
+/* Remove borders and background from burger button */
+.navbar-toggler {
+    border: none;
+    background-color: transparent;
+}

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -31,17 +31,6 @@
         </div>
         {% endif %}
 
-        <button
-            class="navbar-toggler"
-            type="button"
-            data-bs-toggle="collapse"
-            data-bs-target="#navbarNav"
-            aria-controls="navbarNav"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-        >
-            <span class="navbar-toggler-icon"></span>
-        </button>
         <ul class="navbar-nav align-items-center ms-auto">
                 {% if request.resolver_match.url_name == 'club_dashboard' %}
                 <li class="nav-item d-flex align-items-center ms-2">
@@ -138,5 +127,16 @@
 
                 {% endif %}
             </ul>
+            <button
+                class="navbar-toggler border-0 bg-transparent ms-2"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#navbarNav"
+                aria-controls="navbarNav"
+                aria-expanded="false"
+                aria-label="Toggle navigation"
+            >
+                <span class="navbar-toggler-icon"></span>
+            </button>
     </div>
 </header>


### PR DESCRIPTION
## Summary
- adjust header layout so the burger menu sits to the right of the login/avatar items
- remove border and background from burger menu

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688cec166c248321aae001107eb3005c