### PR TITLE
Align club info buttons and footer links

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -52,7 +52,7 @@
                             {% endif %}
                         </h1>
 
-                        <li class="club-actions d-flex flex-column align-items-center align-items-lg-start gap-2 mb-4">
+                        <li class="club-actions d-flex flex-row flex-lg-column flex-wrap justify-content-center align-items-center align-items-lg-start gap-2 mb-4">
 
 
                             <button type="button" class="signup-member-btn fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1" data-club-slug="{{ club.slug }}">

--- a/templates/partials/_footer.html
+++ b/templates/partials/_footer.html
@@ -21,7 +21,7 @@
         </div>
 
         <!-- Enlaces legales y copyright -->
-        <div class="row mt-1">
+        <div class="row mt-1 align-items-center">
             <div class="col-md-6 text-center text-lg-start order-md-1 order-2 d-flex d-lg-block flex-column justify-content-end align-items-center">
                 <a href="/" class="small d-flex d-lg-inline-flex align-items-center justify-content-center justify-content-lg-start gap-1">
                      <img src="{% static 'img/logo.svg' %}"  alt="Logo" style="width:40px;">
@@ -29,7 +29,7 @@
                 </a>
             </div>
 
-            <div class="col-md-6 d-flex flex-row text-center justify-content-md-end justify-content-center gap-3 order-md-2 order-1 aux-footer-links small">
+            <div class="col-md-6 d-flex flex-row text-center justify-content-md-end justify-content-center gap-3 order-md-2 order-1 aux-footer-links small align-items-center">
                 <a href="{% url 'terminos' %}" class="text-decoration-none hover-underline mb-1 mb-lg-0">Términos y Condiciones</a>
                 <a href="{% url 'privacidad' %}" class="text-decoration-none hover-underline mb-1 mb-lg-0">Política de Privacidad</a>
                 <a href="{% url 'cookies' %}" class="text-decoration-none hover-underline mb-1 mb-lg-0">Política de Cookies</a>


### PR DESCRIPTION
## Summary
- lay out club info action buttons horizontally on small screens
- vertically center footer auxiliary links with the logo

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688f53723b448321aaf08a71689e7765