### PR TITLE
Add margin for aux footer links on small screens

### DIFF
--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -30,9 +30,9 @@
             </div>
 
             <div class="col-md-6 d-flex flex-row text-center justify-content-md-end justify-content-center gap-3 order-md-2 order-1 aux-footer-links small">
-                <a href="{% url 'terminos' %}" class="text-decoration-none hover-underline">Términos y Condiciones</a>
-                <a href="{% url 'privacidad' %}" class="text-decoration-none hover-underline">Política de Privacidad</a>
-                <a href="{% url 'cookies' %}" class="text-decoration-none hover-underline">Política de Cookies</a>
+                <a href="{% url 'terminos' %}" class="text-decoration-none hover-underline mb-1 mb-lg-0">Términos y Condiciones</a>
+                <a href="{% url 'privacidad' %}" class="text-decoration-none hover-underline mb-1 mb-lg-0">Política de Privacidad</a>
+                <a href="{% url 'cookies' %}" class="text-decoration-none hover-underline mb-1 mb-lg-0">Política de Cookies</a>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add responsive bottom margin to auxiliary footer links for mobile and tablet sizes

## Testing
- `python manage.py test` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688f21cd7be483219fc66e570255fd4a