### PR TITLE
Expose address field in account dashboard

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -138,10 +138,12 @@ class AccountForm(UniformFieldsMixin, forms.ModelForm):
     notifications = forms.BooleanField(
         label='Recibir notificaciones', required=False
     )
+    bio = forms.CharField(label='Bio', widget=forms.Textarea, required=False)
+    location = forms.CharField(label='Ubicación', required=False)
 
     class Meta:
         model = Profile
-        fields = ['avatar', 'notifications']
+        fields = ['avatar', 'bio', 'location', 'notifications']
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)
@@ -150,7 +152,7 @@ class AccountForm(UniformFieldsMixin, forms.ModelForm):
             self.fields['username'].initial = user.username
             self.fields['email'].initial = user.email
             self.user = user
-        placeholder_fields = ['username', 'email', 'new_password1', 'new_password2']
+        placeholder_fields = ['username', 'email', 'bio', 'location', 'new_password1', 'new_password2']
         for f in placeholder_fields:
             self.fields[f].widget.attrs.setdefault('placeholder', ' ')
 

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -83,8 +83,19 @@
 
                 </div>
 
+                <div class="form-field">
+                    {{ form.bio }}
+                    <button type="button" class="clear-btn bi bi-x"></button>
+                    <label for="{{ form.bio.id_for_label }}">{{ form.bio.label }}</label>
+                </div>
+                <div class="form-field">
+                    {{ form.location }}
+                    <button type="button" class="clear-btn bi bi-x"></button>
+                    <label for="{{ form.location.id_for_label }}">{{ form.location.label }}</label>
+                </div>
+
                 {% if is_owner and club_form %}
-               <h4>Dirección del club</h4>   
+               <h4>Dirección del club</h4>
                 <div class="mt-2 row g-3">
                     <div class="form-field col-md-4">
                         {{ club_form.country }}


### PR DESCRIPTION
## Summary
- Add bio and location fields to account settings form
- Show bio and location inputs in Mi cuenta dashboard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68952b09faf48321bbb8a34bfb566bd1