### PR TITLE
Add margins to phone dropdown and input

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -151,11 +151,13 @@
 
 .profile-form .phone-field .iti--separate-dial-code .iti__flag-container {
   padding: 0 2px;
+  margin: 0 2px;
 }
 
 .profile-form .phone-field .iti--separate-dial-code .iti__selected-flag {
   border-right: 1px solid #ddd;
   padding: 0 2px;
+  margin: 0 2px;
 }
 
 .profile-form .phone-field label {
@@ -167,7 +169,7 @@
 }
 
 .profile-form .phone-field input.phone-input {
-  margin-left: 0;
+  margin: 2px;
 }
 
 .profile-form .phone-field input:placeholder-shown ~ label {


### PR DESCRIPTION
## Summary
- add 2px horizontal margin to phone prefix dropdown
- add 2px margin around phone number input

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894bc7d70d88321bed35cae8d4a5a8a