### PR TITLE
Disable profile avatar upload for club owners

### DIFF
--- a/apps/users/views/profile.py
+++ b/apps/users/views/profile.py
@@ -74,6 +74,11 @@ def profile(request):
 
     owned_clubs = request.user.owned_clubs.all()
     is_owner = owned_clubs.exists()
+    avatar_url = profile_obj.avatar.url if profile_obj.avatar else None
+    if is_owner:
+        first_club = owned_clubs.first()
+        if first_club and first_club.logo:
+            avatar_url = first_club.logo.url
 
     plans = [
         {
@@ -120,6 +125,7 @@ def profile(request):
         'reviews': user_reviews,
         'owned_clubs': owned_clubs,
         'is_owner': is_owner,
+        'avatar_url': avatar_url,
     })
 
 def profile_detail(request, username):

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -23,9 +23,10 @@
             <form method="post" enctype="multipart/form-data" class="profile-form">
                 {% csrf_token %}
                 <div class="mb-5 text-center">
+                    {% if not is_owner %}
                     <div class="avatar-dropzone mx-auto">
                         {{ form.avatar }}
-                        <div class="avatar-preview{% if profile.avatar %} has-image{% endif %}"{% if profile.avatar %} style="background-image:url('{{ profile.avatar.url }}')"{% endif %}>
+                        <div class="avatar-preview{% if avatar_url %} has-image{% endif %}"{% if avatar_url %} style="background-image:url('{{ avatar_url }}')"{% endif %}>
                             <div class="avatar-dropzone-msg">
                                 <i class="bi bi-cloud-upload mb-1 fs-4"></i>
                                 <span>Sube tu avatar</span>
@@ -35,6 +36,11 @@
                     {% if form.avatar.errors %}
                     <div class="invalid-feedback d-block">
                         {{ form.avatar.errors.as_text|striptags }}
+                    </div>
+                    {% endif %}
+                    {% else %}
+                    <div class="avatar-dropzone mx-auto">
+                        <div class="avatar-preview{% if avatar_url %} has-image{% endif %}"{% if avatar_url %} style="background-image:url('{{ avatar_url }}')"{% endif %}></div>
                     </div>
                     {% endif %}
                 </div>


### PR DESCRIPTION
## Summary
- Display club logo as profile avatar when user is an owner
- Hide avatar upload controls on profile page for club owners

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f40696cc8321a2731c6e251c7bc3