### PR TITLE
Fix profile page layout to match home height

### DIFF
--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -1,8 +1,11 @@
 {% extends 'base.html' %}
 {% load static utils_filters %}
 
+{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
+
 {% block content %}
-<div class="d-flex mt-5 container-fluid col-12">
+<main class="flex-grow-1">
+<div class="d-flex flex-grow-1 mt-5 container-fluid col-12">
     <div class="profile-tabs">
         <div class="profile-tab active" data-target="tab-account">Mi cuenta</div>
         {% if is_owner %}
@@ -246,6 +249,7 @@
         </div>
     </div>
 </div>
+</main>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
## Summary
- Make profile page a flex column with full viewport height
- Wrap profile content in `main` and allow tabs container to grow to fill space

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895411953f88321b3a45f5e3ded1767