### PR TITLE
Align footer links horizontally on mobile

### DIFF
--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -4,13 +4,13 @@
     <div class="container-fluid px-3 py-3">
 
         <!-- Logo y Enlaces Principales -->
-        <div class="row align-items-center">
+        <div class="row align-items-center mb-3">
             <div class="col-md-2 text-md-start text-center mb-2 mb-md-0">
         
     </div>
 
             <!-- Enlaces principales -->
-            <div class="col-md-10 d-flex justify-content-md-end justify-content-center text-center gap-2 gap-lg-3 flex-md-row flex-column main-footer-links">
+            <div class="col-md-10 d-flex justify-content-md-end justify-content-center text-center gap-2 gap-lg-3 flex-row main-footer-links">
                 <a class="text-dark fw-bold text-decoration-none" href="{% url 'ayuda' %}">Ayuda</a>
                 <a class="text-dark fw-bold text-decoration-none" href="/pro">Pro</a>
                 <a class="text-dark fw-bold text-decoration-none" href="/blog">Blog</a>
@@ -25,7 +25,7 @@
             <div class="col-md-6 text-center text-lg-start order-md-1 order-2 d-flex d-lg-block flex-column justify-content-end align-items-center">
                 <a href="/" class="small d-flex d-lg-inline-flex align-items-center justify-content-center justify-content-lg-start gap-1">
                      <img src="{% static 'img/logo.svg' %}"  alt="Logo" style="width:40px;">
-                     © 2025 ClubsDeBoxeo.com | Todos los derechos reservados
+                     © 2025 ClubsDeBoxeo.com
                 </a>
             </div>
 


### PR DESCRIPTION
## Summary
- Display footer links in a horizontal row on small screens
- Remove copyright notice text
- Add spacing beneath main footer links

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: 403 Client Error)*

------
https://chatgpt.com/codex/tasks/task_e_688e5d2ac3848321a2d475d87fdeb5cf