### PR TITLE
Add register route and profile alias with login password toggle

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -87,11 +87,10 @@ class RegistroUsuarioForm(UserCreationForm):
 
     def clean_password1(self):
         password = self.cleaned_data.get('password1')
-        if password:
-            if len(password) < 6 or not any(c.islower() for c in password) or not any(c.isupper() for c in password) or not any(c.isdigit() for c in password):
-                raise forms.ValidationError(
-                    'La contraseña debe tener al menos 6 caracteres e incluir mayúsculas, minúsculas y números.'
-                )
+        if password and len(password) < 6:
+            raise forms.ValidationError(
+                'La contraseña debe tener al menos 6 caracteres.'
+            )
         return password
 
 class ProfileForm(forms.ModelForm):

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -8,9 +8,11 @@ from .views.auth import LoginView
 urlpatterns = [
     # Registro de usuarios
     path('signup/', auth.register, name='signup'),
+    path('register/', auth.register, name='register'),
     path('login/', LoginView.as_view(), name='login'),
     path('logout/', auth_views.LogoutView.as_view(next_page='/'), name='logout'),
-    path('perfil/', profile_views.profile, name='profile'),
+    path('profile/', profile_views.profile, name='profile'),
+    path('perfil/', profile_views.profile),
     path('reseña/<slug:slug>/', review.dejar_reseña, name='dejar-reseña'),
   
     path('reseña/<int:reseña_id>/editar/', review.editar_reseña, name='editar_reseña'),

--- a/static/js/toggle-password.js
+++ b/static/js/toggle-password.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.form-field').forEach(field => {
+    const input = field.querySelector('input[type="password"]');
+    const toggle = field.querySelector('.toggle-password');
+    if (!input || !toggle) return;
+
+    toggle.setAttribute('tabindex', '-1');
+    toggle.addEventListener('click', () => {
+      const isPassword = input.getAttribute('type') === 'password';
+      input.setAttribute('type', isPassword ? 'text' : 'password');
+      toggle.classList.toggle('active', !isPassword);
+    });
+  });
+});

--- a/templates/partials/_login-form.html
+++ b/templates/partials/_login-form.html
@@ -24,13 +24,14 @@
 
                 <div class="form-field">
                   <button type="button" class="clear-btn me-4">x</button>
+                  <button type="button" class="toggle-password">👁</button>
                     <input type="password"
                            name="{{ form.password.name }}"
                            class="form-control"
                            id="{{ form.password.id_for_label }}"
                            placeholder=" "
                            required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
-                    
+
                     <label for="{{ form.password.id_for_label }}">Contraseña</label>
                     {% if form.password.errors %}
                       <div class="invalid-feedback d-block">

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -44,5 +44,6 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{% static 'js/page-loader.js' %}"></script>
 <script src="{% static 'js/clear-input.js' %}"></script>
+<script src="{% static 'js/toggle-password.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose registration at `/register/` and add English `/profile/` alias for account page
- enable password field visibility toggle on login and relax registration password requirements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890c3b7eb68832181f6cfbec94cd93d