### PR TITLE
Ajustar prefijo y formatear teléfono

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -271,6 +271,13 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
             css = prefijo_field.widget.attrs.get('class', '')
             prefijo_field.widget.attrs['class'] = (css + ' prefijo-input').strip()
 
+        phone_field = self.fields.get('phone')
+        if phone_field:
+            css = phone_field.widget.attrs.get('class', '')
+            phone_field.widget.attrs['class'] = (css + ' telefono-input').strip()
+            phone_field.widget.attrs['pattern'] = '\\d{3}\\.\\d{2}\\.\\d{2}\\.\\d{2}'
+            phone_field.widget.attrs['maxlength'] = '12'
+
     def clean_slug(self):
         slug = self.cleaned_data.get('slug', '').lstrip('@')
         if len(slug) < 3:
@@ -495,6 +502,13 @@ class MiembroForm(UniformFieldsMixin, forms.ModelForm):
             self.initial.setdefault('prefijo', '+34')
             css = prefijo_field.widget.attrs.get('class', '')
             prefijo_field.widget.attrs['class'] = (css + ' prefijo-input').strip()
+
+        telefono_field = self.fields.get('telefono')
+        if telefono_field:
+            css = telefono_field.widget.attrs.get('class', '')
+            telefono_field.widget.attrs['class'] = (css + ' telefono-input').strip()
+            telefono_field.widget.attrs['pattern'] = '\\d{3}\\.\\d{2}\\.\\d{2}\\.\\d{2}'
+            telefono_field.widget.attrs['maxlength'] = '12'
 
         # Custom placeholders
         if 'peso' in self.fields:

--- a/static/js/phone-prefix.js
+++ b/static/js/phone-prefix.js
@@ -1,5 +1,4 @@
-// Initialize intl-tel-input for prefix fields
-// Applies to inputs with class 'prefijo-input'
+// Initialize intl-tel-input for prefix fields and format phone inputs
 document.addEventListener('DOMContentLoaded', function () {
   const inputs = document.querySelectorAll('input.prefijo-input');
   inputs.forEach(function (input) {
@@ -9,24 +8,37 @@ document.addEventListener('DOMContentLoaded', function () {
       utilsScript: 'https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.19/build/js/utils.js'
     });
 
+    // Hide the input so only the dropdown is visible
+    input.style.display = 'none';
+
+    // Set initial value for form submission
     input.value = '+' + iti.getSelectedCountryData().dialCode;
 
     // Keep value in sync when the selected country changes
     input.addEventListener('countrychange', function () {
       input.value = '+' + iti.getSelectedCountryData().dialCode;
     });
+  });
 
-    // Open the country dropdown when the input itself is clicked
-    input.addEventListener('click', function () {
-      const flag = input.parentNode.querySelector('.iti__selected-flag');
-      if (flag) {
-        flag.click();
+  // Format phone fields as xxx.xx.xx.xx
+  const phoneInputs = document.querySelectorAll('input.telefono-input');
+  phoneInputs.forEach(function (input) {
+    input.addEventListener('input', function () {
+      const digits = input.value.replace(/\D/g, '').substring(0, 9);
+      let formatted = '';
+      if (digits.length > 0) {
+        formatted = digits.substring(0, 3);
       }
-    });
-
-    // Prevent manual text editing while allowing dropdown interaction
-    input.addEventListener('keydown', function (e) {
-      e.preventDefault();
+      if (digits.length >= 4) {
+        formatted += '.' + digits.substring(3, 5);
+      }
+      if (digits.length >= 6) {
+        formatted += '.' + digits.substring(5, 7);
+      }
+      if (digits.length >= 8) {
+        formatted += '.' + digits.substring(7, 9);
+      }
+      input.value = formatted;
     });
   });
 });

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -55,7 +55,6 @@
     <div class="col-md-2">
       <div class="form-field">
         {{ form.prefijo }}
-        <button type="button" class="clear-btn bi bi-x"></button>
         <label for="{{ form.prefijo.id_for_label }}">{{ form.prefijo.label }}</label>
         {% if form.prefijo.errors %}
         <div class="invalid-feedback d-block">

--- a/templates/clubs/_miembro_public_form.html
+++ b/templates/clubs/_miembro_public_form.html
@@ -55,7 +55,6 @@
     <div class="col-md-2">
       <div class="form-field">
         {{ form.prefijo }}
-        <button type="button" class="clear-btn bi bi-x"></button>
         <label for="{{ form.prefijo.id_for_label }}">{{ form.prefijo.label }}</label>
         {% if form.prefijo.errors %}
         <div class="invalid-feedback d-block">

--- a/templates/clubs/miembro_form.html
+++ b/templates/clubs/miembro_form.html
@@ -52,7 +52,6 @@
       <div class="col-md-2">
         <div class="form-field">
           {{ form.prefijo }}
-          <button type="button" class="clear-btn bi bi-x"></button>
           <label for="{{ form.prefijo.id_for_label }}">{{ form.prefijo.label }}</label>
           {% if form.prefijo.errors %}
           <div class="invalid-feedback d-block">

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -71,7 +71,6 @@
                     </div>
                       <div class="form-field col-md-2">
                         {{ club_form.prefijo }}
-                        <button type="button" class="clear-btn bi bi-x"></button>
                         <label for="{{ club_form.prefijo.id_for_label }}">{{ club_form.prefijo.label }}</label>
                         {% if club_form.prefijo.errors %}
                         <div class="invalid-feedback d-block">


### PR DESCRIPTION
## Summary
- Ocultar input del prefijo dejando solo el desplegable y sincronizando el valor
- Formatear automáticamente el teléfono como `xxx.xx.xx.xx` y validar el patrón

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68949a4bf6b483219cdc3327d1af0912