### PR TITLE
Add regression test for header avatar

### DIFF
--- a/apps/users/tests/test_profile_avatar_persistence.py
+++ b/apps/users/tests/test_profile_avatar_persistence.py
@@ -36,3 +36,11 @@ class ProfileAvatarPersistenceTests(TestCase):
                 self.assertEqual(response.status_code, 200)
                 self.assertTrue(self.user.profile.avatar.name)
                 self.assertContains(response, self.user.profile.avatar.url)
+
+                # nav avatar in header should display the uploaded image
+                html = response.content.decode()
+                expected_img = (
+                    f'<img src="{self.user.profile.avatar.url}" '
+                    f'alt="{self.user.username}" class="nav-avatar-img">'
+                )
+                self.assertInHTML(expected_img, html)


### PR DESCRIPTION
## Summary
- ensure uploaded profile avatar appears in header nav avatar

## Testing
- `pytest apps/users/tests/test_profile_avatar_persistence.py -q`
- `pytest -q` *(fails: AvatarResizeTests::test_avatar_resized_on_save, AvatarValidationTests::test_avatar_format_validation, AvatarValidationTests::test_avatar_size_limit, RegistrationTests::test_user_can_register, RegistrationTests::test_welcome_email_sent, LoginPageTests::test_login_page_includes_labels_and_toggle)*

------
https://chatgpt.com/codex/tasks/task_e_6890b6efd51083219e0a4200929f87b7