### PR TITLE
Include all cities in matchmaker filter

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -284,6 +284,12 @@ class DashboardMatchmakerTests(TestCase):
         self.assertContains(res, 'Bob')
         self.assertNotContains(res, 'Alice')
 
+    def test_matchmaker_city_dropdown_lists_all_cities(self):
+        """City options should include cities beyond those with clubs."""
+        url = reverse('club_dashboard')
+        res = self.client.get(url)
+        self.assertIn('Madrid', res.context['cities'])
+
 
 class MessageInboxTests(TestCase):
     def setUp(self):

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -36,6 +36,7 @@ from ..forms import (
     BookingClassForm,
 )
 from ..permissions import has_club_permission
+from ..spain import CITY_CHOICES
 
 
 @login_required
@@ -116,7 +117,8 @@ def dashboard(request):
     # --- Matchmaker ---
     # Search competitors across all registered clubs
     match_qs = Miembro.objects.select_related('club').all()
-    cities = Club.objects.values_list('city', flat=True).distinct()
+    club_cities = set(Club.objects.values_list('city', flat=True).distinct())
+    cities = sorted(club_cities | {city for _, city in CITY_CHOICES})
 
     mm_sexo = request.GET.get('mm_sexo')
     if mm_sexo in ['M', 'F']:


### PR DESCRIPTION
## Summary
- ensure matchmaker searches across all cities by merging known city list with club cities
- test matchmaker city dropdown includes comprehensive options

## Testing
- `pytest`
- `python manage.py test apps.clubs.tests.DashboardMatchmakerTests.test_matchmaker_city_dropdown_lists_all_cities -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6894cced2a78832184f9c7b09993858f