### PR TITLE
Renombrar etiquetas de perfil y mensajes

### DIFF
--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -6,7 +6,7 @@
 <div class="container my-4">
   <div class="row">
     <div class="col-md-4 mb-3">
-      <h5 class="mb-3">Mensajes</h5>
+      <h5 class="mb-3">Mis mensajes</h5>
       <div class="list-group">
         {% for conv in conversations %}
           {% if user == conv.club.owner %}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -2,7 +2,7 @@
 
 <div class="d-flex mt-5 mb-5 container-fluid col-12">
   <div class="profile-tabs">
-    <div class="profile-tab active" data-target="tab-profile">Mi perfil</div>
+    <div class="profile-tab active" data-target="tab-profile">Mi Cuenta</div>
     <div class="profile-tab" data-target="tab-gallery">Galería</div>
     <div class="profile-tab" data-target="tab-schedule">Horarios</div>
     <div class="profile-tab" data-target="tab-clase">Servicios</div>
@@ -14,7 +14,7 @@
   </div>
   <div class="profile-content">
     <div id="tab-profile" class="profile-section active">
-      <h1 class="h3 mb-4">Administrar {{ club.name }}</h1>
+      <h1 class="h3 mb-4">Panel de control de {{ club.name }}</h1>
       <form
         method="post"
         action="{% url 'club_edit' club.slug %}"
@@ -336,7 +336,7 @@
     </div>
 
     <div id="tab-clase" class="profile-section">
-            <h5 class="mt-4">Administrar clases</h5>
+            <h5 class="mt-4">Panel de control de clases</h5>
       <div class="mb-2">
         <button
           type="button"
@@ -607,7 +607,7 @@
       </div>
 
            <div id="availability-manager" class="mb-4" data-club-slug="{{ club.slug }}">
-        <h5 class="mb-3">Administrar disponibilidad</h5>
+        <h5 class="mb-3">Panel de control de disponibilidad</h5>
         <div id="schedule-manager" class="mb-3">
           <!-- Removed legacy day and time pickers -->
           {{ horarios_json|json_script:"schedule-data" }}

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -73,19 +73,19 @@
                             <a
                                 href="{% url 'profile' %}"
                                 class="dropdown-item text-light"
-                                >Mi perfil</a
+                                >Mi Cuenta</a
                             >
                             {% if user.owned_clubs.exists %}
                             <a
                                 href="{% url 'club_dashboard' user.owned_clubs.first.slug %}"
                                 class="dropdown-item text-light"
-                                >Administrar</a
+                                >Panel de control</a
                             >
                             {% endif %}
                             <a
                                 href="{% url 'conversation' %}"
                                 class="dropdown-item text-light"
-                                >Mensajes</a
+                                >Mis mensajes</a
                             >
                             <a
                                 href="#"

--- a/templates/partials/_messages_modal.html
+++ b/templates/partials/_messages_modal.html
@@ -3,7 +3,7 @@
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Mensajes</h5>
+        <h5 class="modal-title">Mis mensajes</h5>
         <button
           type="button"
           class="btn-close"


### PR DESCRIPTION
## Summary
- Actualiza el menú de usuario para mostrar "Mi Cuenta", "Panel de control" y "Mis mensajes".
- Cambia etiquetas del dashboard del club para usar "Mi Cuenta" y "Panel de control".
- Ajusta títulos de mensajes en modal y página de conversaciones a "Mis mensajes".

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f7d3e015c8321ae0d12327a9a18fc