### PR TITLE
Integrate phone prefix dropdown

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -269,8 +269,7 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
         prefijo_field = self.fields.get('prefijo')
         if prefijo_field:
             self.initial.setdefault('prefijo', '+34')
-            css = prefijo_field.widget.attrs.get('class', '')
-            prefijo_field.widget.attrs['class'] = (css + ' prefijo-input').strip()
+            prefijo_field.widget = forms.HiddenInput(attrs={'class': 'prefijo-input'})
 
         telefono_field = self.fields.get('telefono')
         if telefono_field:
@@ -513,8 +512,7 @@ class MiembroForm(UniformFieldsMixin, forms.ModelForm):
         prefijo_field = self.fields.get('prefijo')
         if prefijo_field:
             self.initial.setdefault('prefijo', '+34')
-            css = prefijo_field.widget.attrs.get('class', '')
-            prefijo_field.widget.attrs['class'] = (css + ' prefijo-input').strip()
+            prefijo_field.widget = forms.HiddenInput(attrs={'class': 'prefijo-input'})
 
         # Custom placeholders
         if 'peso' in self.fields:

--- a/static/js/phone-prefix.js
+++ b/static/js/phone-prefix.js
@@ -1,25 +1,33 @@
-// Initialize intl-tel-input for prefix fields
-// Applies to inputs with class 'prefijo-input'
+// Initialize intl-tel-input on phone fields
 document.addEventListener('DOMContentLoaded', function () {
-  const inputs = document.querySelectorAll('input.prefijo-input');
-  inputs.forEach(function (input) {
+  const phoneInputs = document.querySelectorAll('input.phone-input');
+  phoneInputs.forEach(function (input) {
     const iti = window.intlTelInput(input, {
       initialCountry: 'es',
       separateDialCode: true,
       utilsScript: 'https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.19/build/js/utils.js'
     });
-    input.setAttribute('readonly', true);
-    input.value = '+' + iti.getSelectedCountryData().dialCode;
-    input.addEventListener('countrychange', function () {
-      input.value = '+' + iti.getSelectedCountryData().dialCode;
-      const phoneInput = input.closest('.form-field').querySelector('input.phone-input');
-      if (phoneInput) {
-        phoneInput.dispatchEvent(new Event('input', { bubbles: true }));
+    const prefijoInput = input.closest('.form-field')?.querySelector('input.prefijo-input');
+    if (prefijoInput) {
+      if (prefijoInput.value) {
+        const code = prefijoInput.value.replace('+', '');
+        const country = window.intlTelInputGlobals
+          .getCountryData()
+          .find(c => c.dialCode === code);
+        if (country) {
+          iti.setCountry(country.iso2);
+        }
       }
+      prefijoInput.value = '+' + iti.getSelectedCountryData().dialCode;
+    }
+    input.addEventListener('countrychange', function () {
+      if (prefijoInput) {
+        prefijoInput.value = '+' + iti.getSelectedCountryData().dialCode;
+      }
+      input.dispatchEvent(new Event('input', { bubbles: true }));
     });
   });
 
-  const phoneInputs = document.querySelectorAll('input.phone-input');
   const format = (input) => {
     const prefijo = input.closest('.form-field')?.querySelector('input.prefijo-input')?.value || '';
     let digits = input.value.replace(/\D/g, '');
@@ -44,3 +52,4 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   });
 });
+

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -54,17 +54,10 @@
   <div class="row">
     <div class="col-md-6">
       <div class="form-field phone-field">
-        <div class="d-flex gap-2">
-          {{ form.prefijo }}
-          {{ form.telefono }}
-        </div>
+        {{ form.prefijo }}
+        {{ form.telefono }}
         <button type="button" class="clear-btn bi bi-x"></button>
         <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
-        {% if form.prefijo.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.prefijo.errors.as_text|striptags }}
-        </div>
-        {% endif %}
         {% if form.telefono.errors %}
         <div class="invalid-feedback d-block">
           {{ form.telefono.errors.as_text|striptags }}

--- a/templates/clubs/_miembro_public_form.html
+++ b/templates/clubs/_miembro_public_form.html
@@ -54,17 +54,10 @@
   <div class="row">
     <div class="col-md-6">
       <div class="form-field phone-field">
-        <div class="d-flex gap-2">
-          {{ form.prefijo }}
-          {{ form.telefono }}
-        </div>
+        {{ form.prefijo }}
+        {{ form.telefono }}
         <button type="button" class="clear-btn bi bi-x"></button>
         <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
-        {% if form.prefijo.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.prefijo.errors.as_text|striptags }}
-        </div>
-        {% endif %}
         {% if form.telefono.errors %}
         <div class="invalid-feedback d-block">
           {{ form.telefono.errors.as_text|striptags }}

--- a/templates/clubs/miembro_form.html
+++ b/templates/clubs/miembro_form.html
@@ -51,17 +51,10 @@
     <div class="row">
       <div class="col-md-6">
         <div class="form-field phone-field">
-          <div class="d-flex gap-2">
-            {{ form.prefijo }}
-            {{ form.telefono }}
-          </div>
+          {{ form.prefijo }}
+          {{ form.telefono }}
           <button type="button" class="clear-btn bi bi-x"></button>
           <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
-          {% if form.prefijo.errors %}
-          <div class="invalid-feedback d-block">
-            {{ form.prefijo.errors.as_text|striptags }}
-          </div>
-          {% endif %}
           {% if form.telefono.errors %}
           <div class="invalid-feedback d-block">
             {{ form.telefono.errors.as_text|striptags }}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -70,17 +70,10 @@
                         <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
                     </div>
                     <div class="form-field col-md-6 phone-field">
-                        <div class="d-flex gap-2">
-                            {{ club_form.prefijo }}
-                            {{ club_form.phone }}
-                        </div>
+                        {{ club_form.prefijo }}
+                        {{ club_form.phone }}
                         <button type="button" class="clear-btn bi bi-x"></button>
                         <label for="{{ club_form.phone.id_for_label }}">{{ club_form.phone.label }}</label>
-                        {% if club_form.prefijo.errors %}
-                        <div class="invalid-feedback d-block">
-                            {{ club_form.prefijo.errors.as_text|striptags }}
-                        </div>
-                        {% endif %}
                         {% if club_form.phone.errors %}
                         <div class="invalid-feedback d-block">
                             {{ club_form.phone.errors.as_text|striptags }}


### PR DESCRIPTION
## Summary
- Elimina el campo separado de prefijo en los formularios
- Añade dropdown de prefijo dentro del campo de teléfono usando intl-tel-input
- Deja España (+34) como opción por defecto

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6894ae871e608321966291d6d339bf67