### PR TITLE
feat: open user menu as sidebar on mobile

### DIFF
--- a/static/css/_header.css
+++ b/static/css/_header.css
@@ -28,4 +28,27 @@
     .navbar-toggler-icon {
         background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(0,0,0,1)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
     }
+
+    /* Sidebar menu triggered by burger button */
+    #user-menu {
+        position: fixed;
+        top: 0;
+        right: 0;
+        height: 100vh;
+        width: 250px;
+        background: #000;
+        margin-top: 0;
+        border-radius: 0;
+        padding: 70px 20px 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 1050;
+    }
+
+    #user-menu.open {
+        transform: translateX(0);
+    }
 }

--- a/static/js/user-dropdown.js
+++ b/static/js/user-dropdown.js
@@ -7,16 +7,29 @@ document.addEventListener("DOMContentLoaded", function () {
     function toggleMenu(e) {
         e.stopPropagation();
         dropdown.classList.toggle("active");
-        menu.style.display = menu.style.display === "block" ? "none" : "block";
+        if (window.innerWidth <= 991) {
+            menu.classList.toggle("open");
+        } else {
+            menu.style.display =
+                menu.style.display === "block" ? "none" : "block";
+        }
     }
 
-    dropdown.addEventListener("click", toggleMenu);
+    dropdown.addEventListener("click", function (e) {
+        if (window.innerWidth > 991) {
+            toggleMenu(e);
+        }
+    });
     if (burger) burger.addEventListener("click", toggleMenu);
 
     document.addEventListener("click", function (e) {
         if (!dropdown.contains(e.target) && e.target !== burger) {
-            menu.style.display = "none";
+            if (window.innerWidth <= 991) {
+                menu.classList.remove("open");
+            } else {
+                menu.style.display = "none";
+            }
             dropdown.classList.remove("active");
         }
     });
- });
+});


### PR DESCRIPTION
## Summary
- switch burger button to open a right side user menu on mobile
- load same user options in sliding sidebar while keeping avatar visible

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_688e52da88a8832181bbc2dd65ab760c