### PR TITLE
Fix profile avatar saving

### DIFF
--- a/apps/users/tests/test_profile_avatar_persistence.py
+++ b/apps/users/tests/test_profile_avatar_persistence.py
@@ -1,0 +1,38 @@
+import io
+import tempfile
+from PIL import Image
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+class ProfileAvatarPersistenceTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="avataruser", password="pass")
+
+    @override_settings(ALLOWED_HOSTS=["testserver"])
+    def test_avatar_saved_and_header_updated(self):
+        self.client.login(username="avataruser", password="pass")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(MEDIA_ROOT=tmpdir):
+                img = Image.new("RGB", (50, 50), "white")
+                buf = io.BytesIO()
+                img.save(buf, format="JPEG")
+                buf.seek(0)
+                upload = SimpleUploadedFile("avatar.jpg", buf.getvalue(), content_type="image/jpeg")
+                response = self.client.post(
+                    reverse("profile"),
+                    {
+                        "username": "avataruser",
+                        "email": "",
+                        "new_password1": "",
+                        "new_password2": "",
+                        "notifications": "on",
+                        "avatar": upload,
+                    },
+                    follow=True,
+                )
+                self.user.refresh_from_db()
+                self.assertEqual(response.status_code, 200)
+                self.assertTrue(self.user.profile.avatar.name)
+                self.assertContains(response, self.user.profile.avatar.url)

--- a/apps/users/views/profile.py
+++ b/apps/users/views/profile.py
@@ -31,7 +31,9 @@ def profile(request):
             form = AccountForm(request.POST, request.FILES, instance=profile_obj, user=request.user)
             plan_form = PlanForm(initial={'plan': profile_obj.plan})
             if form.is_valid():
-                form.save()
+                profile_obj = form.save()
+                # Refresh the related user profile to ensure updated avatar is used
+                request.user.profile.refresh_from_db()
                 messages.success(request, 'Perfil actualizado exitosamente.')
                 return redirect('profile')
             else:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.base')
+django.setup()
+
+from django.conf import settings
+settings.ALLOWED_HOSTS.append('testserver')

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -64,15 +64,12 @@
                 </div>
 
                 <div class="d-flex gap-3 mb-4">
-              <button type="submit" class="btn btn-dark">Guardar cambios</button>
-
-              <form action="{% url 'delete_account' %}" method="post">
-                  {% csrf_token %}
-                  <button type="submit" class="btn btn-danger">Eliminar cuenta</button>
-              </form>
-          </div>
-
-
+                    <button type="submit" class="btn btn-dark">Guardar cambios</button>
+                    <button type="submit" class="btn btn-danger" form="delete-account-form">Eliminar cuenta</button>
+                </div>
+            </form>
+            <form id="delete-account-form" action="{% url 'delete_account' %}" method="post" class="d-none">
+                {% csrf_token %}
             </form>
         </div>
         {% if is_owner %}


### PR DESCRIPTION
## Summary
- refresh user profile after saving to update avatar
- prevent nested forms in profile template and add dedicated delete account form
- add regression test ensuring avatar updates and appears in header

## Testing
- `PYTHONPATH=/workspace/directorio pytest apps/users/tests/test_profile_avatar_persistence.py -q`
- `PYTHONPATH=/workspace/directorio pytest -q --maxfail=1` *(fails: django.db.utils.IntegrityError: UNIQUE constraint failed: users_profile.user_id)*

------
https://chatgpt.com/codex/tasks/task_e_6890b052e47c8321b0e2eb9f9348c424