### PR TITLE
Align member signup modal fields with profile style

### DIFF
--- a/templates/clubs/_miembro_public_form.html
+++ b/templates/clubs/_miembro_public_form.html
@@ -51,101 +51,87 @@
       </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-md-6">
-      <div class="form-field phone-field">
-        {{ form.prefijo }}
-        {{ form.telefono }}
-        <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
-        {% if form.telefono.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.telefono.errors.as_text|striptags }}
-        </div>
-        {% endif %}
+  <div class="row g-3">
+    <div class="form-field col-md-6 phone-field">
+      {{ form.prefijo }}
+      {{ form.telefono }}
+      <button type="button" class="clear-btn bi bi-x"></button>
+      <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
+      {% if form.telefono.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.telefono.errors.as_text|striptags }}
       </div>
+      {% endif %}
     </div>
-    <div class="col-md-6">
-      <div class="form-field">
-        {{ form.email }}
-        <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
-        {% if form.email.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.email.errors.as_text|striptags }}
-        </div>
-        {% endif %}
+    <div class="form-field col-md-6">
+      {{ form.email }}
+      <button type="button" class="clear-btn bi bi-x"></button>
+      <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
+      {% if form.email.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.email.errors.as_text|striptags }}
       </div>
+      {% endif %}
     </div>
   </div>
-  <div class="row">
-    <div class="col-md-3">
-      <div class="form-field">
-        {{ form.fecha_nacimiento }}
-        <label for="{{ form.fecha_nacimiento.id_for_label }}"
-          >{{ form.fecha_nacimiento.label }}</label
-        >
-        {% if form.fecha_nacimiento.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.fecha_nacimiento.errors.as_text|striptags }}
-        </div>
-        {% endif %}
+  <div class="row g-3">
+    <div class="form-field col-md-3">
+      {{ form.fecha_nacimiento }}
+      <label for="{{ form.fecha_nacimiento.id_for_label }}"
+        >{{ form.fecha_nacimiento.label }}</label
+      >
+      {% if form.fecha_nacimiento.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.fecha_nacimiento.errors.as_text|striptags }}
       </div>
+      {% endif %}
     </div>
-    <div class="col-md-3">
-      <div class="form-field">
-        {{ form.sexo }}
-        <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
-        {% if form.sexo.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.sexo.errors.as_text|striptags }}
-        </div>
-        {% endif %}
+    <div class="form-field col-md-3">
+      {{ form.sexo }}
+      <label for="{{ form.sexo.id_for_label }}">{{ form.sexo.label }}</label>
+      {% if form.sexo.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.sexo.errors.as_text|striptags }}
       </div>
+      {% endif %}
     </div>
-    <div class="col-md-6">
-      <div class="form-field">
-        {{ form.nacionalidad }}
-        <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.nacionalidad.id_for_label }}"
-          >{{ form.nacionalidad.label }}</label
-        >
-        {% if form.nacionalidad.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.nacionalidad.errors.as_text|striptags }}
-        </div>
-        {% endif %}
+    <div class="form-field col-md-6">
+      {{ form.nacionalidad }}
+      <button type="button" class="clear-btn bi bi-x"></button>
+      <label for="{{ form.nacionalidad.id_for_label }}"
+        >{{ form.nacionalidad.label }}</label
+      >
+      {% if form.nacionalidad.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.nacionalidad.errors.as_text|striptags }}
       </div>
+      {% endif %}
     </div>
   </div>
-  <div class="row">
-    <div class="col-md-6">
-      <div class="form-field">
-        {{ form.localidad }}
-        <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.localidad.id_for_label }}"
-          >{{ form.localidad.label }}</label
-        >
-        {% if form.localidad.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.localidad.errors.as_text|striptags }}
-        </div>
-        {% endif %}
+  <div class="row g-3">
+    <div class="form-field col-md-6">
+      {{ form.localidad }}
+      <button type="button" class="clear-btn bi bi-x"></button>
+      <label for="{{ form.localidad.id_for_label }}"
+        >{{ form.localidad.label }}</label
+      >
+      {% if form.localidad.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.localidad.errors.as_text|striptags }}
       </div>
+      {% endif %}
     </div>
-    <div class="col-md-6">
-      <div class="form-field">
-        {{ form.codigo_postal }}
-        <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.codigo_postal.id_for_label }}"
-          >{{ form.codigo_postal.label }}</label
-        >
-        {% if form.codigo_postal.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.codigo_postal.errors.as_text|striptags }}
-        </div>
-        {% endif %}
+    <div class="form-field col-md-6">
+      {{ form.codigo_postal }}
+      <button type="button" class="clear-btn bi bi-x"></button>
+      <label for="{{ form.codigo_postal.id_for_label }}"
+        >{{ form.codigo_postal.label }}</label
+      >
+      {% if form.codigo_postal.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.codigo_postal.errors.as_text|striptags }}
       </div>
+      {% endif %}
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Summary
- match member signup modal field layout to dashboard profile form
- use consistent form-field columns for phone, email, nationality, city and postal code

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894c1e675f8832181616953b772a616