### PR TITLE
feat: add saved filter and update matchmaker styles

### DIFF
--- a/static/css/matchmaker.css
+++ b/static/css/matchmaker.css
@@ -30,10 +30,20 @@
 }
 
 .avatar-container .bookmark-btn {
-  opacity: 0;
-  transition: opacity 0.2s;
+  opacity: 1;
 }
 
-.avatar-container:hover .bookmark-btn {
-  opacity: 1;
+/* Pagination styles */
+.pagination .page-link {
+  color: #000;
+}
+
+.pagination .page-link:hover {
+  color: #000;
+}
+
+.page-item.active .page-link {
+  background-color: #000;
+  border-color: #000;
+  color: #fff;
 }

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -592,8 +592,9 @@ select option[value="España"] {
   border-color: #000;
 }
 
-/* Custom circular checkbox */
+/* Custom circular radio */
 .custom-check {
+  appearance: none;
   width: 1rem;
   height: 1rem;
   border: 1px solid #000;
@@ -605,13 +606,13 @@ select option[value="España"] {
 .custom-check:checked::after {
   content: "";
   position: absolute;
-  top: 45%;
+  top: 50%;
   left: 50%;
-  width: 0.25rem;
+  width: 0.5rem;
   height: 0.5rem;
-  border: solid #000;
-  border-width: 0 1px 1px 0;
-  transform: translate(-50%, -50%) rotate(45deg);
+  background: #000;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
 }
 
 /* Range slider */

--- a/static/js/matchmaker-filter.js
+++ b/static/js/matchmaker-filter.js
@@ -29,12 +29,56 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  const showSavedBtn = document.getElementById('show-saved');
+  const cards = document.querySelectorAll('.matchmaker-card');
+
+  if (showSavedBtn) {
+    showSavedBtn.dataset.mode = 'all';
+    showSavedBtn.addEventListener('click', () => {
+      const showingSaved = showSavedBtn.dataset.mode === 'saved';
+      if (showingSaved) {
+        cards.forEach(card => {
+          const col = card.closest('.col');
+          if (col) col.style.display = '';
+        });
+        showSavedBtn.dataset.mode = 'all';
+        showSavedBtn.textContent = 'Mostrar guardados';
+        showSavedBtn.classList.add('text-secondary');
+        showSavedBtn.classList.remove('text-black');
+      } else {
+        cards.forEach(card => {
+          const col = card.closest('.col');
+          if (col) {
+            col.style.display = card.classList.contains('bookmarked') ? '' : 'none';
+          }
+        });
+        showSavedBtn.dataset.mode = 'saved';
+        showSavedBtn.textContent = 'Mostrar todos';
+        showSavedBtn.classList.add('text-black');
+        showSavedBtn.classList.remove('text-secondary');
+      }
+    });
+  }
+
   document.querySelectorAll('.bookmark-btn').forEach(btn => {
     btn.addEventListener('click', () => {
       const icon = btn.querySelector('i');
       if (!icon) return;
       icon.classList.toggle('bi-bookmark');
       icon.classList.toggle('bi-bookmark-fill');
+      const card = btn.closest('.matchmaker-card');
+      if (card) {
+        card.classList.toggle('bookmarked');
+        const showSavedBtn = document.getElementById('show-saved');
+        if (
+          showSavedBtn &&
+          showSavedBtn.dataset.mode === 'saved' &&
+          !card.classList.contains('bookmarked')
+        ) {
+          const col = card.closest('.col');
+          if (col) col.style.display = 'none';
+        }
+      }
     });
   });
 });

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1252,10 +1252,19 @@
           </form>
         </div>
         <div class="col-12 col-md-10">
+          <div class="d-flex justify-content-end mb-3">
+            <button
+              type="button"
+              id="show-saved"
+              class="small bg-transparent border-0 fw-medium text-secondary"
+            >
+              Mostrar guardados
+            </button>
+          </div>
           <div class="row row-cols-2 row-cols-md-4 g-4">
             {% for c in match_results %}
             <div class="col">
-              <div class="card text-center">
+              <div class="card text-center matchmaker-card">
                 <div class="avatar-container position-relative">
                   {% if c.avatar %}
                   <img


### PR DESCRIPTION
## Summary
- adjust matchmaker pagination and radio styling to use black accents
- add `Mostrar guardados` toggle with persistent bookmark icon

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68955e5d3e648321818cb23927baa1ba