### PR TITLE
Improve matchmaker card UI and filtering behavior

### DIFF
--- a/static/css/matchmaker.css
+++ b/static/css/matchmaker.css
@@ -28,3 +28,12 @@
 .card-flip-back {
   transform: rotateY(180deg);
 }
+
+.avatar-container .bookmark-btn {
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.avatar-container:hover .bookmark-btn {
+  opacity: 1;
+}

--- a/static/js/matchmaker-filter.js
+++ b/static/js/matchmaker-filter.js
@@ -2,17 +2,38 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('matchmaker-filter-form');
   if (!form) return;
 
-  const citySelect = form.querySelector('select[name="mm_ciudad"]');
-  if (citySelect) {
-    citySelect.addEventListener('change', () => {
-      form.requestSubmit();
-    });
-  }
-
   const clearBtn = document.getElementById('clear-matchmaker-filter-btn');
   if (clearBtn) {
     clearBtn.addEventListener('click', () => {
-      window.location.href = window.location.pathname;
+      form.reset();
+      form.querySelectorAll('input[name="mm_sexo"]').forEach(r => (r.checked = false));
+      const citySelect = form.querySelector('select[name="mm_ciudad"]');
+      if (citySelect) citySelect.value = '';
+      const pesoMin = form.querySelector('input[name="mm_peso_min"]');
+      const pesoMax = form.querySelector('input[name="mm_peso_max"]');
+      if (pesoMin && pesoMax) {
+        pesoMin.value = 30;
+        pesoMax.value = 160;
+      }
+      const edadMin = form.querySelector('input[name="mm_edad_min"]');
+      const edadMax = form.querySelector('input[name="mm_edad_max"]');
+      if (edadMin && edadMax) {
+        edadMin.value = 10;
+        edadMax.value = 60;
+      }
+      form.querySelectorAll('.range-slider input[type="range"]').forEach(input => {
+        input.dispatchEvent(new Event('input'));
+      });
     });
   }
+
+  document.querySelectorAll('.bookmark-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const icon = btn.querySelector('i');
+      if (!icon) return;
+      icon.classList.toggle('bi-bookmark');
+      icon.classList.toggle('bi-bookmark-fill');
+    });
+  });
 });
+

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1245,31 +1245,44 @@
             {% for c in match_results %}
             <div class="col">
               <div class="card text-center">
-                {% if c.avatar %}
-                <img
-                  src="{{ c.avatar.url }}"
-                  class="card-img-top object-fit-cover"
-                  style="height: 200px"
-                  alt="{{ c.nombre }} {{ c.apellidos }}"
-                />
-                {% else %}
-                <div
-                  class="card-img-top d-flex align-items-center justify-content-center bg-light"
-                  style="height: 200px"
-                >
-                  <span class="text-muted">{{ c.nombre|initials }}</span>
+                <div class="avatar-container position-relative">
+                  {% if c.avatar %}
+                  <img
+                    src="{{ c.avatar.url }}"
+                    class="card-img-top object-fit-cover"
+                    style="height: 200px"
+                    alt="{{ c.nombre }} {{ c.apellidos }}"
+                  />
+                  {% else %}
+                  <div
+                    class="card-img-top d-flex align-items-center justify-content-center bg-light"
+                    style="height: 200px"
+                  >
+                    <span class="text-muted">{{ c.nombre|add:' '|add:c.apellidos|initials }}</span>
+                  </div>
+                  {% endif %}
+                  <button
+                    type="button"
+                    class="bookmark-btn btn btn-light btn-sm position-absolute top-0 end-0 m-1 p-1"
+                  >
+                    <i class="bi bi-bookmark"></i>
+                  </button>
                 </div>
-
-                {% endif %}
                 <div class="card-body p-2">
                   <span class="fw-medium d-block">{{ c.nombre }} {{ c.apellidos }}</span>
-                  <small class="text-muted d-block">{{ c.club.name }}  </small>
-                  <small> {{ c.club.city }}</small>
+                  <small class="d-block">
+                    {% with rec=c.record_tuple %}
+                    <span class="fw-bold text-success">{{ rec.0 }}</span>-
+                    <span class="fw-bold text-danger">{{ rec.1 }}</span>-
+                    <span class="fw-bold text-primary">{{ rec.2 }}</span>
+                    {% endwith %}
+                  </small>
+                  <small class="text-muted d-block">{{ c.club.name }}</small>
+                  <small>{{ c.club.city }}</small>
                   <small class="d-block">
                     {{ c.peso|default:'—' }}
                     {% if c.edad %}| {{ c.edad }}{% else %}| —{% endif %}
                   </small>
-                  
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Show competitor record beneath names in matchmaker results
- Display initials and allow bookmarking from avatar hover
- Reset matchmaker filters without reloading the page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895565ed32883218214707cbd5f8945