### PR TITLE
Add loader animation to image dropzones

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -241,6 +241,17 @@
   cursor: pointer;
 }
 
+/* Loader overlay for dropzones */
+.dropzone-loader {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: inherit;
+}
+
 /* Square variant for club logos */
 .avatar-dropzone.avatar-dropzone-square {
   width: 200px;

--- a/static/js/avatar-dropzone.js
+++ b/static/js/avatar-dropzone.js
@@ -22,17 +22,26 @@ function initAvatarDropzones(root = document) {
     removeBtn.className = 'avatar-remove-btn';
     removeBtn.innerHTML = '<i class="bi bi-trash"></i>';
     zone.appendChild(removeBtn);
+    const loader = document.createElement('div');
+    loader.className = 'dropzone-loader d-none';
+    loader.innerHTML =
+      '<div class="spinner-border" role="status"><span class="visually-hidden">Cargando...</span></div>';
+    preview.appendChild(loader);
+
     if (!input || !preview) return;
 
     const showFile = file => {
       if (!file) return;
+      loader.classList.remove('d-none');
       const reader = new FileReader();
       reader.onload = e => {
         preview.style.backgroundImage = `url('${e.target.result}')`;
         preview.classList.add('has-image');
         if (msg) msg.style.visibility = 'hidden';
         updateState();
+        loader.classList.add('d-none');
       };
+      reader.onerror = () => loader.classList.add('d-none');
       reader.readAsDataURL(file);
     };
 
@@ -42,6 +51,7 @@ function initAvatarDropzones(root = document) {
       preview.classList.remove('has-image');
       if (clearCheckbox) clearCheckbox.checked = true;
       if (msg) msg.style.visibility = '';
+      loader.classList.add('d-none');
       updateState();
     };
 
@@ -83,6 +93,14 @@ function initAvatarDropzones(root = document) {
     });
 
     updateState();
+    const form = zone.closest('form');
+    if (form) {
+      form.addEventListener('submit', () => {
+        if (input.files.length) {
+          loader.classList.remove('d-none');
+        }
+      });
+    }
     zone.dataset.initialized = 'true';
   });
 }

--- a/static/js/gallery-manager.js
+++ b/static/js/gallery-manager.js
@@ -4,6 +4,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const msg = zone.querySelector('.photo-dropzone-msg');
     const text = msg && msg.querySelector('span');
     if (!input || !msg || !text) return;
+    const loader = document.createElement('div');
+    loader.className = 'dropzone-loader d-none';
+    loader.innerHTML =
+      '<div class="spinner-border" role="status"><span class="visually-hidden">Cargando...</span></div>';
+    zone.appendChild(loader);
     const showCount = () => {
       if (input.files.length) {
         text.textContent = `${input.files.length} archivo(s) seleccionado(s)`;
@@ -12,7 +17,20 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     };
     zone.addEventListener('click', () => input.click());
-    input.addEventListener('change', showCount);
+    input.addEventListener('change', () => {
+      showCount();
+      if (input.files.length) {
+        loader.classList.remove('d-none');
+      }
+    });
+    const form = zone.closest('form');
+    if (form) {
+      form.addEventListener('submit', () => {
+        if (input.files.length) {
+          loader.classList.remove('d-none');
+        }
+      });
+    }
   });
 
   const uploadForm = document.getElementById('upload-form');
@@ -20,9 +38,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const uploadBtn = document.getElementById('add-photos-btn');
 
   if (uploadForm && uploadInput && uploadBtn) {
+    uploadForm.style.position = 'relative';
+    const loader = document.createElement('div');
+    loader.className = 'dropzone-loader d-none';
+    loader.innerHTML =
+      '<div class="spinner-border" role="status"><span class="visually-hidden">Cargando...</span></div>';
+    uploadForm.appendChild(loader);
     uploadBtn.addEventListener('click', () => uploadInput.click());
     uploadInput.addEventListener('change', () => {
       if (uploadInput.files.length) {
+        loader.classList.remove('d-none');
         uploadForm.submit();
       }
     });


### PR DESCRIPTION
## Summary
- add generic dropzone loader overlay style
- show loading spinner for avatar dropzones while previewing and submitting
- display upload spinner in gallery dropzone and auto-upload form

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893f647087c83218dc27d2ad9c68a3d