### PR TITLE
Add dropdown for Spanish regions when country is Spain

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from .models import Reseña
 from . import models
 from .countries import COUNTRY_CHOICES
+from .regions import SPAIN_REGION_CHOICES
 from django.contrib.auth.forms import AuthenticationForm
 
 class LoginForm(AuthenticationForm):
@@ -192,6 +193,17 @@ class ClubForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        country_value = (
+            self.data.get('country')
+            or self.initial.get('country')
+            or getattr(getattr(self, 'instance', None), 'country', None)
+        )
+        if country_value == 'España':
+            self.fields['region'] = forms.ChoiceField(
+                choices=SPAIN_REGION_CHOICES,
+                required=False,
+                label=self.fields['region'].label,
+            )
         for name, field in self.fields.items():
             css = field.widget.attrs.get('class', '')
             field.widget.attrs['class'] = (css + ' form-control').strip()
@@ -201,7 +213,7 @@ class ClubForm(forms.ModelForm):
                                         forms.DateInput, forms.TimeInput)):
                 field.widget.attrs.setdefault('placeholder', ' ')
 
-                  # hide logo input to use dropzone preview
+        # hide logo input to use dropzone preview
         logo_widget = self.fields.get('logo')
         if logo_widget:
             css = logo_widget.widget.attrs.get('class', '')

--- a/apps/clubs/regions.py
+++ b/apps/clubs/regions.py
@@ -1,0 +1,20 @@
+# List of autonomous communities in Spain for region dropdown.
+SPAIN_REGION_CHOICES = [
+    ("Andalucía", "Andalucía"),
+    ("Aragón", "Aragón"),
+    ("Asturias", "Asturias"),
+    ("Islas Baleares", "Islas Baleares"),
+    ("Canarias", "Canarias"),
+    ("Cantabria", "Cantabria"),
+    ("Castilla-La Mancha", "Castilla-La Mancha"),
+    ("Castilla y León", "Castilla y León"),
+    ("Cataluña", "Cataluña"),
+    ("Comunidad Valenciana", "Comunidad Valenciana"),
+    ("Extremadura", "Extremadura"),
+    ("Galicia", "Galicia"),
+    ("La Rioja", "La Rioja"),
+    ("Comunidad de Madrid", "Comunidad de Madrid"),
+    ("Región de Murcia", "Región de Murcia"),
+    ("Navarra", "Navarra"),
+    ("País Vasco", "País Vasco"),
+]

--- a/static/js/region-select.js
+++ b/static/js/region-select.js
@@ -1,0 +1,89 @@
+const SPANISH_REGIONS = [
+  "Andalucía",
+  "Aragón",
+  "Asturias",
+  "Islas Baleares",
+  "Canarias",
+  "Cantabria",
+  "Castilla-La Mancha",
+  "Castilla y León",
+  "Cataluña",
+  "Comunidad Valenciana",
+  "Extremadura",
+  "Galicia",
+  "La Rioja",
+  "Comunidad de Madrid",
+  "Región de Murcia",
+  "Navarra",
+  "País Vasco",
+];
+
+function initRegionSelect() {
+  const country = document.getElementById('id_country');
+  const regionFieldWrapper = document.getElementById('id_region')?.closest('.form-field');
+  if (!country || !regionFieldWrapper) return;
+
+  const buildSelect = (value = '') => {
+    const select = document.createElement('select');
+    select.name = 'region';
+    select.id = 'id_region';
+    select.className = 'form-control';
+    const empty = document.createElement('option');
+    empty.value = '';
+    select.appendChild(empty);
+    SPANISH_REGIONS.forEach((r) => {
+      const opt = document.createElement('option');
+      opt.value = r;
+      opt.textContent = r;
+      select.appendChild(opt);
+    });
+    select.value = value;
+    return select;
+  };
+
+  const buildInput = (value = '') => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.name = 'region';
+    input.id = 'id_region';
+    input.className = 'form-control';
+    input.value = value;
+    return input;
+  };
+
+  const updateField = () => {
+    let current = regionFieldWrapper.querySelector('#id_region');
+    const clearBtn = regionFieldWrapper.querySelector('.clear-btn');
+    if (country.value === 'España') {
+      if (current.tagName.toLowerCase() !== 'select') {
+        const select = buildSelect(current.value);
+        current.replaceWith(select);
+        if (clearBtn) clearBtn.style.display = 'none';
+        if (window.initSelectLabels) window.initSelectLabels(regionFieldWrapper);
+      }
+    } else {
+      if (current.tagName.toLowerCase() !== 'input') {
+        const input = buildInput('');
+        current.replaceWith(input);
+        if (clearBtn) {
+          clearBtn.style.display = '';
+          clearBtn.onclick = () => {
+            input.value = '';
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            clearBtn.style.display = 'none';
+            input.focus();
+          };
+          input.addEventListener('input', () => {
+            clearBtn.style.display = input.value ? 'block' : 'none';
+          });
+          clearBtn.style.display = input.value ? 'block' : 'none';
+        }
+      }
+    }
+  };
+
+  country.addEventListener('change', updateField);
+  updateField();
+}
+
+document.addEventListener('DOMContentLoaded', initRegionSelect);

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1580,4 +1580,5 @@
 <script src="{% static 'js/booking-filter.js' %}"></script>
 <script src="{% static 'js/availability-manager.js' %}"></script>
 <script src="{% static 'js/schedule-manager.js' %}"></script>
+<script src="{% static 'js/region-select.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add list of Spanish autonomous communities
- show dropdown for regions when selected country is Spain
- include frontend script to switch region field based on country

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688fc8f730688321b707d58642de9c83