### PR TITLE
Show owner club name and tweak profile for club owners

### DIFF
--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -33,24 +33,33 @@
         {% endif %}
 
         <ul class="navbar-nav align-items-center ms-auto">
-                {% if request.resolver_match.url_name == 'club_dashboard' %}
+                {% if user.is_authenticated and user.owned_clubs.first %}
+                {% with owner_club=user.owned_clubs.first %}
                 <li class="nav-item d-flex align-items-center ms-2">
                     <a
-                        href="{% url 'club_profile' club.slug %}"
+                        href="{% url 'club_profile' owner_club.slug %}"
                         class="fw-bold"
                     >
-                        <span class="me-1 text-dark">{{ club.name }}</span>
+                        <span class="me-1 text-dark">{{ owner_club.name }}</span>
                         <i class="bi bi-eye-fill"></i>
                     </a>
                 </li>
-                {% endif %} {% if user.is_authenticated %}
+                {% endwith %}
+                {% endif %}
+                {% if user.is_authenticated %}
                 <li class="nav-item">
                     <div
                         class="custom-dropdown p-0 small ms-4"
                         id="user-dropdown"
                     >
                         <div class="selected d-flex align-items-center">
-                            {% if user.profile.avatar %}
+                            {% if user.owned_clubs.first and user.owned_clubs.first.logo %}
+                            <img
+                                src="{{ user.owned_clubs.first.logo.url }}"
+                                alt="{{ user.username }}"
+                                class="nav-avatar-img"
+                            />
+                            {% elif user.profile.avatar %}
                             <img
                                 src="{{ user.profile.avatar.url }}"
                                 alt="{{ user.username }}"

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -38,10 +38,6 @@
                         {{ form.avatar.errors.as_text|striptags }}
                     </div>
                     {% endif %}
-                    {% else %}
-                    <div class="avatar-dropzone mx-auto">
-                        <div class="avatar-preview{% if avatar_url %} has-image{% endif %}"{% if avatar_url %} style="background-image:url('{{ avatar_url }}')"{% endif %}></div>
-                    </div>
                     {% endif %}
                 </div>
                 {% if is_owner %}
@@ -200,12 +196,16 @@
 
                 <div class="d-flex gap-3 mb-4">
                     <button type="submit" class="btn btn-dark">Guardar cambios</button>
+                    {% if not is_owner %}
                     <button type="submit" class="btn btn-danger" form="delete-account-form">Eliminar cuenta</button>
+                    {% endif %}
                 </div>
             </form>
+            {% if not is_owner %}
             <form id="delete-account-form" action="{% url 'delete_account' %}" method="post" class="d-none">
                 {% csrf_token %}
             </form>
+            {% endif %}
         </div>
         {% if is_owner %}
         <div id="tab-plans" class="profile-section">


### PR DESCRIPTION
## Summary
- Always display the owner's club name and logo in the navigation header
- Hide avatar upload and delete-account option for club owners on the profile page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68940c77c26083218eed532780212c06