### PR TITLE
Display plan-colored badges in search results

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -86,6 +86,33 @@ class SearchResultsTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["clubs"]), 1)
 
+    def test_plan_badge_renders_for_each_plan(self):
+        """Clubs should display a plan-colored badge on search results."""
+        Club.objects.create(
+            name="Gold Club",
+            city="NY",
+            address="addr",
+            phone="123",
+            email="gold@example.com",
+            plan="oro",
+        )
+        Club.objects.create(
+            name="Silver Club",
+            city="NY",
+            address="addr",
+            phone="123",
+            email="silver@example.com",
+            plan="plata",
+        )
+
+        url = reverse("search_results")
+        response = self.client.get(url, {"q": "Club"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "badge-verified-gold")
+        self.assertContains(response, "badge-verified-silver")
+        self.assertContains(response, "badge-verified-bronze")
+
 class ClubPhotoResizeTests(TestCase):
     def test_photo_resized_on_save(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/templates/clubs/search_results.html
+++ b/templates/clubs/search_results.html
@@ -44,12 +44,15 @@
                         <div class="d-flex flex-column justify-content-start"  >
                             <div class="d-flex align-items-center   ">
                                 <span class="badge bg-secondary">{{ club.get_category_display }}</span>
-                                {% if club.verified %}
-                                <span class="ms-2" title="Verificado">
-                                    <svg  style="width:20px;"data-name="Layer 1" id="Layer_1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title/><path d="M22.41,10.59,20.36,8.54V5.63a2,2,0,0,0-2-2H15.46l-2.05-2a2,2,0,0,0-2.82,0L8.54,3.64H5.63a2,2,0,0,0-2,2V8.54l-2,2.05A2,2,0,0,0,1,12a2,2,0,0,0,.58,1.41l2.06,2.05v2.91a2,2,0,0,0,2,2H8.54l2.05,2.05A2,2,0,0,0,12,23a2,2,0,0,0,1.41-.58l2.05-2.06h2.91a2,2,0,0,0,2-2V15.46l2.05-2.05a2,2,0,0,0,0-2.82Zm-4.05,4.05v3.72H14.64L12,21,9.36,18.36H5.64V14.64L3,12,5.64,9.36V5.64H9.36L12,3l2.64,2.64h3.72V9.36L21,12Z"/><polygon points="11 12.73 8.71 10.44 7.29 11.85 11 15.56 16.71 9.85 15.29 8.44 11 12.73"/></svg>
-
+                                <span class="ms-2">
+                                    {% if club.plan == 'oro' %}
+                                        {% include 'partials/_verified-gold.html' %}
+                                    {% elif club.plan == 'plata' %}
+                                        {% include 'partials/_verified-silver.html' %}
+                                    {% else %}
+                                        {% include 'partials/_verified-bronze.html' %}
+                                    {% endif %}
                                 </span>
-                                {% endif %}
                             </div>  
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- show a colored verification badge for each club in search results based on its plan
- test that gold, silver and bronze plan badges appear in search results

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688f4eb111bc8321a35a9b302278d59a