### PR TITLE
Add pagination for Matchmaker competitor cards

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -7,6 +7,7 @@ from django.template.loader import render_to_string
 from django.db.models import Q, Exists, OuterRef
 from django.db.models.functions import ExtractYear
 from django.utils import timezone
+from django.core.paginator import Paginator
 import json
 from collections import defaultdict
 
@@ -142,6 +143,14 @@ def dashboard(request):
     if mm_edad_max:
         match_qs = match_qs.filter(edad__lte=mm_edad_max)
 
+    paginator = Paginator(match_qs, 18)
+    page_number = request.GET.get('page')
+    match_results = paginator.get_page(page_number)
+    query_params = request.GET.copy()
+    if 'page' in query_params:
+        query_params.pop('page')
+    current_query = query_params.urlencode()
+
     # Filtros para los miembros
     estado = request.GET.get('estado')
     if estado in ['activo', 'inactivo']:
@@ -219,7 +228,8 @@ def dashboard(request):
             'form': form,
             'coaches': coaches,
             'members': members,
-            'match_results': match_qs,
+            'match_results': match_results,
+            'current_query': current_query,
             'cities': cities,
             'estado_counts': estado_counts,
             'sexo_counts': sexo_counts,

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1138,7 +1138,7 @@
           </form>
         </div>
         <div class="col-12 col-md-6">
-          <div class="row row-cols-1 row-cols-sm-2 g-4">
+          <div class="row row-cols-2 row-cols-md-3 g-4">
             {% for c in match_results %}
             <div class="col">
               <div class="card-flip">
@@ -1174,6 +1174,41 @@
             <p>No hay competidores.</p>
             {% endfor %}
           </div>
+          {% if match_results.paginator.num_pages > 1 %}
+          <nav aria-label="Matchmaker pagination" class="mt-3">
+            <ul class="pagination justify-content-center">
+              {% if match_results.has_previous %}
+              <li class="page-item">
+                <a class="page-link" href="?page={{ match_results.previous_page_number }}{% if current_query %}&{{ current_query }}{% endif %}" aria-label="Anterior">
+                  <span aria-hidden="true">&laquo;</span>
+                </a>
+              </li>
+              {% else %}
+              <li class="page-item disabled">
+                <span class="page-link" aria-hidden="true">&laquo;</span>
+              </li>
+              {% endif %}
+              {% for num in match_results.paginator.page_range %}
+              {% if num == match_results.number %}
+              <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+              {% else %}
+              <li class="page-item"><a class="page-link" href="?page={{ num }}{% if current_query %}&{{ current_query }}{% endif %}">{{ num }}</a></li>
+              {% endif %}
+              {% endfor %}
+              {% if match_results.has_next %}
+              <li class="page-item">
+                <a class="page-link" href="?page={{ match_results.next_page_number }}{% if current_query %}&{{ current_query }}{% endif %}" aria-label="Siguiente">
+                  <span aria-hidden="true">&raquo;</span>
+                </a>
+              </li>
+              {% else %}
+              <li class="page-item disabled">
+                <span class="page-link" aria-hidden="true">&raquo;</span>
+              </li>
+              {% endif %}
+            </ul>
+          </nav>
+          {% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Show matchmaker competitor cards in a 2-col grid that expands to 3 cards per row
- Paginate competitors (18 per page) and add navigation controls under the grid

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894de36c1e08321b27498fafc5e7c6d