### PR TITLE
feat: add placeholder when club has no photos

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -87,11 +87,21 @@
        display: none;
  }
 
- .gallery-slide.active {
+.gallery-slide.active {
        display: block;
- }
+}
 
- .slide-arrow {
+.gallery-placeholder {
+       width: 100%;
+       max-height: 500px;
+       min-height: 500px;
+       background: rgb(85, 85, 85);
+       display: flex;
+       align-items: center;
+       justify-content: center;
+}
+
+.slide-arrow {
        position: absolute;
        top: 50%;
        transform: translateY(-50%);

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -160,7 +160,15 @@
                             </div>
                         </div>
                     {% else %}
-                        <p>No hay fotos todavía.</p>
+                        <div class="d-flex flex-column align-items-center">
+                            <div class="gallery-placeholder rounded shadow-sm">
+                                <svg class="text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="60" height="60" fill="none" viewBox="0 0 24 24">
+                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 16.5V6a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1v10.5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1Zm16 0-4-5-3 3-2-2-4 4"/>
+                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14.5 9.5a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"/>
+                                </svg>
+                            </div>
+                            <p class="mt-2">No hay fotos todavía.</p>
+                        </div>
                     {% endif %}
                 </div>
                 <!-- Menú de pestañas -->


### PR DESCRIPTION
## Summary
- show grey placeholder with image icon when a club gallery is empty
- style gallery placeholder with fixed dimensions and centered content

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921ab8c68083219868200abb9b7138