### PR TITLE
Add dynamic province/city selection for clubs

### DIFF
--- a/apps/clubs/spain.py
+++ b/apps/clubs/spain.py
@@ -137,3 +137,103 @@ CITY_CHOICES = [
     ("Ceuta", "Ceuta"),
     ("Melilla", "Melilla"),
 ]
+
+# Mapping of regions to their provinces. Used for dynamically loading
+# province choices when a Spanish "Comunidad Autónoma" is selected.
+REGION_PROVINCES = {
+    "Andalucía": [
+        "Almería", "Cádiz", "Córdoba", "Granada",
+        "Huelva", "Jaén", "Málaga", "Sevilla",
+    ],
+    "Aragón": ["Huesca", "Teruel", "Zaragoza"],
+    "Asturias": ["Asturias"],
+    "Islas Baleares": ["Islas Baleares"],
+    "Canarias": ["Las Palmas", "Santa Cruz de Tenerife"],
+    "Cantabria": ["Cantabria"],
+    "Castilla-La Mancha": [
+        "Albacete", "Ciudad Real", "Cuenca",
+        "Guadalajara", "Toledo",
+    ],
+    "Castilla y León": [
+        "Ávila", "Burgos", "León", "Palencia",
+        "Salamanca", "Segovia", "Soria",
+        "Valladolid", "Zamora",
+    ],
+    "Cataluña": ["Barcelona", "Girona", "Lérida", "Tarragona"],
+    "Comunidad Valenciana": ["Alicante", "Castellón", "Valencia"],
+    "Extremadura": ["Badajoz", "Cáceres"],
+    "Galicia": ["La Coruña", "Lugo", "Orense", "Pontevedra"],
+    "Madrid": ["Madrid"],
+    "Murcia": ["Murcia"],
+    "Navarra": ["Navarra"],
+    "País Vasco": ["Álava", "Guipúzcoa", "Vizcaya"],
+    "La Rioja": ["La Rioja"],
+    "Ceuta": ["Ceuta"],
+    "Melilla": ["Melilla"],
+}
+
+# Mapping of provinces to their major cities. This allows loading
+# city options only after a province has been chosen.
+PROVINCE_CITIES = {
+    "Álava": ["Vitoria-Gasteiz"],
+    "Albacete": ["Albacete"],
+    "Alicante": ["Alicante"],
+    "Almería": ["Almería"],
+    "Asturias": ["Oviedo"],
+    "Ávila": ["Ávila"],
+    "Badajoz": ["Badajoz"],
+    "Barcelona": ["Barcelona"],
+    "Burgos": ["Burgos"],
+    "Cáceres": ["Cáceres"],
+    "Cádiz": ["Cádiz"],
+    "Cantabria": ["Santander"],
+    "Castellón": ["Castellón de la Plana"],
+    "Ciudad Real": ["Ciudad Real"],
+    "Córdoba": ["Córdoba"],
+    "Cuenca": ["Cuenca"],
+    "Girona": ["Girona"],
+    "Granada": ["Granada"],
+    "Guadalajara": ["Guadalajara"],
+    "Guipúzcoa": ["San Sebastián"],
+    "Huelva": ["Huelva"],
+    "Huesca": ["Huesca"],
+    "Islas Baleares": ["Palma de Mallorca"],
+    "Jaén": ["Jaén"],
+    "La Coruña": ["A Coruña"],
+    "La Rioja": ["Logroño"],
+    "Las Palmas": ["Las Palmas de Gran Canaria"],
+    "León": ["León"],
+    "Lérida": ["Lleida"],
+    "Lugo": ["Lugo"],
+    "Madrid": ["Madrid"],
+    "Málaga": ["Málaga"],
+    "Murcia": ["Murcia"],
+    "Navarra": ["Pamplona"],
+    "Orense": ["Ourense"],
+    "Palencia": ["Palencia"],
+    "Pontevedra": ["Pontevedra"],
+    "Salamanca": ["Salamanca"],
+    "Santa Cruz de Tenerife": ["Santa Cruz de Tenerife"],
+    "Segovia": ["Segovia"],
+    "Sevilla": ["Sevilla"],
+    "Soria": ["Soria"],
+    "Tarragona": ["Tarragona"],
+    "Teruel": ["Teruel"],
+    "Toledo": ["Toledo"],
+    "Valencia": ["Valencia"],
+    "Valladolid": ["Valladolid"],
+    "Vizcaya": ["Bilbao"],
+    "Zamora": ["Zamora"],
+    "Zaragoza": ["Zaragoza"],
+    "Ceuta": ["Ceuta"],
+    "Melilla": ["Melilla"],
+}
+
+# Reverse lookup from city to province, useful when an existing city
+# is stored but its province needs to be inferred.
+CITY_TO_PROVINCE = {
+    city: province
+    for province, cities in PROVINCE_CITIES.items()
+    for city in cities
+}
+

--- a/static/js/location-select.js
+++ b/static/js/location-select.js
@@ -1,0 +1,164 @@
+// Handles dependent dropdowns for country/region/province/city in the club dashboard
+
+document.addEventListener('DOMContentLoaded', function () {
+  const country = document.getElementById('id_country');
+  const region = document.getElementById('id_region');
+  const province = document.getElementById('id_province');
+  const city = document.getElementById('id_city');
+
+  if (!country || !region || !province || !city) return;
+
+  const provincesByRegion = {
+    'Andalucía': ['Almería', 'Cádiz', 'Córdoba', 'Granada', 'Huelva', 'Jaén', 'Málaga', 'Sevilla'],
+    'Aragón': ['Huesca', 'Teruel', 'Zaragoza'],
+    'Asturias': ['Asturias'],
+    'Islas Baleares': ['Islas Baleares'],
+    'Canarias': ['Las Palmas', 'Santa Cruz de Tenerife'],
+    'Cantabria': ['Cantabria'],
+    'Castilla-La Mancha': ['Albacete', 'Ciudad Real', 'Cuenca', 'Guadalajara', 'Toledo'],
+    'Castilla y León': ['Ávila', 'Burgos', 'León', 'Palencia', 'Salamanca', 'Segovia', 'Soria', 'Valladolid', 'Zamora'],
+    'Cataluña': ['Barcelona', 'Girona', 'Lérida', 'Tarragona'],
+    'Comunidad Valenciana': ['Alicante', 'Castellón', 'Valencia'],
+    'Extremadura': ['Badajoz', 'Cáceres'],
+    'Galicia': ['La Coruña', 'Lugo', 'Orense', 'Pontevedra'],
+    'Madrid': ['Madrid'],
+    'Murcia': ['Murcia'],
+    'Navarra': ['Navarra'],
+    'País Vasco': ['Álava', 'Guipúzcoa', 'Vizcaya'],
+    'La Rioja': ['La Rioja'],
+    'Ceuta': ['Ceuta'],
+    'Melilla': ['Melilla']
+  };
+
+  const citiesByProvince = {
+    'Álava': ['Vitoria-Gasteiz'],
+    'Albacete': ['Albacete'],
+    'Alicante': ['Alicante'],
+    'Almería': ['Almería'],
+    'Asturias': ['Oviedo'],
+    'Ávila': ['Ávila'],
+    'Badajoz': ['Badajoz'],
+    'Barcelona': ['Barcelona'],
+    'Burgos': ['Burgos'],
+    'Cáceres': ['Cáceres'],
+    'Cádiz': ['Cádiz'],
+    'Cantabria': ['Santander'],
+    'Castellón': ['Castellón de la Plana'],
+    'Ciudad Real': ['Ciudad Real'],
+    'Córdoba': ['Córdoba'],
+    'Cuenca': ['Cuenca'],
+    'Girona': ['Girona'],
+    'Granada': ['Granada'],
+    'Guadalajara': ['Guadalajara'],
+    'Guipúzcoa': ['San Sebastián'],
+    'Huelva': ['Huelva'],
+    'Huesca': ['Huesca'],
+    'Islas Baleares': ['Palma de Mallorca'],
+    'Jaén': ['Jaén'],
+    'La Coruña': ['A Coruña'],
+    'La Rioja': ['Logroño'],
+    'Las Palmas': ['Las Palmas de Gran Canaria'],
+    'León': ['León'],
+    'Lérida': ['Lleida'],
+    'Lugo': ['Lugo'],
+    'Madrid': ['Madrid'],
+    'Málaga': ['Málaga'],
+    'Murcia': ['Murcia'],
+    'Navarra': ['Pamplona'],
+    'Orense': ['Ourense'],
+    'Palencia': ['Palencia'],
+    'Pontevedra': ['Pontevedra'],
+    'Salamanca': ['Salamanca'],
+    'Santa Cruz de Tenerife': ['Santa Cruz de Tenerife'],
+    'Segovia': ['Segovia'],
+    'Sevilla': ['Sevilla'],
+    'Soria': ['Soria'],
+    'Tarragona': ['Tarragona'],
+    'Teruel': ['Teruel'],
+    'Toledo': ['Toledo'],
+    'Valencia': ['Valencia'],
+    'Valladolid': ['Valladolid'],
+    'Vizcaya': ['Bilbao'],
+    'Zamora': ['Zamora'],
+    'Zaragoza': ['Zaragoza'],
+    'Ceuta': ['Ceuta'],
+    'Melilla': ['Melilla']
+  };
+
+  const provinceInitial = province.value;
+  const cityInitial = city.value;
+  if (provinceInitial) province.dataset.initial = provinceInitial;
+  if (cityInitial) city.dataset.initial = cityInitial;
+
+  function clearOptions(select) {
+    select.innerHTML = '<option value=""></option>';
+  }
+
+  function updateCities() {
+    const selectedProvince = province.value;
+    const currentCity = city.dataset.initial || city.value;
+    clearOptions(city);
+    if (selectedProvince && citiesByProvince[selectedProvince]) {
+      citiesByProvince[selectedProvince].forEach(function (c) {
+        const opt = document.createElement('option');
+        opt.value = c;
+        opt.textContent = c;
+        city.appendChild(opt);
+      });
+      city.disabled = false;
+      if (citiesByProvince[selectedProvince].includes(currentCity)) {
+        city.value = currentCity;
+      }
+    } else {
+      city.disabled = true;
+    }
+    city.dataset.initial = '';
+  }
+
+  function updateProvinces() {
+    const selectedRegion = region.value;
+    const currentProvince = province.dataset.initial || province.value;
+    clearOptions(province);
+    clearOptions(city);
+    if (selectedRegion && provincesByRegion[selectedRegion]) {
+      provincesByRegion[selectedRegion].forEach(function (p) {
+        const opt = document.createElement('option');
+        opt.value = p;
+        opt.textContent = p;
+        province.appendChild(opt);
+      });
+      province.disabled = false;
+      if (provincesByRegion[selectedRegion].includes(currentProvince)) {
+        province.value = currentProvince;
+      }
+    } else {
+      province.disabled = true;
+      city.disabled = true;
+    }
+    province.dataset.initial = '';
+    updateCities();
+  }
+
+  function updateByCountry() {
+    if (country.value === 'España') {
+      region.parentElement.style.display = '';
+      province.parentElement.style.display = '';
+      region.disabled = false;
+      updateProvinces();
+    } else {
+      region.parentElement.style.display = 'none';
+      province.parentElement.style.display = 'none';
+      province.disabled = true;
+      city.disabled = false;
+      clearOptions(province);
+      clearOptions(city);
+    }
+  }
+
+  country.addEventListener('change', updateByCountry);
+  region.addEventListener('change', updateProvinces);
+  province.addEventListener('change', updateCities);
+
+  updateByCountry();
+});
+

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1590,6 +1590,7 @@
 <script src="{% static 'js/feature-select.js' %}"></script>
 <script src="{% static 'js/avatar-dropzone.js' %}"></script>
 <script src="{% static 'js/slug-check.js' %}"></script>
+<script src="{% static 'js/location-select.js' %}"></script>
 <script src="{% static 'js/schedule-form.js' %}"></script>
 <script src="{% static 'js/gallery-manager.js' %}"></script>
 <script src="{% static 'js/delete-confirm.js' %}"></script>


### PR DESCRIPTION
## Summary
- show provinces only after selecting a region and cities after selecting a province on the dashboard
- hide region and province fields when country is not Spain and allow free-form city
- include client script and data mappings for Spanish regions, provinces and cities

## Testing
- `python manage.py test` *(no tests discovered)*
- `python manage.py test apps.clubs.tests.MessageConversationTests apps.clubs.tests.UserReviewFirstTests -v 2` *(errors: `ClubMessage` and `Reseña` not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6893ebe48964832189d3a80e953ba139