### PR TITLE
Center club info links on mobile

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -35,12 +35,12 @@
             {% endif %}
             </div>
 
-                <div class="p-2 d-flex align-items-start mt-2 mb-4 gap-3 ">
-                    <ul class="p-0 club-info-links">
-                        <div class="d-flex align-items-start mb-1">
+                <div class="p-2 d-flex align-items-start justify-content-center justify-content-lg-start mt-2 mb-4 gap-3">
+                    <ul class="p-0 club-info-links d-flex flex-column align-items-center align-items-lg-start text-center text-lg-start mx-auto mx-lg-0">
+                        <div class="d-flex justify-content-center justify-content-lg-start mb-1">
                             <span class="badge  fw-medium">{{ club.get_category_display }}</span>
                          </div>
-                        <h1 class="mb-2" style="font-size:24px !important; font-weight:900;">
+                        <h1 class="mb-2 text-center text-lg-start" style="font-size:24px !important; font-weight:900;">
 
                             {{ club.name }}
                             {% if club.plan == 'oro' %}
@@ -52,10 +52,10 @@
                             {% endif %}
                         </h1>
 
-                        <li class="club-actions d-flex flex-column align-items-start gap-2 mb-4">
+                        <li class="club-actions d-flex flex-column align-items-center align-items-lg-start gap-2 mb-4">
 
 
-                            <button type="button" class=" signup-member-btn fw-medium d-flex align-items-center gap-1 mb-1  " data-club-slug="{{ club.slug }}">
+                            <button type="button" class="signup-member-btn fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1" data-club-slug="{{ club.slug }}">
                                 <svg class="w-[48px] h-[48px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="none" viewBox="0 0 24 24">
                                   <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 12h4m-2 2v-4M4 18v-1a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3v1a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1Zm8-10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
                                 </svg>
@@ -64,7 +64,7 @@
 
                             <button
                                 type="button"
-                                class="fw-medium d-flex align-items-center gap-1 mb-1"
+                                class="fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1"
                                 onclick="window.open('https://www.google.com/maps/search/?api=1&query={{ club.address|urlencode }}', '_blank')"
                             >
 
@@ -77,7 +77,7 @@
 
                             <button type="button"
                                     onclick="location.href='{% url 'conversation' %}?club={{ club.slug }}'"
-                                    class="fw-medium d-flex align-items-center gap-1 mb-1">
+                                    class="fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1">
                                 <svg class="w-6 h-6 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="none" viewBox="0 0 24 24">
                                   <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 10.5h.01m-4.01 0h.01M8 10.5h.01M5 5h14a1 1 0 0 1 1 1v9a1 1 0 0 1-1 1h-6.6a1 1 0 0 0-.69.275l-2.866 2.723A.5.5 0 0 1 8 18.635V17a1 1 0 0 0-1-1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Z"/>
                                 </svg>
@@ -86,7 +86,7 @@
                             <button id="club-heart"
                                     aria-label="Seguir"
                                     data-url="{% url 'toggle_follow' 'club' club.id %}"
-                                    class="fw-medium {% if club_followed %}liked{% endif %} d-flex align-items-center gap-1 mb-1">
+                                    class="fw-medium {% if club_followed %}liked{% endif %} d-flex flex-column flex-lg-row align-items-center gap-1 mb-1">
                                 <svg aria-hidden="true"
                                      xmlns="http://www.w3.org/2000/svg"
                                      width="26"
@@ -97,7 +97,7 @@
                                 </svg>
                                 Añadir a favoritos
                             </button>
-                            <button class="fw-medium d-flex align-items-center gap-1 mb-1" id="club-share" aria-label="Compartir">
+                            <button class="fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1" id="club-share" aria-label="Compartir">
                                 <svg aria-hidden="true"
                                      xmlns="http://www.w3.org/2000/svg"
                                      width="26"


### PR DESCRIPTION
## Summary
- center club info links and club name on small screens
- stack action button icons above labels on mobile/tablet

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_688f513d50d48321af5a25e45ca818bc