### PR TITLE
Improve form UX and validation

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -54,6 +54,15 @@ class LoginForm(UniformFieldsMixin, AuthenticationForm):
  
 class RegistroUsuarioForm(UniformFieldsMixin, UserCreationForm):
     email = forms.EmailField(label='Correo electrónico', required=True, error_messages={"required": "Rellene este campo"})
+    username = forms.CharField(
+        label='Nombre de usuario',
+        min_length=3,
+        error_messages={
+            'required': 'Rellene este campo',
+            'min_length': 'El nombre de usuario debe tener al menos 3 caracteres'
+        },
+        widget=forms.TextInput(attrs={'minlength': 3})
+    )
 
     error_messages = {
         **UserCreationForm.error_messages,
@@ -117,7 +126,15 @@ class AccountForm(UniformFieldsMixin, forms.ModelForm):
         label='Confirmar contraseña', widget=forms.PasswordInput, required=False
     )
     email = forms.EmailField(label='Correo electrónico', required=False)
-    username = forms.CharField(label='Nombre de usuario')
+    username = forms.CharField(
+        label='Nombre de usuario',
+        min_length=3,
+        error_messages={
+            'required': 'Rellene este campo',
+            'min_length': 'El nombre de usuario debe tener al menos 3 caracteres'
+        },
+        widget=forms.TextInput(attrs={'minlength': 3})
+    )
     notifications = forms.BooleanField(
         label='Recibir notificaciones', required=False
     )

--- a/apps/users/tests/test_user.py
+++ b/apps/users/tests/test_user.py
@@ -33,6 +33,18 @@ class RegistrationTests(TestCase):
             self.client.post(url, data)
             mock_send.assert_called_once_with("email@example.com")
 
+    def test_username_too_short(self):
+        data = {
+            "username": "ab",
+            "email": "short@example.com",
+            "password1": "secretpass123",
+            "password2": "secretpass123",
+        }
+        url = reverse("register")
+        response = self.client.post(url, data)
+        self.assertContains(response, "El nombre de usuario debe tener al menos 3 caracteres")
+        self.assertFalse(User.objects.filter(username="ab").exists())
+
 
 class LoginRememberMeTests(TestCase):
     def setUp(self):

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -65,7 +65,7 @@
 .profile-form .form-field select:focus {
   outline: none;
   border-color: #000;
-  box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
+  box-shadow: none;
 }
 
 .profile-form .form-field label {
@@ -138,6 +138,13 @@
 .profile-form .slug-field input {
   padding-left:30px !important;
   margin-right: calc(1.5rem + 5px) !important;
+}
+
+.profile-form .slug-field.always-active label {
+  top: 0;
+  transform: translateY(-50%);
+  font-size: 0.7rem;
+  color: #000;
 }
 
 

--- a/static/js/clear-input.js
+++ b/static/js/clear-input.js
@@ -12,6 +12,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Make clear button not tabbable
     btn.setAttribute("tabindex", "-1");
+    btn.addEventListener("mousedown", (e) => e.preventDefault());
 
     const toggle = () => {
       if (document.activeElement === input && input.value) {

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -44,7 +44,8 @@
                     </div>
                     {% endif %}
                 </div>
-                <div class="form-field">
+                <div class="form-field slug-field always-active">
+                    <span class="username-prefix">@</span>
                     {{ form.username }}
                     <button type="button" class="clear-btn bi bi-x"></button>
                     <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -51,8 +51,9 @@
             {{ form.non_field_errors }}
 
           <!-- Username -->
-<div class="form-field">
-    <input type="text" name="{{ form.username.name }}" value="{{ form.username.value|default_if_none:'' }}" class="form-control" id="{{ form.username.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
+<div class="form-field slug-field always-active">
+    <span class="username-prefix">@</span>
+    <input type="text" name="{{ form.username.name }}" value="{{ form.username.value|default_if_none:'' }}" class="form-control" id="{{ form.username.id_for_label }}" placeholder=" " minlength="3" required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
     <button type="button" class="clear-btn bi bi-x"></button>
     <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
     {% if form.username.errors %}


### PR DESCRIPTION
## Summary
- Ensure clear buttons actually clear their inputs
- Enforce minimum length for usernames and prefix them with @ in forms
- Remove input focus shadow and keep username field label active

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893798a2fb88321b77e3fc39a5077a0