### PR TITLE
Add credit card payment form for plan selection

### DIFF
--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const tipoRadios = document.querySelectorAll('input[name="tipo"]');
   const tipoCards = document.querySelectorAll('.tipo-card');
   const planCards = document.querySelectorAll('.plan-card');
+  const paymentSection = document.getElementById('payment-section');
 
   function showStep(n) {
     steps.forEach((step, idx) => {
@@ -69,8 +70,20 @@ document.addEventListener('DOMContentLoaded', () => {
     card.addEventListener('click', () => {
       input.checked = true;
       planCards.forEach(c => c.classList.toggle('active', c === card));
+      togglePaymentSection();
     });
   });
+
+  function togglePaymentSection() {
+    const selected = document.querySelector('input[name="plan"]:checked');
+    if (selected && (selected.value === 'plata' || selected.value === 'oro')) {
+      paymentSection && paymentSection.classList.remove('d-none');
+    } else {
+      paymentSection && paymentSection.classList.add('d-none');
+    }
+  }
+
+  togglePaymentSection();
 
   toggleTipoFields();
 

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -74,6 +74,30 @@
                 <div class="plan-card-price">19€ / mes</div>
             </label>
         </div>
+        <div id="payment-section" class="mt-4 d-none">
+            <h3 class="h6 mb-3">Datos de pago</h3>
+            <div class="form-field">
+                <input type="text" name="card_number" id="id_card_number" placeholder=" ">
+                <button type="button" class="clear-btn">×</button>
+                <label for="id_card_number">Número de tarjeta</label>
+            </div>
+            <div class="row">
+                <div class="col">
+                    <div class="form-field">
+                        <input type="text" name="card_expiry" id="id_card_expiry" placeholder="MM/AA">
+                        <button type="button" class="clear-btn">×</button>
+                        <label for="id_card_expiry">Expiración</label>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="form-field">
+                        <input type="text" name="card_cvc" id="id_card_cvc" placeholder=" ">
+                        <button type="button" class="clear-btn">×</button>
+                        <label for="id_card_cvc">CVC</label>
+                    </div>
+                </div>
+            </div>
+        </div>
             {% if form.plan.errors %}
             <div class="invalid-feedback d-block">{{ form.plan.errors.as_text|striptags }}</div>
             {% endif %}


### PR DESCRIPTION
## Summary
- add credit card fields to professional registration plan step
- toggle payment section visibility based on selected plan

## Testing
- `python manage.py test` *(no tests found)*
- `PYTHONPATH=/workspace/directorio DJANGO_SETTINGS_MODULE=config.settings.dev pytest` *(errors: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_688fcaec313c83219a83d132da3bc551