### PR TITLE
Enhance matchmaker competitor details and filters

### DIFF
--- a/static/js/matchmaker-filter.js
+++ b/static/js/matchmaker-filter.js
@@ -7,6 +7,8 @@ document.addEventListener('DOMContentLoaded', () => {
     clearBtn.addEventListener('click', () => {
       form.reset();
       form.querySelectorAll('input[name="mm_sexo"]').forEach(r => (r.checked = false));
+      const allRadio = form.querySelector('#mm-sexo-all');
+      if (allRadio) allRadio.checked = true;
       const citySelect = form.querySelector('select[name="mm_ciudad"]');
       if (citySelect) citySelect.value = '';
       const pesoMin = form.querySelector('input[name="mm_peso_min"]');

--- a/static/js/range-slider.js
+++ b/static/js/range-slider.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const minVal = slider.querySelector('.min-value');
     const maxVal = slider.querySelector('.max-value');
     const track = slider.querySelector('.slider-track');
+    const unit = slider.dataset.unit || '';
 
     const update = () => {
       let min = parseInt(minInput.value);
@@ -20,8 +21,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const end = ((max - minInput.min) / range) * 100;
       track.style.left = start + '%';
       track.style.right = (100 - end) + '%';
-      if (minVal) minVal.textContent = min;
-      if (maxVal) maxVal.textContent = max;
+      if (minVal) minVal.textContent = unit ? `${min} ${unit}` : min;
+      if (maxVal) maxVal.textContent = unit ? `${max} ${unit}` : max;
     };
 
     minInput.addEventListener('input', update);

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1144,28 +1144,39 @@
                 <input
                   class="form-check-input custom-check"
                   type="radio"
-              name="mm_sexo"
-              id="mm-sexo-m"
-              value="M"
-              {% if request.GET.mm_sexo == 'M' %}checked{% endif %}
-            />
-            <label class="form-check-label" for="mm-sexo-m">Masculino</label>
-          </div>
-          <div class="form-check d-flex align-items-center gap-2 mb-1 small ms-2 mt-2">
-            <input
-              class="form-check-input custom-check"
-              type="radio"
-              name="mm_sexo"
-              id="mm-sexo-f"
-              value="F"
-              {% if request.GET.mm_sexo == 'F' %}checked{% endif %}
-            />
+                  name="mm_sexo"
+                  id="mm-sexo-all"
+                  value=""
+                  {% if not request.GET.mm_sexo %}checked{% endif %}
+                />
+                <label class="form-check-label" for="mm-sexo-all">Todos</label>
+              </div>
+              <div class="form-check d-flex align-items-center gap-2 mb-1 small ms-2 mt-2">
+                <input
+                  class="form-check-input custom-check"
+                  type="radio"
+                  name="mm_sexo"
+                  id="mm-sexo-m"
+                  value="M"
+                  {% if request.GET.mm_sexo == 'M' %}checked{% endif %}
+                />
+                <label class="form-check-label" for="mm-sexo-m">Masculino</label>
+              </div>
+              <div class="form-check d-flex align-items-center gap-2 mb-1 small ms-2 mt-2">
+                <input
+                  class="form-check-input custom-check"
+                  type="radio"
+                  name="mm_sexo"
+                  id="mm-sexo-f"
+                  value="F"
+                  {% if request.GET.mm_sexo == 'F' %}checked{% endif %}
+                />
                 <label class="form-check-label" for="mm-sexo-f">Femenino</label>
               </div>
             </div>
             <div>
-              <span class="d-block small fw-bold">Peso</span>
-              <div class="range-slider ms-2 me-2">
+              <span class="d-block small fw-bold">Peso (kg)</span>
+              <div class="range-slider ms-2 me-2" data-unit="kg">
                 <div class="range-values">
                   <span class="min-value"></span>
                   <span class="max-value"></span>
@@ -1201,8 +1212,8 @@
               </select>
             </div>
             <div>
-              <span class="d-block small fw-bold">Edad</span>
-              <div class="range-slider ms-2 me-2">
+              <span class="d-block small fw-bold">Edad (años)</span>
+              <div class="range-slider ms-2 me-2" data-unit="años">
                 <div class="range-values">
                   <span class="min-value"></span>
                   <span class="max-value"></span>
@@ -1280,8 +1291,11 @@
                   <small class="text-muted d-block">{{ c.club.name }}</small>
                   <small>{{ c.club.city }}</small>
                   <small class="d-block">
-                    {{ c.peso|default:'—' }}
-                    {% if c.edad %}| {{ c.edad }}{% else %}| —{% endif %}
+                    {{ c.peso|default:'—' }} | {{ c.peso_kg|default:'—' }} kg
+                  </small>
+                  <small class="d-block">
+                    Edad:
+                    {% if c.edad %}{{ c.edad }} años{% else %}—{% endif %}
                   </small>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Show weight category with exact kilograms and age on separate line in matchmaker cards
- Add 'Todos' option to sex filter and display units on weight/age sliders
- Update range slider script to append units and reset sex filter to default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68955a132e0c83218214578e83ad9841