### PR TITLE
Align password toggle with clear button

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -123,6 +123,21 @@
   margin-right: 3px;
 }
 
+.profile-form .with-toggle .clear-btn {
+  right: 40px;
+}
+
+.profile-form .toggle-password {
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
 .profile-form textarea + .clear-btn {
   display: none !important;
 }

--- a/templates/partials/_login-form.html
+++ b/templates/partials/_login-form.html
@@ -22,7 +22,7 @@
                 </div>
 
 
-                <div class="form-field">
+                <div class="form-field with-toggle">
                   <button type="button" class="clear-btn bi bi-x"></button>
                   <button type="button" class="toggle-password">👁</button>
                     <input type="password"

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -76,23 +76,25 @@
 </div>
 
 <!-- Password1 -->
-<div class="form-field">
+<div class="form-field with-toggle">
     <button type="button" class="clear-btn bi bi-x"></button>
+    <button type="button" class="toggle-password">👁</button>
     <input type="password" name="{{ form.password1.name }}" class="form-control" id="{{ form.password1.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
-    
+
     <label for="{{ form.password1.id_for_label }}">{{ form.password1.label }}</label>
     {% if form.password1.errors %}
       <div class="invalid-feedback d-block">
         {{ form.password1.errors.as_text|striptags }}
       </div>
-    {% endif %} 
+    {% endif %}
 </div>
     <small style="position:relative; top:-15px; font-size:12px;" class="form-text text-muted">La contraseña debe tener al menos 6 caracteres e incluir mayúsculas, minúsculas y números.</small>
 
 
 <!-- Password2 -->
-<div class="form-field">
+<div class="form-field with-toggle">
     <button type="button" class="clear-btn bi bi-x"></button>
+    <button type="button" class="toggle-password">👁</button>
     <input type="password" name="{{ form.password2.name }}" class="form-control" id="{{ form.password2.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
     <label for="{{ form.password2.id_for_label }}">{{ form.password2.label }}</label>
     {% if form.password2.errors %}
@@ -128,8 +130,9 @@
   </main> 
 </div> 
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
-<script src="{% static 'js/page-loader.js' %}"></script>
-<script src="{% static 'js/clear-input.js' %}"></script>
-</body>
-</html>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{% static 'js/page-loader.js' %}"></script>
+  <script src="{% static 'js/clear-input.js' %}"></script>
+  <script src="{% static 'js/toggle-password.js' %}"></script>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- Position password visibility toggle and clear button side by side within form fields
- Add password visibility toggle to registration form and hook up script

## Testing
- `python manage.py test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68942d6cafb083218eeae4ba8a752829