### PR TITLE
style: adjust clear button behavior and label spacing

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -33,15 +33,26 @@
   margin-bottom: 1.5rem;
 }
 
-.profile-form .form-field input:not([type="checkbox"]),
-.profile-form .form-field textarea,
-.profile-form .form-field select {
+ .profile-form .form-field input:not([type="checkbox"]),
+ .profile-form .form-field textarea,
+ .profile-form .form-field select {
   width: 100%;
   padding: 0.75rem 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
   background: none;
   transition: border-color 0.3s, box-shadow 0.3s;
+ }
+
+.profile-form .form-field select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PScwIDAgMTAgNicgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJz48cG9seWdvbiBwb2ludHM9JzAgMCA1IDYgMTAgMCcgZmlsbD0nIzY2NicvPjwvc3ZnPg==");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 10px 6px;
+  padding-right: 1.5rem;
 }
 
 .profile-form .form-field input[type="checkbox"] {
@@ -59,10 +70,11 @@
 
 .profile-form .form-field label {
   position: absolute;
-  left: 0.5rem;
+  left: 0;
+  margin-left: 3px;
   top: 50%;
   transform: translateY(-50%);
-  background: #fff;
+  background: none;
   padding: 0 0.25rem;
   color: #666;
   pointer-events: none;
@@ -100,7 +112,7 @@
 
 .profile-form .clear-btn {
   position: absolute;
-  right: 0.75rem;
+  right: 3px;
   top: 50%;
   transform: translateY(-50%);
   border: none;
@@ -108,10 +120,11 @@
   cursor: pointer;
   font-size: 1rem;
   display: none;
+  margin-right: 3px;
 }
 
-.profile-form input:not(:placeholder-shown) + .clear-btn {
-  display: block;
+.profile-form textarea + .clear-btn {
+  display: none !important;
 }
 
 .profile-form .slug-field .username-prefix {
@@ -120,14 +133,16 @@
   top: 50%;
   transform: translateY(-50%);
   color: #666;
+  margin-right: 5px;
 }
 
 .profile-form .slug-field input {
-  padding-left: 1.5rem;
+  padding-left: calc(1.5rem + 5px);
 }
 
 .profile-form .slug-field label {
   left: 1.5rem;
+  margin-left: 3px;
 }
 
 .profile-form .slug-field #slug-status {
@@ -471,7 +486,7 @@ select option[value="España"] {
 
 .search-field .clear-btn {
   position: absolute;
-  right: 2.25rem;
+  right: calc(1.5rem + 3px);
   top: 50%;
   transform: translateY(-50%);
   border: none;
@@ -479,16 +494,13 @@ select option[value="España"] {
   cursor: pointer;
   font-size: 1rem;
   display: none;
-}
-
-.search-field input:not(:placeholder-shown) + .clear-btn {
-  display: block;
+  margin-right: 3px;
 }
 
 /* Search button inside input */
 .search-field .search-btn {
   position: absolute;
-  right: 0.75rem;
+  right: 3px;
   top: 50%;
   transform: translateY(-50%);
   border: none;

--- a/static/js/clear-input.js
+++ b/static/js/clear-input.js
@@ -4,11 +4,17 @@ document.addEventListener("DOMContentLoaded", () => {
     const btn = field.querySelector(".clear-btn");
     if (!input || !btn) return;
 
+    // Remove clear button for textareas
+    if (input.tagName === "TEXTAREA") {
+      btn.remove();
+      return;
+    }
+
     // Make clear button not tabbable
     btn.setAttribute("tabindex", "-1");
 
     const toggle = () => {
-      if (input.value) {
+      if (document.activeElement === input && input.value) {
         btn.style.display = "block";
       } else {
         btn.style.display = "none";
@@ -27,6 +33,8 @@ document.addEventListener("DOMContentLoaded", () => {
       input.focus();
     });
 
+    input.addEventListener("focus", toggle);
+    input.addEventListener("blur", toggle);
     const eventName = input.tagName === "SELECT" ? "change" : "input";
     input.addEventListener(eventName, toggle);
     toggle();

--- a/static/js/region-select.js
+++ b/static/js/region-select.js
@@ -68,17 +68,24 @@ function initRegionSelect() {
         const input = buildInput('');
         current.replaceWith(input);
         if (clearBtn) {
-          clearBtn.style.display = '';
+          clearBtn.style.display = 'none';
           clearBtn.onclick = () => {
             input.value = '';
             input.dispatchEvent(new Event('input', { bubbles: true }));
             clearBtn.style.display = 'none';
             input.focus();
           };
-          input.addEventListener('input', () => {
-            clearBtn.style.display = input.value ? 'block' : 'none';
-          });
-          clearBtn.style.display = input.value ? 'block' : 'none';
+          const toggle = () => {
+            if (document.activeElement === input && input.value) {
+              clearBtn.style.display = 'block';
+            } else {
+              clearBtn.style.display = 'none';
+            }
+          };
+          input.addEventListener('focus', toggle);
+          input.addEventListener('blur', toggle);
+          input.addEventListener('input', toggle);
+          toggle();
         }
       }
     }

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -75,7 +75,6 @@
 
         <div class="form-field">
           {{ form.about }}
-          <button type="button" class="clear-btn">×</button>
           <label for="{{ form.about.id_for_label }}">{{ form.about.label }}</label>
           {% if form.about.errors %}
           <div class="invalid-feedback d-block">

--- a/templates/partials/_login-form.html
+++ b/templates/partials/_login-form.html
@@ -23,7 +23,7 @@
 
 
                 <div class="form-field">
-                  <button type="button" class="clear-btn me-4">x</button>
+                  <button type="button" class="clear-btn">x</button>
                   <button type="button" class="toggle-password">👁</button>
                     <input type="password"
                            name="{{ form.password.name }}"

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -76,7 +76,7 @@
 
 <!-- Password1 -->
 <div class="form-field">
-    <button type="button" class="clear-btn me-4">x</button>
+    <button type="button" class="clear-btn">x</button>
     <input type="password" name="{{ form.password1.name }}" class="form-control" id="{{ form.password1.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
     
     <label for="{{ form.password1.id_for_label }}">{{ form.password1.label }}</label>
@@ -91,7 +91,7 @@
 
 <!-- Password2 -->
 <div class="form-field">
-    <button type="button" class="clear-btn me-4">x</button>
+    <button type="button" class="clear-btn">x</button>
     <input type="password" name="{{ form.password2.name }}" class="form-control" id="{{ form.password2.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
     <label for="{{ form.password2.id_for_label }}">{{ form.password2.label }}</label>
     {% if form.password2.errors %}


### PR DESCRIPTION
## Summary
- hide clear buttons until inputs are focused and drop them from textareas
- add triangular icon to dropdowns and standardize label and prefix spacing
- ensure clear buttons maintain 3px right margin across forms

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68931444a524832196adf568a1da7887