### PR TITLE
Align name and username fields

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -114,6 +114,29 @@
   display: block;
 }
 
+.profile-form .slug-field .username-prefix {
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #666;
+}
+
+.profile-form .slug-field input {
+  padding-left: 1.5rem;
+}
+
+.profile-form .slug-field label {
+  left: 1.5rem;
+}
+
+.profile-form .slug-field #slug-status {
+  position: absolute;
+  right: 2.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
 .feature-option {
   cursor: pointer;
 }

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -58,12 +58,10 @@
             {% endif %}
           </div>
 
-          <div class="form-field col-md-6">
-            <div class="input-group">
-              <span class="input-group-text">@</span>
-              {{ form.slug }}
-              <span class="input-group-text bg-transparent border-0" id="slug-status"></span>
-            </div>
+          <div class="form-field col-md-6 slug-field">
+            <span class="username-prefix">@</span>
+            {{ form.slug }}
+            <span id="slug-status"></span>
             <button type="button" class="clear-btn">×</button>
             <label for="{{ form.slug.id_for_label }}">{{ form.slug.label }}</label>
             {% if form.slug.errors %}


### PR DESCRIPTION
## Summary
- Align club name and username inputs horizontally on dashboard
- Remove background from username '@' prefix and reposition slug status indicator

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6892ea163ec0832194acba4a4580352e