### PR TITLE
Unify dashboard form input styling

### DIFF
--- a/static/js/clear-input.js
+++ b/static/js/clear-input.js
@@ -1,6 +1,6 @@
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll(".form-field").forEach((field) => {
-    const input = field.querySelector("input");
+    const input = field.querySelector("input, textarea, select");
     const btn = field.querySelector(".clear-btn");
     if (!input || !btn) return;
 
@@ -16,13 +16,19 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     btn.addEventListener("click", () => {
-      input.value = "";
-      input.dispatchEvent(new Event("input", { bubbles: true }));
+      if (input.tagName === "SELECT") {
+        input.selectedIndex = 0;
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+      } else {
+        input.value = "";
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      }
       toggle();
       input.focus();
     });
 
-    input.addEventListener("input", toggle);
+    const eventName = input.tagName === "SELECT" ? "change" : "input";
+    input.addEventListener(eventName, toggle);
     toggle();
   });
 });

--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -57,18 +57,21 @@
       <div class="col-4 col-md-2">
         <div class="form-field">
           {{ form.victorias }}
+          <button type="button" class="clear-btn">×</button>
           <label for="{{ form.victorias.id_for_label }}" class="text-success">Victorias</label>
         </div>
       </div>
       <div class="col-4 col-md-2">
         <div class="form-field">
           {{ form.derrotas }}
+          <button type="button" class="clear-btn">×</button>
           <label for="{{ form.derrotas.id_for_label }}" class="text-danger">Derrotas</label>
         </div>
       </div>
       <div class="col-4 col-md-2">
         <div class="form-field">
           {{ form.empates }}
+          <button type="button" class="clear-btn">×</button>
           <label for="{{ form.empates.id_for_label }}" class="text-primary">Empates</label>
         </div>
       </div>
@@ -94,6 +97,7 @@
       <div class="col-6 col-md-4">
         <div class="form-field">
           {{ form.sexo }}
+          <button type="button" class="clear-btn">×</button>
           <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
           {% if form.sexo.errors %}
           <div class="invalid-feedback d-block">
@@ -105,6 +109,7 @@
       <div class="col-6 col-md-2">
         <div class="form-field">
           {{ form.edad }}
+          <button type="button" class="clear-btn">×</button>
           <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
           {% if form.edad.errors %}
           <div class="invalid-feedback d-block">
@@ -118,6 +123,7 @@
       <div class="col-12 col-md-6">
         <div class="form-field" id="modalidad-field">
           {{ form.modalidad }}
+          <button type="button" class="clear-btn">×</button>
           <label for="{{ form.modalidad.id_for_label }}">{{ form.modalidad.label }}</label>
           {% if form.modalidad.errors %}
           <div class="invalid-feedback d-block">
@@ -129,6 +135,7 @@
       <div class="col-12 col-md-6">
         <div class="form-field">
           {{ form.peso }}
+          <button type="button" class="clear-btn">×</button>
           <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
           {% if form.peso.errors %}
           <div class="invalid-feedback d-block">
@@ -139,26 +146,29 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-6">
-        <div class="form-field">
-          {{ form.peso_kg }}
-          <label for="{{ form.peso_kg.id_for_label }}">{{ form.peso_kg.label }}</label>
+        <div class="col-6">
+          <div class="form-field">
+            {{ form.peso_kg }}
+            <button type="button" class="clear-btn">×</button>
+            <label for="{{ form.peso_kg.id_for_label }}">{{ form.peso_kg.label }}</label>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="form-field">
+            {{ form.altura_cm }}
+            <button type="button" class="clear-btn">×</button>
+            <label for="{{ form.altura_cm.id_for_label }}">{{ form.altura_cm.label }}</label>
+          </div>
         </div>
       </div>
-      <div class="col-6">
-        <div class="form-field">
-          {{ form.altura_cm }}
-          <label for="{{ form.altura_cm.id_for_label }}">{{ form.altura_cm.label }}</label>
+      <div class="form-field">
+        {{ form.palmares }}
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.palmares.id_for_label }}">{{ form.palmares.label }}</label>
+        {% if form.palmares.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.palmares.errors.as_text|striptags }}
         </div>
-      </div>
-    </div>
-    <div class="form-field">
-      {{ form.palmares }}
-      <label for="{{ form.palmares.id_for_label }}">{{ form.palmares.label }}</label>
-      {% if form.palmares.errors %}
-      <div class="invalid-feedback d-block">
-        {{ form.palmares.errors.as_text|striptags }}
-      </div>
       {% endif %}
     </div>
     <div class="text-end">

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -93,9 +93,8 @@
     <div class="col-md-3">
       <div class="form-field">
         {{ form.fecha_nacimiento }}
-        <label for="{{ form.fecha_nacimiento.id_for_label }}"
-          >{{ form.fecha_nacimiento.label }}</label
-        >
+        <button type="button" class="clear-btn">×</button>
+        <label for="{{ form.fecha_nacimiento.id_for_label }}">{{ form.fecha_nacimiento.label }}</label>
         {% if form.fecha_nacimiento.errors %}
         <div class="invalid-feedback d-block">
           {{ form.fecha_nacimiento.errors.as_text|striptags }}
@@ -106,6 +105,7 @@
     <div class="col-md-3">
       <div class="form-field">
         {{ form.sexo }}
+        <button type="button" class="clear-btn">×</button>
         <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
         {% if form.sexo.errors %}
         <div class="invalid-feedback d-block">
@@ -159,34 +159,35 @@
       </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-md-6">
-      <div class="form-field">
-        {{ form.altura }}
-        <label for="{{ form.altura.id_for_label }}"
-          >{{ form.altura.label }}</label
-        >
-        {% if form.altura.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.altura.errors.as_text|striptags }}
-        </div>
+    <div class="row">
+      <div class="col-md-6">
+        <div class="form-field">
+          {{ form.altura }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ form.altura.id_for_label }}">{{ form.altura.label }}</label>
+          {% if form.altura.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.altura.errors.as_text|striptags }}
+          </div>
         {% endif %}
       </div>
     </div>
-    <div class="col-md-6">
-      <div class="form-field">
-        {{ form.peso }}
-        <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
-        {% if form.peso.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.peso.errors.as_text|striptags }}
-        </div>
+      <div class="col-md-6">
+        <div class="form-field">
+          {{ form.peso }}
+          <button type="button" class="clear-btn">×</button>
+          <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
+          {% if form.peso.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.peso.errors.as_text|striptags }}
+          </div>
         {% endif %}
       </div>
     </div>
   </div>
   <div class="form-field">
     {{ form.edad }}
+    <button type="button" class="clear-btn">×</button>
     <label for="{{ form.edad.id_for_label }}">{{ form.edad.label }}</label>
     {% if form.edad.errors %}
     <div class="invalid-feedback d-block">
@@ -196,6 +197,7 @@
   </div>
   <div class="form-field">
     {{ form.estado }}
+    <button type="button" class="clear-btn">×</button>
     <label for="{{ form.estado.id_for_label }}">{{ form.estado.label }}</label>
     {% if form.estado.errors %}
     <div class="invalid-feedback d-block">
@@ -205,6 +207,7 @@
   </div>
   <div class="form-field">
     {{ form.notas }}
+    <button type="button" class="clear-btn">×</button>
     <label for="{{ form.notas.id_for_label }}">{{ form.notas.label }}</label>
     {% if form.notas.errors %}
     <div class="invalid-feedback d-block">

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -59,6 +59,7 @@
 
         <div class="form-field">
           {{ form.about }}
+          <button type="button" class="clear-btn">×</button>
           <label for="{{ form.about.id_for_label }}">{{ form.about.label }}</label>
           {% if form.about.errors %}
           <div class="invalid-feedback d-block">


### PR DESCRIPTION
## Summary
- add clear buttons to dashboard forms for consistent spacing and appearance
- extend clear-input script to support textareas and selects

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689110d4cf888321afdce4ed905aa241