### PR TITLE
Ensure matchmaker cards have minimum height

### DIFF
--- a/static/css/matchmaker.css
+++ b/static/css/matchmaker.css
@@ -1,5 +1,6 @@
 .card-flip {
   perspective: 1000px;
+  min-height: 300px;
 }
 
 .card-flip-inner {


### PR DESCRIPTION
## Summary
- enforce minimum height of 300px on matchmaker cards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894e0e4b6208321a51e2e39769c9cc1