### PR TITLE
feat: cierre y overlay en menú lateral

### DIFF
--- a/static/css/_header.css
+++ b/static/css/_header.css
@@ -51,4 +51,25 @@
     #user-menu.open {
         transform: translateX(0);
     }
+
+    #sidebar-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100vh;
+        background: rgba(0, 0, 0, 0.5);
+        display: none;
+        z-index: 1040;
+    }
+
+    #sidebar-overlay.show {
+        display: block;
+    }
+
+    #user-menu .menu-close-btn {
+        position: absolute;
+        top: 20px;
+        right: 20px;
+    }
 }

--- a/static/js/user-dropdown.js
+++ b/static/js/user-dropdown.js
@@ -3,12 +3,15 @@ document.addEventListener("DOMContentLoaded", function () {
     if (!dropdown) return;
     const menu = document.getElementById("user-menu");
     const burger = document.getElementById("burger-button");
+    const overlay = document.getElementById("sidebar-overlay");
+    const closeBtn = document.getElementById("menu-close-button");
 
     function toggleMenu(e) {
         e.stopPropagation();
         dropdown.classList.toggle("active");
         if (window.innerWidth <= 991) {
             menu.classList.toggle("open");
+            if (overlay) overlay.classList.toggle("show");
         } else {
             menu.style.display =
                 menu.style.display === "block" ? "none" : "block";
@@ -21,11 +24,25 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     });
     if (burger) burger.addEventListener("click", toggleMenu);
+    if (overlay)
+        overlay.addEventListener("click", function () {
+            menu.classList.remove("open");
+            dropdown.classList.remove("active");
+            overlay.classList.remove("show");
+        });
+    if (closeBtn)
+        closeBtn.addEventListener("click", function (e) {
+            e.stopPropagation();
+            menu.classList.remove("open");
+            dropdown.classList.remove("active");
+            if (overlay) overlay.classList.remove("show");
+        });
 
     document.addEventListener("click", function (e) {
         if (!dropdown.contains(e.target) && e.target !== burger) {
             if (window.innerWidth <= 991) {
                 menu.classList.remove("open");
+                if (overlay) overlay.classList.remove("show");
             } else {
                 menu.style.display = "none";
             }

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -62,6 +62,12 @@
                             {% endif %}
                         </div>
                         <div class="dropdown-menu" id="user-menu">
+                            <button
+                                type="button"
+                                class="btn-close btn-close-white menu-close-btn"
+                                aria-label="Cerrar"
+                                id="menu-close-button"
+                            ></button>
                             <a
                                 href="{% url 'profile' %}"
                                 class="dropdown-item text-light"
@@ -139,3 +145,4 @@
             {% endif %}
     </div>
 </header>
+<div id="sidebar-overlay"></div>


### PR DESCRIPTION
## Summary
- añade botón de cierre en el menú lateral del usuario
- oscurece el contenido principal con un overlay cuando el menú está abierto

## Testing
- `python manage.py test` *(falla: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(falla: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e54885cf08321ae3743b11717e4fe