### PR TITLE
Use club slug for owner profile usernames

### DIFF
--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -44,12 +44,27 @@
                     </div>
                     {% endif %}
                 </div>
+                {% if is_owner %}
+                <div class="form-field slug-field always-active">
+                    <span class="username-prefix">@</span>
+                    {{ club_form.slug }}
+                    <span id="slug-status"></span>
+                    <button type="button" class="clear-btn bi bi-x"></button>
+                    <label for="{{ club_form.slug.id_for_label }}">{{ club_form.slug.label }}</label>
+                    <div id="slug-error" class="invalid-feedback {% if club_form.slug.errors %}d-block{% else %}d-none{% endif %}">
+                        {% if club_form.slug.errors %}
+                        {{ club_form.slug.errors.as_text|striptags }}
+                        {% endif %}
+                    </div>
+                </div>
+                {% else %}
                 <div class="form-field slug-field always-active">
                     <span class="username-prefix">@</span>
                     {{ form.username }}
                     <button type="button" class="clear-btn bi bi-x"></button>
                     <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
                 </div>
+                {% endif %}
                 <div class="form-field">
                     {{ form.email }}
                     <button type="button" class="clear-btn bi bi-x"></button>
@@ -70,19 +85,7 @@
                     <label for="{{ form.notifications.id_for_label }}">{{ form.notifications.label }}</label>
                 </div>
 
-                {% if club_form %}
-                <div class="form-field slug-field">
-                    <span class="username-prefix">@</span>
-                    {{ club_form.slug }}
-                    <span id="slug-status"></span>
-                    <button type="button" class="clear-btn bi bi-x"></button>
-                    <label for="{{ club_form.slug.id_for_label }}">{{ club_form.slug.label }}</label>
-                    <div id="slug-error" class="invalid-feedback {% if club_form.slug.errors %}d-block{% else %}d-none{% endif %}">
-                      {% if club_form.slug.errors %}
-                      {{ club_form.slug.errors.as_text|striptags }}
-                      {% endif %}
-                    </div>
-                </div>
+                {% if is_owner and club_form %}
 
                 <div class="row g-3">
                     <div class="form-field col-md-6">
@@ -335,7 +338,7 @@
 <script src="{% static 'js/clear-input.js' %}"></script>
 <script src="{% static 'js/avatar-dropzone.js' %}"></script>
 <script src="{% static 'js/plan-cards.js' %}"></script>
-{% if club_form %}
+{% if is_owner %}
 <script src="{% static 'js/slug-check.js' %}"></script>
 <script src="{% static 'js/location-select.js' %}"></script>
 {% endif %}


### PR DESCRIPTION
## Summary
- Only show club slug as the username field for owners
- Hide address-related fields for non-owner profiles
- Auto-fill owner username from submitted slug in profile view

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689409847f5483219aa5bacaa8473de1