### PR TITLE
Combine prefix and phone fields

### DIFF
--- a/static/js/clear-input.js
+++ b/static/js/clear-input.js
@@ -1,6 +1,6 @@
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll(".form-field").forEach((field) => {
-    const input = field.querySelector("input, textarea, select");
+    const input = field.querySelector("input:not(.prefijo-input), textarea, select");
     const btn = field.querySelector(".clear-btn");
     if (!input || !btn) return;
 

--- a/static/js/phone-prefix.js
+++ b/static/js/phone-prefix.js
@@ -12,6 +12,35 @@ document.addEventListener('DOMContentLoaded', function () {
     input.value = '+' + iti.getSelectedCountryData().dialCode;
     input.addEventListener('countrychange', function () {
       input.value = '+' + iti.getSelectedCountryData().dialCode;
+      const phoneInput = input.closest('.form-field').querySelector('input.phone-input');
+      if (phoneInput) {
+        phoneInput.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    });
+  });
+
+  const phoneInputs = document.querySelectorAll('input.phone-input');
+  const format = (input) => {
+    const prefijo = input.closest('.form-field')?.querySelector('input.prefijo-input')?.value || '';
+    let digits = input.value.replace(/\D/g, '');
+    if (prefijo === '+34') {
+      digits = digits.slice(0, 9);
+    } else {
+      digits = digits.slice(0, 15);
+    }
+    const parts = [];
+    if (digits.length > 0) parts.push(digits.slice(0, 3));
+    if (digits.length >= 4) parts.push(digits.slice(3, 5));
+    if (digits.length >= 6) parts.push(digits.slice(5, 7));
+    if (digits.length >= 8) parts.push(digits.slice(7, 9));
+    if (digits.length > 9) parts.push(digits.slice(9));
+    input.value = parts.filter(Boolean).join(' ').trim();
+  };
+
+  phoneInputs.forEach(function (input) {
+    format(input);
+    input.addEventListener('input', function () {
+      format(input);
     });
   });
 });

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -52,23 +52,19 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md-2">
-      <div class="form-field">
-        {{ form.prefijo }}
+    <div class="col-md-6">
+      <div class="form-field phone-field">
+        <div class="d-flex gap-2">
+          {{ form.prefijo }}
+          {{ form.telefono }}
+        </div>
         <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.prefijo.id_for_label }}">{{ form.prefijo.label }}</label>
+        <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
         {% if form.prefijo.errors %}
         <div class="invalid-feedback d-block">
           {{ form.prefijo.errors.as_text|striptags }}
         </div>
         {% endif %}
-      </div>
-    </div>
-    <div class="col-md-4">
-      <div class="form-field">
-        {{ form.telefono }}
-        <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
         {% if form.telefono.errors %}
         <div class="invalid-feedback d-block">
           {{ form.telefono.errors.as_text|striptags }}

--- a/templates/clubs/_miembro_public_form.html
+++ b/templates/clubs/_miembro_public_form.html
@@ -52,23 +52,19 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md-2">
-      <div class="form-field">
-        {{ form.prefijo }}
+    <div class="col-md-6">
+      <div class="form-field phone-field">
+        <div class="d-flex gap-2">
+          {{ form.prefijo }}
+          {{ form.telefono }}
+        </div>
         <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.prefijo.id_for_label }}">{{ form.prefijo.label }}</label>
+        <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
         {% if form.prefijo.errors %}
         <div class="invalid-feedback d-block">
           {{ form.prefijo.errors.as_text|striptags }}
         </div>
         {% endif %}
-      </div>
-    </div>
-    <div class="col-md-4">
-      <div class="form-field">
-        {{ form.telefono }}
-        <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
         {% if form.telefono.errors %}
         <div class="invalid-feedback d-block">
           {{ form.telefono.errors.as_text|striptags }}

--- a/templates/clubs/miembro_form.html
+++ b/templates/clubs/miembro_form.html
@@ -49,23 +49,19 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-md-2">
-        <div class="form-field">
-          {{ form.prefijo }}
+      <div class="col-md-6">
+        <div class="form-field phone-field">
+          <div class="d-flex gap-2">
+            {{ form.prefijo }}
+            {{ form.telefono }}
+          </div>
           <button type="button" class="clear-btn bi bi-x"></button>
-          <label for="{{ form.prefijo.id_for_label }}">{{ form.prefijo.label }}</label>
+          <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
           {% if form.prefijo.errors %}
           <div class="invalid-feedback d-block">
             {{ form.prefijo.errors.as_text|striptags }}
           </div>
           {% endif %}
-        </div>
-      </div>
-      <div class="col-md-4">
-        <div class="form-field">
-          {{ form.telefono }}
-          <button type="button" class="clear-btn bi bi-x"></button>
-          <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
           {% if form.telefono.errors %}
           <div class="invalid-feedback d-block">
             {{ form.telefono.errors.as_text|striptags }}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -69,20 +69,18 @@
                         <button type="button" class="clear-btn bi bi-x"></button>
                         <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
                     </div>
-                      <div class="form-field col-md-2">
-                        {{ club_form.prefijo }}
+                    <div class="form-field col-md-6 phone-field">
+                        <div class="d-flex gap-2">
+                            {{ club_form.prefijo }}
+                            {{ club_form.phone }}
+                        </div>
                         <button type="button" class="clear-btn bi bi-x"></button>
-                        <label for="{{ club_form.prefijo.id_for_label }}">{{ club_form.prefijo.label }}</label>
+                        <label for="{{ club_form.phone.id_for_label }}">{{ club_form.phone.label }}</label>
                         {% if club_form.prefijo.errors %}
                         <div class="invalid-feedback d-block">
                             {{ club_form.prefijo.errors.as_text|striptags }}
                         </div>
                         {% endif %}
-                    </div>
-                    <div class="form-field col-md-4">
-                        {{ club_form.phone }}
-                        <button type="button" class="clear-btn bi bi-x"></button>
-                        <label for="{{ club_form.phone.id_for_label }}">{{ club_form.phone.label }}</label>
                         {% if club_form.phone.errors %}
                         <div class="invalid-feedback d-block">
                             {{ club_form.phone.errors.as_text|striptags }}


### PR DESCRIPTION
## Summary
- Merge prefix and phone inputs into one phone field with dropdown prefix
- Format phone numbers and limit Spanish numbers to nine digits
- Adjust clear button handling for combined phone field

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894ab61871c8321a53b52423ef5f8ec