### PR TITLE
Move club address fields to dashboard

### DIFF
--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -60,20 +60,94 @@
             {% endif %}
           </div>
            <div class="form-field">
-          {{ form.about }}
-          <label for="{{ form.about.id_for_label }}">{{ form.about.label }}</label>
-          {% if form.about.errors %}
-          <div class="invalid-feedback d-block">
-            {{ form.about.errors.as_text|striptags }}
-          </div>
-          {% endif %}
-          </div>
+            {{ form.about }}
+            <label for="{{ form.about.id_for_label }}">{{ form.about.label }}</label>
+            {% if form.about.errors %}
+            <div class="invalid-feedback d-block">
+              {{ form.about.errors.as_text|striptags }}
+            </div>
+            {% endif %}
+            </div>
 
-          
+
+        </div>
+
+        <h5 class="mt-4">Dirección del club</h5>
+        <div class="row g-3 mt-2">
+          <div class="form-field col-md-4">
+            {{ form.country }}
+            <label for="{{ form.country.id_for_label }}">{{ form.country.label }}</label>
+            {% if form.country.errors %}
+            <div class="invalid-feedback d-block">
+              {{ form.country.errors.as_text|striptags }}
+            </div>
+            {% endif %}
+          </div>
+          <div class="form-field col-md-4">
+            {{ form.region }}
+            <label for="{{ form.region.id_for_label }}">{{ form.region.label }}</label>
+            {% if form.region.errors %}
+            <div class="invalid-feedback d-block">
+              {{ form.region.errors.as_text|striptags }}
+            </div>
+            {% endif %}
+          </div>
+          <div class="form-field col-md-4">
+            {{ form.city }}
+            <button type="button" class="clear-btn bi bi-x"></button>
+            <label for="{{ form.city.id_for_label }}">{{ form.city.label }}</label>
+            {% if form.city.errors %}
+            <div class="invalid-feedback d-block">
+              {{ form.city.errors.as_text|striptags }}
+            </div>
+            {% endif %}
+          </div>
+        </div>
+        <div class="row g-3">
+          <div class="form-field col-md-6">
+            {{ form.street }}
+            <button type="button" class="clear-btn bi bi-x"></button>
+            <label for="{{ form.street.id_for_label }}">{{ form.street.label }}</label>
+            {% if form.street.errors %}
+            <div class="invalid-feedback d-block">
+              {{ form.street.errors.as_text|striptags }}
+            </div>
+            {% endif %}
+          </div>
+          <div class="form-field col-md-2">
+            {{ form.number }}
+            <button type="button" class="clear-btn bi bi-x"></button>
+            <label for="{{ form.number.id_for_label }}">{{ form.number.label }}</label>
+            {% if form.number.errors %}
+            <div class="invalid-feedback d-block">
+              {{ form.number.errors.as_text|striptags }}
+            </div>
+            {% endif %}
+          </div>
+          <div class="form-field col-md-2">
+            {{ form.door }}
+            <button type="button" class="clear-btn bi bi-x"></button>
+            <label for="{{ form.door.id_for_label }}">{{ form.door.label }}</label>
+            {% if form.door.errors %}
+            <div class="invalid-feedback d-block">
+              {{ form.door.errors.as_text|striptags }}
+            </div>
+            {% endif %}
+          </div>
+          <div class="form-field col-md-2">
+            {{ form.postal_code }}
+            <button type="button" class="clear-btn bi bi-x"></button>
+            <label for="{{ form.postal_code.id_for_label }}">{{ form.postal_code.label }}</label>
+            {% if form.postal_code.errors %}
+            <div class="invalid-feedback d-block">
+              {{ form.postal_code.errors.as_text|striptags }}
+            </div>
+            {% endif %}
+          </div>
         </div>
 
 
-       
+
 
         <button type="submit" class="btn btn-dark mt-4">Guardar</button>
       </form> 
@@ -1495,6 +1569,7 @@
 <script src="{% static 'js/profile-tabs.js' %}"></script>
 <script src="{% static 'js/feature-select.js' %}"></script>
 <script src="{% static 'js/avatar-dropzone.js' %}"></script>
+<script src="{% static 'js/location-select.js' %}"></script>
 <script src="{% static 'js/schedule-form.js' %}"></script>
 <script src="{% static 'js/gallery-manager.js' %}"></script>
 <script src="{% static 'js/delete-confirm.js' %}"></script>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -83,82 +83,6 @@
 
                 </div>
 
-                {% if is_owner and club_form %}
-               <h4>Dirección del club</h4>   
-                <div class="mt-2 row g-3">
-                    <div class="form-field col-md-4">
-                        {{ club_form.country }}
-                        <label for="{{ club_form.country.id_for_label }}">{{ club_form.country.label }}</label>
-                        {% if club_form.country.errors %}
-                        <div class="invalid-feedback d-block">
-                            {{ club_form.country.errors.as_text|striptags }}
-                        </div>
-                        {% endif %}
-                    </div>
-                    <div class="form-field col-md-4">
-                        {{ club_form.region }}
-                        <label for="{{ club_form.region.id_for_label }}">{{ club_form.region.label }}</label>
-                        {% if club_form.region.errors %}
-                        <div class="invalid-feedback d-block">
-                            {{ club_form.region.errors.as_text|striptags }}
-                        </div>
-                        {% endif %}
-                    </div>
-                     <div class="form-field col-md-4">
-                        {{ club_form.city }}
-                        <button type="button" class="clear-btn bi bi-x"></button>
-                        <label for="{{ club_form.city.id_for_label }}">{{ club_form.city.label }}</label>
-                        {% if club_form.city.errors %}
-                        <div class="invalid-feedback d-block">
-                            {{ club_form.city.errors.as_text|striptags }}
-                        </div>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="row g-3">
-                    <div class="form-field col-md-6">
-                        {{ club_form.street }}
-                        <button type="button" class="clear-btn bi bi-x"></button>
-                        <label for="{{ club_form.street.id_for_label }}">{{ club_form.street.label }}</label>
-                        {% if club_form.street.errors %}
-                        <div class="invalid-feedback d-block">
-                            {{ club_form.street.errors.as_text|striptags }}
-                        </div>
-                        {% endif %}
-                    </div>
-                    <div class="form-field col-md-2">
-                        {{ club_form.number }}
-                        <button type="button" class="clear-btn bi bi-x"></button>
-                        <label for="{{ club_form.number.id_for_label }}">{{ club_form.number.label }}</label>
-                        {% if club_form.number.errors %}
-                        <div class="invalid-feedback d-block">
-                            {{ club_form.number.errors.as_text|striptags }}
-                        </div>
-                        {% endif %}
-                    </div>
-                    <div class="form-field col-md-2">
-                        {{ club_form.door }}
-                        <button type="button" class="clear-btn bi bi-x"></button>
-                        <label for="{{ club_form.door.id_for_label }}">{{ club_form.door.label }}</label>
-                        {% if club_form.door.errors %}
-                        <div class="invalid-feedback d-block">
-                            {{ club_form.door.errors.as_text|striptags }}
-                        </div>
-                        {% endif %}
-                    </div>
-                    <div class="form-field col-md-2">
-                        {{ club_form.postal_code }}
-                        <button type="button" class="clear-btn bi bi-x"></button>
-                        <label for="{{ club_form.postal_code.id_for_label }}">{{ club_form.postal_code.label }}</label>
-                        {% if club_form.postal_code.errors %}
-                        <div class="invalid-feedback d-block">
-                            {{ club_form.postal_code.errors.as_text|striptags }}
-                        </div>
-                        {% endif %}
-                    </div>
-                </div>
-
-                {% endif %}
 
                 <div class="form-field checkbox-field">
                     {{ form.notifications }}
@@ -312,6 +236,5 @@
 <script src="{% static 'js/plan-cards.js' %}"></script>
 {% if is_owner %}
 <script src="{% static 'js/slug-check.js' %}"></script>
-<script src="{% static 'js/location-select.js' %}"></script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Show club address fields on dashboard profile form after the bio
- Remove address editing and location script from user profile page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689530c5715483218f4a48587d774827