### PR TITLE
Prioritize Spain in country selector and refresh regional data

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -203,6 +203,12 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
             or self.initial.get('country')
             or getattr(getattr(self, 'instance', None), 'country', None)
         )
+
+        country_field = self.fields.get('country')
+        if country_field:
+            other_countries = [c for c in COUNTRY_CHOICES if c[0] != 'España']
+            country_field.choices = [('', 'País'), ('España', 'España'), ('Otros países', other_countries)]
+            country_field.initial = country_value or 'España'
         for name, field in self.fields.items():
             css = field.widget.attrs.get('class', '')
             field.widget.attrs['class'] = (css + ' form-control').strip()

--- a/static/data/arbol.json
+++ b/static/data/arbol.json
@@ -7672,7 +7672,7 @@
   },
   {
     "parent_code": "0",
-    "label": "Asturias, Principado de",
+    "label": "Principado de Asturias",
     "code": "03",
     "provinces": [
       {
@@ -8076,13 +8076,13 @@
   },
   {
     "parent_code": "0",
-    "label": "Balears, Illes",
+    "label": "Islas Baleares",
     "code": "04",
     "provinces": [
       {
         "parent_code": "04",
         "code": "07",
-        "label": "Balears, Illes",
+        "label": "Islas Baleares",
         "towns": [
           {
             "parent_code": "07",
@@ -20720,7 +20720,7 @@
   },
   {
     "parent_code": "0",
-    "label": "Castilla - La Mancha",
+    "label": "Castilla-La Mancha",
     "code": "08",
     "provinces": [
       {
@@ -25357,7 +25357,7 @@
   },
   {
     "parent_code": "0",
-    "label": "Cataluńa",
+    "label": "Cataluña",
     "code": "09",
     "provinces": [
       {
@@ -30127,7 +30127,7 @@
   },
   {
     "parent_code": "0",
-    "label": "Comunitat Valenciana",
+    "label": "Comunidad Valenciana",
     "code": "10",
     "provinces": [
       {
@@ -36426,7 +36426,7 @@
   },
   {
     "parent_code": "0",
-    "label": "Madrid, Comunidad de",
+    "label": "Comunidad de Madrid",
     "code": "13",
     "provinces": [
       {
@@ -37335,7 +37335,7 @@
   },
   {
     "parent_code": "0",
-    "label": "Murcia, Región de",
+    "label": "Región de Murcia",
     "code": "14",
     "provinces": [
       {
@@ -37574,7 +37574,7 @@
   },
   {
     "parent_code": "0",
-    "label": "Navarra, Comunidad Foral de",
+    "label": "Comunidad Foral de Navarra",
     "code": "15",
     "provinces": [
       {
@@ -40231,13 +40231,13 @@
   },
   {
     "parent_code": "0",
-    "label": "Rioja, La",
+    "label": "La Rioja",
     "code": "17",
     "provinces": [
       {
         "parent_code": "17",
         "code": "26",
-        "label": "Rioja, La",
+        "label": "La Rioja",
         "towns": [
           {
             "parent_code": "26",

--- a/static/data/ccaa.json
+++ b/static/data/ccaa.json
@@ -11,12 +11,12 @@
   },
   {
     "parent_code": "0",
-    "label": "Asturias, Principado de",
+    "label": "Principado de Asturias",
     "code": "03"
   },
   {
     "parent_code": "0",
-    "label": "Balears, Illes",
+    "label": "Islas Baleares",
     "code": "04"
   },
   {
@@ -36,17 +36,17 @@
   },
   {
     "parent_code": "0",
-    "label": "Castilla - La Mancha",
+    "label": "Castilla-La Mancha",
     "code": "08"
   },
   {
     "parent_code": "0",
-    "label": "Cataluńa",
+    "label": "Cataluña",
     "code": "09"
   },
   {
     "parent_code": "0",
-    "label": "Comunitat Valenciana",
+    "label": "Comunidad Valenciana",
     "code": "10"
   },
   {
@@ -61,17 +61,17 @@
   },
   {
     "parent_code": "0",
-    "label": "Madrid, Comunidad de",
+    "label": "Comunidad de Madrid",
     "code": "13"
   },
   {
     "parent_code": "0",
-    "label": "Murcia, Región de",
+    "label": "Región de Murcia",
     "code": "14"
   },
   {
     "parent_code": "0",
-    "label": "Navarra, Comunidad Foral de",
+    "label": "Comunidad Foral de Navarra",
     "code": "15"
   },
   {
@@ -81,7 +81,7 @@
   },
   {
     "parent_code": "0",
-    "label": "Rioja, La",
+    "label": "La Rioja",
     "code": "17"
   },
   {

--- a/static/data/provincias.json
+++ b/static/data/provincias.json
@@ -62,7 +62,7 @@
   {
     "parent_code": "04",
     "code": "07",
-    "label": "Balears, Illes"
+    "label": "Islas Baleares"
   },
   {
     "parent_code": "05",
@@ -247,7 +247,7 @@
   {
     "parent_code": "17",
     "code": "26",
-    "label": "Rioja, La"
+    "label": "La Rioja"
   },
   {
     "parent_code": "18",

--- a/static/js/region-select.js
+++ b/static/js/region-select.js
@@ -32,7 +32,7 @@ function initRegionSelect() {
 
     const empty = document.createElement('option');
     empty.value = '';
-    empty.textContent = `Selecciona ${name}`;
+    empty.textContent = '';
     select.appendChild(empty);
 
     options.forEach(opt => {
@@ -72,22 +72,22 @@ function initRegionSelect() {
 
       if (provinceSelect.tagName.toLowerCase() !== 'select') {
         const select = buildSelect([], 'province', '');
-        select.options[0].textContent = 'Selecciona una provincia';
         provinceSelect.replaceWith(select);
         if (window.initSelectLabels && provinceWrapper) window.initSelectLabels(provinceWrapper);
         provinceSelect = select;
       } else {
-        provinceSelect.innerHTML = `<option value="">Selecciona una provincia</option>`;
+        provinceSelect.innerHTML = '<option value=""></option>';
+        provinceSelect.options[0].hidden = true;
       }
 
       if (citySelect.tagName.toLowerCase() !== 'select') {
         const select = buildSelect([], 'city', '');
-        select.options[0].textContent = 'Selecciona una ciudad';
         citySelect.replaceWith(select);
         if (window.initSelectLabels && cityWrapper) window.initSelectLabels(cityWrapper);
         citySelect = select;
       } else {
-        citySelect.innerHTML = `<option value="">Selecciona una ciudad</option>`;
+        citySelect.innerHTML = '<option value=""></option>';
+        citySelect.options[0].hidden = true;
       }
 
       current.addEventListener('change', () => {
@@ -143,8 +143,10 @@ function initRegionSelect() {
   }
 
   function updateProvince(region) {
-    provinceSelect.innerHTML = `<option value="">Selecciona una provincia</option>`;
-    citySelect.innerHTML = `<option value="">Selecciona una ciudad</option>`;
+    provinceSelect.innerHTML = '<option value=""></option>';
+    provinceSelect.options[0].hidden = true;
+    citySelect.innerHTML = '<option value=""></option>';
+    citySelect.options[0].hidden = true;
     citySelect.disabled = true;
 
     if (!region || !REGION_DATA[region]) {
@@ -166,7 +168,8 @@ function initRegionSelect() {
   }
 
   function updateCity(region, provincia) {
-    citySelect.innerHTML = `<option value="">Selecciona una ciudad</option>`;
+    citySelect.innerHTML = '<option value=""></option>';
+    citySelect.options[0].hidden = true;
     if (!region || !provincia || !REGION_DATA[region][provincia]) {
       citySelect.disabled = true;
       return;


### PR DESCRIPTION
## Summary
- Show Spain first and group remaining countries under "Otros países" in the dashboard form
- Hide default "Selecciona" options for province and city selectors
- Normalize region data JSON files with official community and province names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893da4c1c188321bb036ba66f354d12