### PR TITLE
Match dashboard service cards to booking modal style

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -115,26 +115,33 @@
   color: #fff;
 }
 
-/* Booking modal class cards */
-#bookingModal .class-card {
+/* Class cards (booking modal and dashboard services) */
+.class-card {
   cursor: pointer;
-  flex: 0 0 calc((100% - 2rem) / 3);
   position: relative;
 }
-#bookingModal .class-card .form-check-input {
-  display: none;
-}
-#bookingModal .class-card.active {
+
+.class-card.active {
   background-color: #000;
   color: #fff;
 }
-#bookingModal .class-card.highlighted {
+
+.class-card.highlighted {
   /* Highlighted card no longer scaled */
 }
 
 /* Offer badge inside highlighted card */
-#bookingModal .offer-badge {
+.offer-badge {
   font-size: 0.75rem;
+}
+
+/* Booking modal specific class card tweaks */
+#bookingModal .class-card {
+  flex: 0 0 calc((100% - 2rem) / 3);
+}
+
+#bookingModal .class-card .form-check-input {
+  display: none;
 }
 
 /* Hover effect for booking button */

--- a/static/js/booking-class-modal.js
+++ b/static/js/booking-class-modal.js
@@ -1,4 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+    new bootstrap.Tooltip(el);
+  });
   const addEl = document.getElementById('addBookingClassModal');
   const editEl = document.getElementById('editBookingClassModal');
   const addModal = addEl ? new bootstrap.Modal(addEl) : null;

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -373,22 +373,26 @@
       <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 g-4">
         {% for c in booking_classes %}
         <div class="col">
-          <div class="card h-100 text-center">
-            <div class="card-body p-2 d-flex flex-column justify-content-between">
-              <div>
-                <span class="fw-medium d-block mb-1">{{ c.titulo|upper }}</span>
-                <small class="d-block mb-1">{{ c.detalle }}</small>
-                <small class="d-block mb-1">{% if c.precio == 0 %}Gratis{% else %}{{ c.precio }} €{% endif %}</small>
-                <small class="d-block mb-1">{{ c.duracion }} min</small>
-                <small class="d-block">{% if c.destacado %}Destacada{% else %}No destacada{% endif %}</small>
-              </div>
-              <div class="mt-2 d-flex justify-content-center gap-2">
-                <button type="button" class="bi bi-pencil-square icon-large btn btn-link p-0 edit-booking-class-btn text-dark" data-class-id="{{ c.id }}"></button>
-                <form method="post" action="{% url 'booking_class_delete' c.id %}" class="m-0 p-0 delete-profile-form">
-                  {% csrf_token %}
-                  <button type="submit" class="bi bi-dash-circle icon-large btn btn-link text-danger p-0"></button>
-                </form>
-              </div>
+          <div class="class-card border rounded text-center p-3 h-100 d-flex flex-column justify-content-between position-relative {% if c.destacado %}highlighted{% endif %}">
+            {% if c.destacado %}
+            <span class="offer-badge position-absolute top-0 end-0 m-1 text-danger">Oferta <i class="bi bi-fire"></i></span>
+            {% endif %}
+            {% if c.detalle %}
+            <span class="d-block">
+              <i class="bi bi-info-circle" data-bs-toggle="tooltip" title="{{ c.detalle }}"></i>
+            </span>
+            {% endif %}
+            <div>
+              <span class="fw-bold text-uppercase d-block">{{ c.titulo }}</span>
+              <span class="d-block">{% if c.precio == 0 %}Gratis{% else %}{{ c.precio }} €{% endif %}</span>
+              <span class="d-block fst-italic fw-light"><small><i class="bi bi-clock"></i> {{ c.duracion }} min</small></span>
+            </div>
+            <div class="mt-2 d-flex justify-content-center gap-2">
+              <button type="button" class="bi bi-pencil-square icon-large btn btn-link p-0 edit-booking-class-btn text-dark" data-class-id="{{ c.id }}"></button>
+              <form method="post" action="{% url 'booking_class_delete' c.id %}" class="m-0 p-0 delete-profile-form">
+                {% csrf_token %}
+                <button type="submit" class="bi bi-dash-circle icon-large btn btn-link text-danger p-0"></button>
+              </form>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Unify service cards in the club dashboard with the booking modal's card layout, including offer badges and tooltips.
- Generalize `class-card` CSS for reuse and enable tooltip initialization on the dashboard.

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68956edbc6dc832188fe975a8d4cdbb6