### PR TITLE
Use competitor database for matchmaker search

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -6,7 +6,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth.models import User, Group
 from PIL import Image
 
-from .models import Club, ClubPhoto, ClubPost, Miembro, Pago
+from .models import Club, ClubPhoto, ClubPost, Miembro, Pago, Competidor
 from datetime import date
 
 
@@ -266,15 +266,13 @@ class DashboardMatchmakerTests(TestCase):
         self.club2 = Club.objects.create(
             name='Club Two', city='City2', address='A2', phone='2', email='2@e.com', owner=self.owner2
         )
-        self.member1 = Miembro.objects.create(
+        self.comp1 = Competidor.objects.create(
             club=self.club1,
-            nombre='Alice', apellidos='A', sexo='F', peso=55,
-            fecha_nacimiento=date(2000, 1, 1)
+            nombre='Alice', apellidos='A', sexo='F', peso_kg=55, edad=24
         )
-        self.member2 = Miembro.objects.create(
+        self.comp2 = Competidor.objects.create(
             club=self.club2,
-            nombre='Bob', apellidos='B', sexo='M', peso=70,
-            fecha_nacimiento=date(1995, 1, 1)
+            nombre='Bob', apellidos='B', sexo='M', peso_kg=70, edad=29
         )
         self.client.login(username='owner1', password='pass')
 

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -116,7 +116,7 @@ def dashboard(request):
 
     # --- Matchmaker ---
     # Search competitors across all registered clubs
-    match_qs = Miembro.objects.select_related('club').all()
+    match_qs = Competidor.objects.select_related('club').all()
     club_cities = set(Club.objects.values_list('city', flat=True).distinct())
     cities = sorted(club_cities | {city for _, city in CITY_CHOICES})
 
@@ -126,32 +126,21 @@ def dashboard(request):
 
     mm_peso_min = request.GET.get('mm_peso_min')
     if mm_peso_min:
-        match_qs = match_qs.filter(peso__gte=mm_peso_min)
+        match_qs = match_qs.filter(peso_kg__gte=mm_peso_min)
     mm_peso_max = request.GET.get('mm_peso_max')
     if mm_peso_max:
-        match_qs = match_qs.filter(peso__lte=mm_peso_max)
+        match_qs = match_qs.filter(peso_kg__lte=mm_peso_max)
 
     mm_ciudad = request.GET.get('mm_ciudad')
     if mm_ciudad:
         match_qs = match_qs.filter(club__city=mm_ciudad)
 
-    current_year = timezone.now().year
-    match_qs = match_qs.annotate(
-        birth_year=ExtractYear('fecha_nacimiento')
-    )
-
     mm_edad_min = request.GET.get('mm_edad_min')
     if mm_edad_min:
-        year_max = current_year - int(mm_edad_min)
-        match_qs = match_qs.filter(birth_year__lte=year_max)
+        match_qs = match_qs.filter(edad__gte=mm_edad_min)
     mm_edad_max = request.GET.get('mm_edad_max')
     if mm_edad_max:
-        year_min = current_year - int(mm_edad_max)
-        match_qs = match_qs.filter(birth_year__gte=year_min)
-
-    match_qs = match_qs.annotate(
-        edad=current_year - ExtractYear('fecha_nacimiento')
-    )
+        match_qs = match_qs.filter(edad__lte=mm_edad_max)
 
     # Filtros para los miembros
     estado = request.GET.get('estado')


### PR DESCRIPTION
## Summary
- search competitors in matchmaker instead of generic members
- adjust matchmaker weight/age filters for competitor fields
- update dashboard matchmaker tests to use competitors

## Testing
- `python3 manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6894dc3e8ef4832196db356d05b7c8ea