### PR TITLE
Display burger in header only for logged-in users

### DIFF
--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -127,6 +127,7 @@
 
                 {% endif %}
             </ul>
+            {% if user.is_authenticated %}
             <button
                 id="burger-button"
                 class="navbar-toggler border-0 bg-transparent ms-2"
@@ -135,5 +136,6 @@
             >
                 <span class="navbar-toggler-icon"></span>
             </button>
+            {% endif %}
     </div>
 </header>


### PR DESCRIPTION
## Summary
- Render header's burger button only when the user is authenticated

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_688e4a330b388321969279688583a763