### PR TITLE
Refine phone field appearance and placeholder

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -275,13 +275,13 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
         if telefono_field:
             css = telefono_field.widget.attrs.get('class', '')
             telefono_field.widget.attrs['class'] = (css + ' phone-input').strip()
-            telefono_field.widget.attrs['placeholder'] = 'Teléfono'
+            telefono_field.widget.attrs['placeholder'] = ' '
 
         phone_field = self.fields.get('phone')
         if phone_field:
             css = phone_field.widget.attrs.get('class', '')
             phone_field.widget.attrs['class'] = (css + ' phone-input').strip()
-            phone_field.widget.attrs['placeholder'] = 'Teléfono'
+            phone_field.widget.attrs['placeholder'] = ' '
 
         logo_widget = self.fields.get('logo')
         if logo_widget:

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -142,6 +142,21 @@
   display: none !important;
 }
 
+/* Phone field prefix tweaks */
+.profile-form .phone-field .iti--separate-dial-code .iti__flag-container,
+.profile-form .phone-field .iti--separate-dial-code .iti__selected-flag,
+.profile-form .phone-field .iti--separate-dial-code .iti__selected-dial-code {
+  background: none;
+}
+
+.profile-form .phone-field .iti--separate-dial-code .iti__selected-flag {
+  border-right: 1px solid #ddd;
+}
+
+.profile-form .phone-field label {
+  margin-left: 90px;
+}
+
 .profile-form .slug-field .username-prefix {
   position: absolute;
   left: 1.3rem;


### PR DESCRIPTION
## Summary
- Show phone field placeholder using floating label
- Style phone prefix area with transparent background and divider

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894b2953a3c83218bd9cb26d3e08f86