### PR TITLE
Remove close button from avatar sidebar dropdown

### DIFF
--- a/static/css/_header.css
+++ b/static/css/_header.css
@@ -67,9 +67,4 @@
         display: block;
     }
 
-    #user-menu .menu-close-btn {
-        position: absolute;
-        top: 20px;
-        right: 20px;
-    }
 }

--- a/static/js/user-dropdown.js
+++ b/static/js/user-dropdown.js
@@ -4,7 +4,6 @@ document.addEventListener("DOMContentLoaded", function () {
     const menu = document.getElementById("user-menu");
     const burger = document.getElementById("burger-button");
     const overlay = document.getElementById("sidebar-overlay");
-    const closeBtn = document.getElementById("menu-close-button");
 
     function toggleMenu(e) {
         e.stopPropagation();
@@ -29,13 +28,6 @@ document.addEventListener("DOMContentLoaded", function () {
             menu.classList.remove("open");
             dropdown.classList.remove("active");
             overlay.classList.remove("show");
-        });
-    if (closeBtn)
-        closeBtn.addEventListener("click", function (e) {
-            e.stopPropagation();
-            menu.classList.remove("open");
-            dropdown.classList.remove("active");
-            if (overlay) overlay.classList.remove("show");
         });
 
     document.addEventListener("click", function (e) {

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -62,12 +62,6 @@
                             {% endif %}
                         </div>
                         <div class="dropdown-menu" id="user-menu">
-                            <button
-                                type="button"
-                                class="btn-close btn-close-white menu-close-btn"
-                                aria-label="Cerrar"
-                                id="menu-close-button"
-                            ></button>
                             <a
                                 href="{% url 'profile' %}"
                                 class="dropdown-item text-light"


### PR DESCRIPTION
## Summary
- remove X close button from header avatar dropdown
- delete related styles and scripts

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_688f4b3041b4832191c9c8f342a89d3a