### PR TITLE
Fix phone field layout and validation

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -275,13 +275,13 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
         if telefono_field:
             css = telefono_field.widget.attrs.get('class', '')
             telefono_field.widget.attrs['class'] = (css + ' phone-input').strip()
-            telefono_field.widget.attrs['placeholder'] = ' '
+            telefono_field.widget.attrs['placeholder'] = 'Telefono'
 
         phone_field = self.fields.get('phone')
         if phone_field:
             css = phone_field.widget.attrs.get('class', '')
             phone_field.widget.attrs['class'] = (css + ' phone-input').strip()
-            phone_field.widget.attrs['placeholder'] = ' '
+            phone_field.widget.attrs['placeholder'] = 'Telefono'
 
         logo_widget = self.fields.get('logo')
         if logo_widget:
@@ -300,8 +300,11 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
         phone = self.cleaned_data.get('phone', '')
         prefijo = self.cleaned_data.get('prefijo', '')
         digits = re.sub(r'\D', '', phone)
-        if prefijo == '+34' and len(digits) > 9:
-            raise forms.ValidationError('El teléfono debe tener 9 dígitos.')
+        if prefijo == '+34':
+            if len(digits) > 9:
+                raise forms.ValidationError('El teléfono debe tener 9 dígitos.')
+            if digits and digits[0] not in '679':
+                raise forms.ValidationError('Introduce un número de teléfono válido')
         return digits
 
     def save(self, commit=True):
@@ -514,6 +517,12 @@ class MiembroForm(UniformFieldsMixin, forms.ModelForm):
             self.initial.setdefault('prefijo', '+34')
             prefijo_field.widget = forms.HiddenInput(attrs={'class': 'prefijo-input'})
 
+        telefono_field = self.fields.get('telefono')
+        if telefono_field:
+            css = telefono_field.widget.attrs.get('class', '')
+            telefono_field.widget.attrs['class'] = (css + ' phone-input').strip()
+            telefono_field.widget.attrs['placeholder'] = 'Telefono'
+
         # Custom placeholders
         if 'peso' in self.fields:
             self.fields['peso'].widget.attrs['placeholder'] = 'peso (kg)'
@@ -550,8 +559,11 @@ class MiembroForm(UniformFieldsMixin, forms.ModelForm):
         telefono = self.cleaned_data.get('telefono', '')
         prefijo = self.cleaned_data.get('prefijo', '')
         digits = re.sub(r'\D', '', telefono)
-        if prefijo == '+34' and len(digits) > 9:
-            raise forms.ValidationError('El teléfono debe tener 9 dígitos.')
+        if prefijo == '+34':
+            if len(digits) > 9:
+                raise forms.ValidationError('El teléfono debe tener 9 dígitos.')
+            if digits and digits[0] not in '679':
+                raise forms.ValidationError('Introduce un número de teléfono válido')
         return digits
 
 

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -149,16 +149,29 @@
   background: none;
 }
 
+.profile-form .phone-field .iti--separate-dial-code .iti__flag-container {
+  padding: 0 2px;
+}
+
 .profile-form .phone-field .iti--separate-dial-code .iti__selected-flag {
   border-right: 1px solid #ddd;
+  padding: 0 2px;
 }
 
 .profile-form .phone-field label {
   margin-left: 90px;
 }
 
+.profile-form .phone-field .iti {
+  width: 100%;
+}
+
 .profile-form .phone-field input.phone-input {
-  margin-left: 3px;
+  margin-left: 0;
+}
+
+.profile-form .phone-field input:placeholder-shown ~ label {
+  display: none;
 }
 
 .profile-form .phone-field input:not(:placeholder-shown) ~ label,

--- a/static/js/phone-prefix.js
+++ b/static/js/phone-prefix.js
@@ -63,5 +63,23 @@ document.addEventListener('DOMContentLoaded', function () {
       format(input);
     });
   });
+
+  const isValidSpanishPhone = (input) => {
+    const prefijo = input.closest('.form-field')?.querySelector('input.prefijo-input')?.value || '';
+    const digits = input.value.replace(/\D/g, '');
+    if (prefijo === '+34' && digits && !['6', '7', '9'].includes(digits.charAt(0))) {
+      alert('Introduce un número de teléfono válido');
+      return false;
+    }
+    return true;
+  };
+
+  phoneInputs.forEach(function (input) {
+    input.form?.addEventListener('submit', function (e) {
+      if (!isValidSpanishPhone(input)) {
+        e.preventDefault();
+      }
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- ensure phone field spans its column and add padding for prefix dropdown
- add placeholder 'Telefono' for empty phone inputs
- validate Spanish phone numbers to start with 6, 7 or 9 and block submission when invalid

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894b8fbeef083218583703ebef61e75