### PR TITLE
Preserve dropzone layout after image upload

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -184,7 +184,7 @@
   color: transparent;
 }
 .avatar-dropzone .avatar-preview.has-image .avatar-dropzone-msg {
-  display: none;
+  visibility: hidden;
 }
 .avatar-dropzone .avatar-remove-btn {
   position: absolute;

--- a/static/js/avatar-dropzone.js
+++ b/static/js/avatar-dropzone.js
@@ -17,7 +17,7 @@ function initAvatarDropzones(root = document) {
       reader.onload = e => {
         preview.style.backgroundImage = `url('${e.target.result}')`;
         preview.classList.add('has-image');
-        if (msg) msg.style.display = 'none';
+        if (msg) msg.style.visibility = 'hidden';
         updateState();
       };
       reader.readAsDataURL(file);
@@ -27,7 +27,7 @@ function initAvatarDropzones(root = document) {
       input.value = '';
       preview.style.backgroundImage = '';
       preview.classList.remove('has-image');
-      if (msg) msg.style.display = '';
+      if (msg) msg.style.visibility = '';
       updateState();
     };
 


### PR DESCRIPTION
## Summary
- hide dropzone hint using visibility to keep layout unchanged
- keep avatar message element in DOM to preserve margins after upload

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890991e4a208321be156358de4a9161