### PR TITLE
Add close button to sidebar on mobile

### DIFF
--- a/static/js/user-dropdown.js
+++ b/static/js/user-dropdown.js
@@ -4,6 +4,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const menu = document.getElementById("user-menu");
     const burger = document.getElementById("burger-button");
     const overlay = document.getElementById("sidebar-overlay");
+    const closeBtn = document.getElementById("sidebar-close");
 
     function toggleMenu(e) {
         e.stopPropagation();
@@ -28,6 +29,12 @@ document.addEventListener("DOMContentLoaded", function () {
             menu.classList.remove("open");
             dropdown.classList.remove("active");
             overlay.classList.remove("show");
+        });
+    if (closeBtn)
+        closeBtn.addEventListener("click", function () {
+            menu.classList.remove("open");
+            dropdown.classList.remove("active");
+            if (overlay) overlay.classList.remove("show");
         });
 
     document.addEventListener("click", function (e) {

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -62,6 +62,14 @@
                             {% endif %}
                         </div>
                         <div class="dropdown-menu" id="user-menu">
+                            <button
+                                type="button"
+                                id="sidebar-close"
+                                class="position-absolute top-0 end-0 m-3 d-lg-none text-white bg-transparent border-0 fs-4"
+                                aria-label="Cerrar"
+                            >
+                                &times;
+                            </button>
                             <a
                                 href="{% url 'profile' %}"
                                 class="dropdown-item text-light"


### PR DESCRIPTION
## Summary
- add dedicated close button to mobile sidebar
- wire close button into existing sidebar script

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_688f4c5725308321b8ba794a4d95a85e