### PR TITLE
Align phone field label and clean country names

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -157,6 +157,15 @@
   margin-left: 90px;
 }
 
+.profile-form .phone-field input.phone-input {
+  margin-left: 3px;
+}
+
+.profile-form .phone-field input:not(:placeholder-shown) ~ label,
+.profile-form .phone-field input:focus ~ label {
+  margin-left: 15px;
+}
+
 .profile-form .slug-field .username-prefix {
   position: absolute;
   left: 1.3rem;

--- a/static/js/phone-prefix.js
+++ b/static/js/phone-prefix.js
@@ -7,6 +7,18 @@ document.addEventListener('DOMContentLoaded', function () {
       separateDialCode: true,
       utilsScript: 'https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.19/build/js/utils.js'
     });
+
+    const itiContainer = input.closest('.iti');
+    const cleanCountryNames = () => {
+      itiContainer
+        ?.querySelectorAll('.iti__country-name')
+        .forEach(el => {
+          el.textContent = el.textContent.replace(/\s*\([^)]*\)/, '');
+        });
+    };
+    cleanCountryNames();
+    input.addEventListener('open:countrydropdown', cleanCountryNames);
+
     const prefijoInput = input.closest('.form-field')?.querySelector('input.prefijo-input');
     if (prefijoInput) {
       if (prefijoInput.value) {


### PR DESCRIPTION
## Summary
- Ensure phone label floats above prefix and add slight left margin to phone input
- Strip localized duplicates from phone country dropdown names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894b572faac8321a222755e794a9dc7