### PR TITLE
Ajustes responsive en footer para móvil y tablet

### DIFF
--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -10,7 +10,7 @@
     </div>
 
             <!-- Enlaces principales -->
-            <div class="col-md-10 d-flex justify-content-md-end justify-content-center text-center gap-3 flex-md-row flex-column">
+            <div class="col-md-10 d-flex justify-content-md-end justify-content-center text-center gap-2 gap-lg-3 flex-md-row flex-column main-footer-links">
                 <a class="text-dark fw-bold text-decoration-none" href="{% url 'ayuda' %}">Ayuda</a>
                 <a class="text-dark fw-bold text-decoration-none" href="/pro">Pro</a>
                 <a class="text-dark fw-bold text-decoration-none" href="/blog">Blog</a>
@@ -22,18 +22,17 @@
 
         <!-- Enlaces legales y copyright -->
         <div class="row mt-1">
-            <div class="col-md-6  text-md-start text-center order-md-1 order-2">
-                <a href="/" class="d-block d-md-inline small ">
-                     <img src="{% static 'img/logo.svg' %}"  alt="Logo" class="mb-1 d-md-inline d-block " style="width:40px;  "> 
-                     
-                © 2025 ClubsDeBoxeo.com | Todos los derechos reservados
-                </a> 
+            <div class="col-md-6 text-center text-lg-start order-md-1 order-2 d-flex d-lg-block flex-column justify-content-end align-items-center">
+                <a href="/" class="small d-flex d-lg-inline-flex align-items-center justify-content-center justify-content-lg-start gap-1">
+                     <img src="{% static 'img/logo.svg' %}"  alt="Logo" style="width:40px;">
+                     © 2025 ClubsDeBoxeo.com | Todos los derechos reservados
+                </a>
             </div>
 
-            <div class="col-md-6 d-flex text-center justify-content-md-end justify-content-center gap-3 order-md-2 order-1 flex-md-row flex-column small" >
-                <a href="{% url 'terminos' %}" class="text-decoration-none  hover-underline">Términos y Condiciones</a>
-                <a href="{% url 'privacidad' %}" class="text-decoration-none  hover-underline">Política de Privacidad</a>
-                <a href="{% url 'cookies' %}" class="text-decoration-none  hover-underline">Política de Cookies</a>
+            <div class="col-md-6 d-flex flex-row text-center justify-content-md-end justify-content-center gap-3 order-md-2 order-1 aux-footer-links small">
+                <a href="{% url 'terminos' %}" class="text-decoration-none hover-underline">Términos y Condiciones</a>
+                <a href="{% url 'privacidad' %}" class="text-decoration-none hover-underline">Política de Privacidad</a>
+                <a href="{% url 'cookies' %}" class="text-decoration-none hover-underline">Política de Cookies</a>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Reduce spacing between main footer links on small screens
- Align and center copyright block in footer for mobile and tablet
- Display auxiliary footer links horizontally on narrow viewports

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688e5a47cc448321a7fb246259d9f0af