### PR TITLE
Display matchmaker results beside filters

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1029,7 +1029,7 @@
       <h4>Matchmaker</h4>
 
       <div class="row mb-3">
-        <div class="col-12 col-lg-4">
+        <div class="col-12 col-md-6">
           <form
             method="get"
             id="matchmaker-filter-form"
@@ -1137,42 +1137,44 @@
             </div>
           </form>
         </div>
-      </div>
-      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 g-4">
-        {% for c in match_results %}
-        <div class="col">
-          <div class="card-flip">
-            <div class="card-flip-inner">
-              <div class="card text-center card-flip-front">
-                {% if c.avatar %}
-                <img src="{{ c.avatar.url }}" class="card-img-top object-fit-cover" style="height: 200px" alt="{{ c.nombre }}" />
-                {% else %}
-                <div class="card-img-top d-flex align-items-center justify-content-center bg-light" style="height: 200px">
-                  <span class="text-muted">{{ c.nombre|initials }}</span>
-                </div>
-                {% endif %}
-                <div class="card-body p-2">
-                  <span class="fw-medium d-block">{{ c.nombre }} {{ c.apellidos }}</span>
-                  <small class="text-muted d-block">{{ c.club.name }} - {{ c.club.city }}</small>
-                  <small class="d-block">
-                    {{ c.peso|default:'—' }}
-                    {% if c.edad %}| {{ c.edad }}{% else %}| —{% endif %}
-                  </small>
-                </div>
-              </div>
-              <div class="card card-flip-back text-center bg-dark text-white">
-                <div class="p-2 d-flex flex-column justify-content-center align-items-center h-100">
-                  <small class="d-block">Sexo: {{ c.get_sexo_display|default:'—' }}</small>
-                  <small class="d-block">Edad: {{ c.edad|default:'—' }}</small>
-                  <small class="d-block">Peso: {{ c.peso|default:'—' }}</small>
+        <div class="col-12 col-md-6">
+          <div class="row row-cols-1 row-cols-sm-2 g-4">
+            {% for c in match_results %}
+            <div class="col">
+              <div class="card-flip">
+                <div class="card-flip-inner">
+                  <div class="card text-center card-flip-front">
+                    {% if c.avatar %}
+                    <img src="{{ c.avatar.url }}" class="card-img-top object-fit-cover" style="height: 200px" alt="{{ c.nombre }}" />
+                    {% else %}
+                    <div class="card-img-top d-flex align-items-center justify-content-center bg-light" style="height: 200px">
+                      <span class="text-muted">{{ c.nombre|initials }}</span>
+                    </div>
+                    {% endif %}
+                    <div class="card-body p-2">
+                      <span class="fw-medium d-block">{{ c.nombre }} {{ c.apellidos }}</span>
+                      <small class="text-muted d-block">{{ c.club.name }} - {{ c.club.city }}</small>
+                      <small class="d-block">
+                        {{ c.peso|default:'—' }}
+                        {% if c.edad %}| {{ c.edad }}{% else %}| —{% endif %}
+                      </small>
+                    </div>
+                  </div>
+                  <div class="card card-flip-back text-center bg-dark text-white">
+                    <div class="p-2 d-flex flex-column justify-content-center align-items-center h-100">
+                      <small class="d-block">Sexo: {{ c.get_sexo_display|default:'—' }}</small>
+                      <small class="d-block">Edad: {{ c.edad|default:'—' }}</small>
+                      <small class="d-block">Peso: {{ c.peso|default:'—' }}</small>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
+            {% empty %}
+            <p>No hay competidores.</p>
+            {% endfor %}
           </div>
         </div>
-        {% empty %}
-        <p>No hay competidores.</p>
-        {% endfor %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Show matchmaker competitor cards in a right-side column
- Keep city filter based on competitor's club city with "Todas" default

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894d29a76108321a04a030213f0868f