### PR TITLE
Rename footer pro link to Planes PRO

### DIFF
--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -12,7 +12,7 @@
             <!-- Enlaces principales -->
             <div class="col-md-10 d-flex justify-content-md-end justify-content-center text-center gap-2 gap-lg-3 flex-row main-footer-links">
                 <a class="text-dark fw-bold text-decoration-none" href="{% url 'ayuda' %}">Ayuda</a>
-                <a class="text-dark fw-bold text-decoration-none" href="/pro">Pro</a>
+                <a class="text-dark fw-bold text-decoration-none" href="/pro">Planes PRO</a>
                 <a class="text-dark fw-bold text-decoration-none" href="/blog">Blog</a>
                 <a class="text-dark fw-bold text-decoration-none d-flex justify-content-center " href="#">
                     <img src="{% static 'img/instagram-icon.svg' %}" alt="Instagram">


### PR DESCRIPTION
## Summary
- Rename footer link text from Pro to Planes PRO

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests; 403 proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_688f24b4f3888321b897abd0359b7d4c