### PR TITLE
Add uniform fields mixin for consistent form styling

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -6,8 +6,9 @@ from . import models
 from .countries import COUNTRY_CHOICES
 from .regions import SPAIN_REGION_CHOICES
 from django.contrib.auth.forms import AuthenticationForm
+from apps.core.mixins import UniformFieldsMixin
 
-class LoginForm(AuthenticationForm):
+class LoginForm(UniformFieldsMixin, AuthenticationForm):
     username = forms.CharField(
         label="Usuario",
         widget=forms.TextInput(attrs={'class': 'form-control'})
@@ -18,7 +19,7 @@ class LoginForm(AuthenticationForm):
         widget=forms.PasswordInput(attrs={'class': 'form-control'})
     )
  
-class RegistroUsuarioForm(UserCreationForm):
+class RegistroUsuarioForm(UniformFieldsMixin, UserCreationForm):
     email = forms.EmailField(label='Correo electrónico', required=True)
 
     class Meta:
@@ -41,7 +42,7 @@ class RegistroUsuarioForm(UserCreationForm):
 
  
 
-class ReseñaForm(forms.ModelForm):
+class ReseñaForm(UniformFieldsMixin, forms.ModelForm):
     titulo = forms.CharField(
         label='Título',
         max_length=100,
@@ -93,7 +94,7 @@ class ReseñaForm(forms.ModelForm):
             'calidad_precio': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input', 'required': 'required'}),
             'variedad_clases': forms.NumberInput(attrs={'min': 1, 'max': 5, 'class': 'star-input', 'required': 'required'}),
         }
-class ClubPostForm(forms.ModelForm):
+class ClubPostForm(UniformFieldsMixin, forms.ModelForm):
     """Formulario para crear publicaciones de club."""
 
     class Meta:
@@ -112,7 +113,7 @@ class ClubPostForm(forms.ModelForm):
             'image': forms.ClearableFileInput(attrs={'class': 'd-none'})
         }
 
-class ClubPostReplyForm(forms.ModelForm):
+class ClubPostReplyForm(UniformFieldsMixin, forms.ModelForm):
     class Meta:
         model = models.ClubPost
         fields = ['contenido']
@@ -124,14 +125,14 @@ class ClubPostReplyForm(forms.ModelForm):
         }
 
 
-class BookingForm(forms.ModelForm):
+class BookingForm(UniformFieldsMixin, forms.ModelForm):
     class Meta:
         model = models.Booking
         fields = []
 
  
 
-class BookingClassForm(forms.ModelForm):
+class BookingClassForm(UniformFieldsMixin, forms.ModelForm):
     class Meta:
         model = models.BookingClass
         fields = ['titulo', 'precio', 'duracion', 'detalle', 'destacado']
@@ -162,7 +163,7 @@ class BookingClassForm(forms.ModelForm):
                 field.widget.attrs.setdefault('placeholder', ' ')
 
 
-class ClubForm(forms.ModelForm):
+class ClubForm(UniformFieldsMixin, forms.ModelForm):
     class Meta:
         model = models.Club
         exclude = (
@@ -233,18 +234,18 @@ class ClubForm(forms.ModelForm):
             logo_widget.widget.attrs['class'] = (css + ' d-none').strip()
 
 
-class CancelBookingForm(forms.Form):
+class CancelBookingForm(UniformFieldsMixin, forms.Form):
     """Simple form used to confirm cancellation."""
     pass
 
 
-class ClubPhotoForm(forms.ModelForm):
+class ClubPhotoForm(UniformFieldsMixin, forms.ModelForm):
     class Meta:
         model = models.ClubPhoto
         fields = ['image']
 
 
-class HorarioForm(forms.ModelForm):
+class HorarioForm(UniformFieldsMixin, forms.ModelForm):
     class Meta:
         model = models.Horario
         fields = ['dia', 'hora_inicio', 'hora_fin', 'estado', 'estado_otro']
@@ -256,7 +257,7 @@ class HorarioForm(forms.ModelForm):
         }
 
 
-class CompetidorForm(forms.ModelForm):
+class CompetidorForm(UniformFieldsMixin, forms.ModelForm):
     victorias = forms.IntegerField(required=False, min_value=0, label='Victorias')
     derrotas = forms.IntegerField(required=False, min_value=0, label='Derrotas')
     empates = forms.IntegerField(required=False, min_value=0, label='Empates')
@@ -360,7 +361,7 @@ class CompetidorForm(forms.ModelForm):
         return super().save(commit)
 
 
-class EntrenadorForm(forms.ModelForm):
+class EntrenadorForm(UniformFieldsMixin, forms.ModelForm):
     class Meta:
         model = models.Entrenador
         exclude = ['slug', 'club']
@@ -396,7 +397,7 @@ class EntrenadorForm(forms.ModelForm):
             avatar_widget.widget.attrs['class'] = (css + ' d-none').strip()
 
 
-class MiembroForm(forms.ModelForm):
+class MiembroForm(UniformFieldsMixin, forms.ModelForm):
     edad = forms.IntegerField(required=False, min_value=0, label='Edad')
     nacionalidad = forms.ChoiceField(
         choices=[('', 'País')] + COUNTRY_CHOICES,
@@ -458,7 +459,7 @@ class MiembroForm(forms.ModelForm):
             self.fields['codigo_postal'].label = 'Código postal'
 
 
-class PagoForm(forms.ModelForm):
+class PagoForm(UniformFieldsMixin, forms.ModelForm):
     fecha = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}))
     monto = forms.DecimalField(
         max_digits=8,
@@ -489,7 +490,7 @@ class PagoForm(forms.ModelForm):
                 field.widget.attrs.setdefault('placeholder', ' ')
 
 
-class ClubMessageForm(forms.ModelForm):
+class ClubMessageForm(UniformFieldsMixin, forms.ModelForm):
     class Meta:
         model = models.ClubMessage
         fields = ['content']

--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -1,6 +1,7 @@
 from django import forms
+from apps.core.mixins import UniformFieldsMixin
 
-class TipoUsuarioForm(forms.Form):
+class TipoUsuarioForm(UniformFieldsMixin, forms.Form):
     tipo = forms.ChoiceField(
         label='Selecciona que eres',
         choices=[
@@ -12,7 +13,7 @@ class TipoUsuarioForm(forms.Form):
         widget=forms.RadioSelect
     )
 
-class PlanForm(forms.Form):
+class PlanForm(UniformFieldsMixin, forms.Form):
     plan = forms.ChoiceField(
         label='Selecciona el tipo de Plan',
         choices=[
@@ -23,7 +24,7 @@ class PlanForm(forms.Form):
         widget=forms.RadioSelect
     )
 
-class RegistroProfesionalForm(forms.Form):
+class RegistroProfesionalForm(UniformFieldsMixin, forms.Form):
     """Formulario multipaso para seleccionar tipo de usuario y plan."""
 
     tipo = TipoUsuarioForm.base_fields['tipo']

--- a/apps/core/mixins/__init__.py
+++ b/apps/core/mixins/__init__.py
@@ -1,1 +1,4 @@
+from .fields import UniformFieldsMixin
+from .permissions import IsAdminMixin
 
+__all__ = ["UniformFieldsMixin", "IsAdminMixin"]

--- a/apps/core/mixins/fields.py
+++ b/apps/core/mixins/fields.py
@@ -1,0 +1,28 @@
+# apps/core/mixins/fields.py
+from django import forms
+
+class UniformFieldsMixin:
+    """Aplicar estilo uniforme a los campos de un formulario."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            css = field.widget.attrs.get('class', '')
+            if isinstance(field.widget, forms.CheckboxInput):
+                field.widget.attrs['class'] = (css + ' form-check-input').strip()
+            else:
+                field.widget.attrs['class'] = (css + ' form-control').strip()
+            if isinstance(
+                field.widget,
+                (
+                    forms.TextInput,
+                    forms.EmailInput,
+                    forms.URLInput,
+                    forms.NumberInput,
+                    forms.PasswordInput,
+                    forms.Textarea,
+                    forms.DateInput,
+                    forms.TimeInput,
+                ),
+            ):
+                field.widget.attrs.setdefault('placeholder', ' ')

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.forms import AuthenticationForm
 from django.utils.translation import gettext_lazy as _
 from .models import Profile
+from apps.core.mixins import UniformFieldsMixin
 import os
 
 
@@ -23,7 +24,7 @@ def _validate_avatar(avatar):
     return avatar
 
 
-class LoginForm(AuthenticationForm):
+class LoginForm(UniformFieldsMixin, AuthenticationForm):
     error_messages = {
         "invalid_login": _("El usuario o la contraseña introducida no es correcta, por favor intente de nuevo"),
         "inactive": _("Esta cuenta está inactiva."),
@@ -51,7 +52,7 @@ class LoginForm(AuthenticationForm):
         # Mark "recordar contraseña" checked by default
         self.fields["remember_me"].initial = True
  
-class RegistroUsuarioForm(UserCreationForm):
+class RegistroUsuarioForm(UniformFieldsMixin, UserCreationForm):
     email = forms.EmailField(label='Correo electrónico', required=True, error_messages={"required": "Rellene este campo"})
 
     error_messages = {
@@ -93,7 +94,7 @@ class RegistroUsuarioForm(UserCreationForm):
             )
         return password
 
-class ProfileForm(forms.ModelForm):
+class ProfileForm(UniformFieldsMixin, forms.ModelForm):
     avatar = forms.FileField(required=False)
 
     class Meta:
@@ -107,7 +108,7 @@ class ProfileForm(forms.ModelForm):
         return _validate_avatar(avatar)
 
 
-class AccountForm(forms.ModelForm):
+class AccountForm(UniformFieldsMixin, forms.ModelForm):
     avatar = forms.FileField(required=False)
     new_password1 = forms.CharField(
         label='Nueva contraseña', widget=forms.PasswordInput, required=False


### PR DESCRIPTION
## Summary
- add `UniformFieldsMixin` for applying Bootstrap styles to form fields automatically
- expose new mixin and apply it across core, user, and club form classes for consistent styling

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6892f1fde62083218bfb1498a1e6795f