### PR TITLE
Integrar intl-tel-input para prefijos telefónicos

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -265,6 +265,12 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
                 field.widget.attrs['minlength'] = 3
                 field.required = True
 
+        prefijo_field = self.fields.get('prefijo')
+        if prefijo_field:
+            self.initial.setdefault('prefijo', '+34')
+            css = prefijo_field.widget.attrs.get('class', '')
+            prefijo_field.widget.attrs['class'] = (css + ' prefijo-input').strip()
+
     def clean_slug(self):
         slug = self.cleaned_data.get('slug', '').lstrip('@')
         if len(slug) < 3:
@@ -483,6 +489,12 @@ class MiembroForm(UniformFieldsMixin, forms.ModelForm):
                 forms.TimeInput,
             )):
                 field.widget.attrs.setdefault('placeholder', ' ')
+
+        prefijo_field = self.fields.get('prefijo')
+        if prefijo_field:
+            self.initial.setdefault('prefijo', '+34')
+            css = prefijo_field.widget.attrs.get('class', '')
+            prefijo_field.widget.attrs['class'] = (css + ' prefijo-input').strip()
 
         # Custom placeholders
         if 'peso' in self.fields:

--- a/static/js/phone-prefix.js
+++ b/static/js/phone-prefix.js
@@ -1,0 +1,17 @@
+// Initialize intl-tel-input for prefix fields
+// Applies to inputs with class 'prefijo-input'
+document.addEventListener('DOMContentLoaded', function () {
+  const inputs = document.querySelectorAll('input.prefijo-input');
+  inputs.forEach(function (input) {
+    const iti = window.intlTelInput(input, {
+      initialCountry: 'es',
+      separateDialCode: true,
+      utilsScript: 'https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.19/build/js/utils.js'
+    });
+    input.setAttribute('readonly', true);
+    input.value = '+' + iti.getSelectedCountryData().dialCode;
+    input.addEventListener('countrychange', function () {
+      input.value = '+' + iti.getSelectedCountryData().dialCode;
+    });
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/svg+xml" href="{% static 'img/logo.svg' %}">
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css">
+   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.19/build/css/intlTelInput.css">
   {% load_css_files %}
 
 </head>
@@ -42,6 +43,8 @@
 <script src="{% static 'js/page-loader.js' %}"></script>
 <script src="{% static 'js/clear-input.js' %}"></script>
 <script src="{% static 'js/select-label.js' %}"></script>
+<script src="https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.19/build/js/intlTelInput.min.js"></script>
+<script src="{% static 'js/phone-prefix.js' %}"></script>
 {% block extra_js %}{% endblock %}
 
 </body>


### PR DESCRIPTION
## Summary
- Usa intl-tel-input para los campos de prefijo de Club y Miembro
- Incluye assets y script de inicialización

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894923e33008321ab63679f8e5f395a