### PR TITLE
Ensure mobile club actions align horizontally

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -451,7 +451,19 @@
  }
 
 
- .review-filter-dropdown .selected-text {
-       display: inline-flex;
-       align-items: center;
+.review-filter-dropdown .selected-text {
+      display: inline-flex;
+      align-items: center;
  }
+
+@media (max-width: 991.98px) {
+      .club-actions {
+            flex-wrap: nowrap !important;
+      }
+
+      .club-actions button {
+            white-space: normal;
+            word-break: break-word;
+            text-align: center;
+      }
+}


### PR DESCRIPTION
## Summary
- Prevent mobile club profile action buttons from wrapping onto multiple rows
- Allow long button text to wrap within each button

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688f57dbf9288321bb30b2ce445770a0