### PR TITLE
Validación de longitud mínima para slug y alertas de guardado

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -220,9 +220,13 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
                 field.widget.attrs.setdefault('placeholder', ' ')
             if name == 'slug':
                 field.widget.attrs['data-current'] = getattr(self.instance, 'slug', '')
+                field.widget.attrs['minlength'] = 3
+                field.required = True
 
     def clean_slug(self):
         slug = self.cleaned_data.get('slug', '').lstrip('@')
+        if len(slug) < 3:
+            raise forms.ValidationError('Introduce un nombre con al menos 3 carácteres')
         if models.Club.objects.exclude(pk=self.instance.pk).filter(slug=slug).exists():
             raise forms.ValidationError('Este usuario ya está en uso.')
         return slug

--- a/static/js/slug-check.js
+++ b/static/js/slug-check.js
@@ -1,23 +1,43 @@
 document.addEventListener('DOMContentLoaded', () => {
   const input = document.getElementById('id_slug');
   const status = document.getElementById('slug-status');
+  const error = document.getElementById('slug-error');
   if (!input || !status) return;
   const current = input.dataset.current || '';
+
+  const showError = (msg) => {
+    status.innerHTML = '<i class="bi bi-x-circle text-danger"></i>';
+    if (error) {
+      error.textContent = msg;
+      error.classList.remove('d-none');
+    }
+  };
+
+  const clearError = () => {
+    status.innerHTML = '';
+    if (error) {
+      error.textContent = '';
+      error.classList.add('d-none');
+    }
+  };
+
+  if (error && error.textContent.trim()) {
+    status.innerHTML = '<i class="bi bi-x-circle text-danger"></i>';
+  }
+
   let timer;
   input.addEventListener('input', () => {
     const value = input.value.trim();
     clearTimeout(timer);
     if (!value) {
-      status.innerHTML = '';
-      status.classList.remove('text-danger');
+      clearError();
       return;
     }
     if (value.length < 3) {
-      status.textContent = 'Introduce un nombre con al menos 3 carácteres';
-      status.classList.add('text-danger');
+      showError('Introduce un nombre con al menos 3 carácteres');
       return;
     }
-    status.classList.remove('text-danger');
+    clearError();
     timer = setTimeout(() => {
       fetch(`/clubs/slug-disponible/?slug=${encodeURIComponent(value)}&current=${encodeURIComponent(current)}`)
         .then(res => res.json())
@@ -31,4 +51,15 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }, 300);
   });
+
+  const form = input.closest('form');
+  if (form) {
+    form.addEventListener('submit', (e) => {
+      const value = input.value.trim();
+      if (value.length < 3) {
+        e.preventDefault();
+        showError('Introduce un nombre con al menos 3 carácteres');
+      }
+    });
+  }
 });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -64,11 +64,11 @@
             <span id="slug-status"></span>
             <button type="button" class="clear-btn bi bi-x"></button>
             <label for="{{ form.slug.id_for_label }}">{{ form.slug.label }}</label>
-            {% if form.slug.errors %}
-            <div class="invalid-feedback d-block">
+            <div id="slug-error" class="invalid-feedback {% if form.slug.errors %}d-block{% else %}d-none{% endif %}">
+              {% if form.slug.errors %}
               {{ form.slug.errors.as_text|striptags }}
+              {% endif %}
             </div>
-            {% endif %}
           </div>
 
         </div>


### PR DESCRIPTION
## Summary
- exige mínimo de tres caracteres para el slug en el formulario de club
- añade validaciones en cliente con aviso bajo el input y estado en rojo
- prepara la plantilla para mostrar errores del slug

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68938c6cb9688321874f56ef9f79dedf