### PR TITLE
Eliminar labels en avatar-dropzone y agregar botón para borrar imagen

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -186,6 +186,21 @@
 .avatar-dropzone .avatar-preview.has-image .avatar-dropzone-msg {
   display: none;
 }
+.avatar-dropzone .avatar-remove-btn {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 30px;
+  height: 30px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  cursor: pointer;
+}
 
 /* Square variant for club logos */
 .avatar-dropzone.avatar-dropzone-square {

--- a/static/js/avatar-dropzone.js
+++ b/static/js/avatar-dropzone.js
@@ -4,6 +4,11 @@ function initAvatarDropzones(root = document) {
     const input = zone.querySelector('input[type="file"]');
     const preview = zone.querySelector('.avatar-preview');
     const msg = preview.querySelector('.avatar-dropzone-msg');
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'avatar-remove-btn';
+    removeBtn.innerHTML = '<i class="bi bi-trash"></i>';
+    zone.appendChild(removeBtn);
     if (!input || !preview) return;
 
     const showFile = file => {
@@ -13,8 +18,26 @@ function initAvatarDropzones(root = document) {
         preview.style.backgroundImage = `url('${e.target.result}')`;
         preview.classList.add('has-image');
         if (msg) msg.style.display = 'none';
+        updateState();
       };
       reader.readAsDataURL(file);
+    };
+
+    const clearFile = () => {
+      input.value = '';
+      preview.style.backgroundImage = '';
+      preview.classList.remove('has-image');
+      if (msg) msg.style.display = '';
+      updateState();
+    };
+
+    removeBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      clearFile();
+    });
+
+    const updateState = () => {
+      removeBtn.style.display = preview.classList.contains('has-image') ? 'flex' : 'none';
     };
 
     zone.addEventListener('click', () => input.click());
@@ -44,6 +67,7 @@ function initAvatarDropzones(root = document) {
       }
     });
 
+    updateState();
     zone.dataset.initialized = 'true';
   });
 }

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -39,9 +39,6 @@
               </div>
             </div>
           </div>
-          <label class="form-label mt-2" for="{{ form.logo.id_for_label }}">
-            {{ form.logo.label }}
-          </label>
           {% if form.logo.errors %}
           <div class="invalid-feedback d-block">
             {{ form.logo.errors.as_text|striptags }}

--- a/templates/clubs/entrenador_form.html
+++ b/templates/clubs/entrenador_form.html
@@ -16,7 +16,6 @@
           </div>
         </div>
       </div>
-      <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
       {% if form.avatar.errors %}
       <div class="invalid-feedback d-block">
         {{ form.avatar.errors.as_text|striptags }}

--- a/templates/clubs/miembro_form.html
+++ b/templates/clubs/miembro_form.html
@@ -16,7 +16,6 @@
           </div>
         </div>
       </div>
-      <label for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
       {% if form.avatar.errors %}
       <div class="invalid-feedback d-block">
         {{ form.avatar.errors.as_text|striptags }}

--- a/templates/core/_profile_fields.html
+++ b/templates/core/_profile_fields.html
@@ -10,7 +10,6 @@
         </div>
       </div>
     </div>
-    <label for="{{ field.id_for_label }}">{{ field.label }}</label>
     {% if field.errors %}
     <div class="invalid-feedback d-block">{{ field.errors.as_text|striptags }}</div>
     {% endif %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -32,7 +32,6 @@
                             </div>
                         </div>
                     </div>
-                    <label class="form-label mt-2" for="{{ form.avatar.id_for_label }}">{{ form.avatar.label }}</label>
                     {% if form.avatar.errors %}
                     <div class="invalid-feedback d-block">
                         {{ form.avatar.errors.as_text|striptags }}


### PR DESCRIPTION
## Summary
- Oculta los labels y nombres de archivo en los avatar-dropzone
- Añade botón con icono de basura para eliminar la imagen subida y actualizar la vista previa

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68906d6ad44083219a839c13b1b2fc1d