### PR TITLE
Show slug warning for short usernames

### DIFF
--- a/static/js/slug-check.js
+++ b/static/js/slug-check.js
@@ -9,8 +9,15 @@ document.addEventListener('DOMContentLoaded', () => {
     clearTimeout(timer);
     if (!value) {
       status.innerHTML = '';
+      status.classList.remove('text-danger');
       return;
     }
+    if (value.length < 3) {
+      status.textContent = 'Introduce un nombre con al menos 3 carácteres';
+      status.classList.add('text-danger');
+      return;
+    }
+    status.classList.remove('text-danger');
     timer = setTimeout(() => {
       fetch(`/clubs/slug-disponible/?slug=${encodeURIComponent(value)}&current=${encodeURIComponent(current)}`)
         .then(res => res.json())


### PR DESCRIPTION
## Summary
- show warning text when slug/username length is less than 3 characters
- keep slug availability check for valid lengths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68937f458c4883219a0d60dcf84f64ab