### PR TITLE
Habilitar selector de prefijo telefónico

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -71,14 +71,14 @@
 .profile-form .form-field label {
   position: absolute;
   left: 0;
-  margin-left:15px;
-  top: 50%;
+  margin-left: 15px;
+  top: 0;
   transform: translateY(-50%);
   background: white;
   padding: 0 0.25rem;
-  color: #666;
+  color: #000;
   pointer-events: none;
-  transition: transform 0.2s, font-size 0.2s, color 0.2s;
+  font-size: 0.7rem;
 }
 
 .profile-form .checkbox-field label {
@@ -98,17 +98,7 @@
   padding: 0;
 }
 
-.profile-form .form-field input:not(:placeholder-shown) ~ label,
-.profile-form .form-field input:focus ~ label,
-.profile-form .form-field textarea:not(:placeholder-shown) ~ label,
-.profile-form .form-field textarea:focus ~ label,
-.profile-form .form-field select.has-value ~ label,
-.profile-form .form-field select:focus ~ label {
-  top: 0;
-  transform: translateY(-50%);
-  font-size: 0.7rem;
-  color: #000;
-}
+
 
 .profile-form .clear-btn {
   position: absolute;
@@ -185,6 +175,11 @@
 }
 #id_notas{
   height:50px;
+}
+
+/* Remove background color from phone prefix flag */
+.iti__selected-flag {
+  background-color: transparent !important;
 }
 
 /* Avatar dropzone styles */

--- a/static/js/phone-prefix.js
+++ b/static/js/phone-prefix.js
@@ -8,10 +8,25 @@ document.addEventListener('DOMContentLoaded', function () {
       separateDialCode: true,
       utilsScript: 'https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.19/build/js/utils.js'
     });
-    input.setAttribute('readonly', true);
+
     input.value = '+' + iti.getSelectedCountryData().dialCode;
+
+    // Keep value in sync when the selected country changes
     input.addEventListener('countrychange', function () {
       input.value = '+' + iti.getSelectedCountryData().dialCode;
+    });
+
+    // Open the country dropdown when the input itself is clicked
+    input.addEventListener('click', function () {
+      const flag = input.parentNode.querySelector('.iti__selected-flag');
+      if (flag) {
+        flag.click();
+      }
+    });
+
+    // Prevent manual text editing while allowing dropdown interaction
+    input.addEventListener('keydown', function (e) {
+      e.preventDefault();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Permite abrir el selector de países al hacer clic en el campo de prefijo
- Mantiene las etiquetas de los campos siempre visibles y sin fondo en la bandera

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894963f374083219265d0bd71f5392e