### PR TITLE
feat: square club logo dropzone

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -187,6 +187,16 @@
   display: none;
 }
 
+/* Square variant for club logos */
+.avatar-dropzone.avatar-dropzone-square {
+  width: 200px;
+  height: 200px;
+}
+
+.avatar-dropzone.avatar-dropzone-square .avatar-preview {
+  border-radius: 0;
+}
+
 /* Gallery styles */
 .gallery-grid {
   display: grid;

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -25,7 +25,7 @@
       >
         {% csrf_token %}
         <div class="mb-5 text-center">
-          <div class="avatar-dropzone mx-auto">
+          <div class="avatar-dropzone avatar-dropzone-square mx-auto">
             {{ form.logo }}
             <div
               class="avatar-preview{% if club.logo|safe_url %} has-image{% endif %}"


### PR DESCRIPTION
## Summary
- make club logo dropzone square at 200x200
- reuse avatar dropzone script with square preview

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688fba0edc8483219f9318d76eb40705