### PR TITLE
feat: mobile dropdown tabs

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -1,9 +1,14 @@
 .profile-wrapper {
-  display: flex;
-  gap: 2rem;
+    display: flex;
+    gap: 2rem;
+}
+.profile-tabs-select {
+    background-color: #000;
+    color: #fff;
 }
 .profile-tabs {
-  min-width: 200px;
+    min-width: 200px;
+    overflow-x: auto;
 }
 .profile-tab {
   padding: 0.5rem 1rem;
@@ -16,12 +21,13 @@
   font-weight: 600;
 }
 .profile-content {
-  flex: 1;
+    flex: 1;
+    overflow-x: auto;
 }
 .profile-section {
-  display: none;
-  opacity: 0;
-  transition: opacity 0.3s;
+    display: none;
+    opacity: 0;
+    transition: opacity 0.3s;
 }
 .profile-section.active {
   display: block;

--- a/static/js/profile-tabs.js
+++ b/static/js/profile-tabs.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const tabs = document.querySelectorAll('.profile-tab');
   const sections = document.querySelectorAll('.profile-section');
+  const select = document.querySelector('.profile-tabs-select');
   const storageKey = 'activeTab:' + window.location.pathname;
 
   function activate(tab) {
@@ -11,11 +12,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const sec = document.getElementById(target);
     if (sec) sec.classList.add('active');
     localStorage.setItem(storageKey, target);
+    if (select) select.value = target;
   }
 
   tabs.forEach(t => {
     t.addEventListener('click', () => activate(t));
   });
+
+  if (select) {
+    select.addEventListener('change', () => {
+      const tab = document.querySelector(`.profile-tab[data-target="${select.value}"]`);
+      if (tab) activate(tab);
+    });
+  }
+
   let target = localStorage.getItem(storageKey);
   let activeTab = tabs[0];
   if (target) {

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -5,8 +5,21 @@
 
 {% block content %}
 <main class="flex-grow-1">
+<div class="d-lg-none mb-3">
+  <select id="mobile-dashboard-tabs" class="profile-tabs-select form-select bg-dark text-white">
+    <option value="tab-profile">Mi Perfil</option>
+    <option value="tab-gallery">Galería</option>
+    <option value="tab-schedule">Horarios</option>
+    <option value="tab-clase">Servicios</option>
+    <option value="tab-bookings">Reservas</option>
+    <option value="tab-coaches">Entrenadores</option>
+    <option value="tab-competitors">Competidores</option>
+    <option value="tab-members">Miembros</option>
+    <option value="tab-matchmaker">Matchmaker</option>
+  </select>
+</div>
 <div class="d-flex flex-grow-1 mt-5 mb-5 container-fluid col-12">
-  <div class="profile-tabs">
+  <div class="profile-tabs d-none d-lg-block">
     <div class="profile-tab active" data-target="tab-profile">Mi Perfil</div>
     <div class="profile-tab" data-target="tab-gallery">Galería</div>
     <div class="profile-tab" data-target="tab-schedule">Horarios</div>

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -40,7 +40,6 @@
                         href="{% url 'club_profile' owner_club.slug %}"
                         class="fw-bold"
                     >
-                        <span class="me-1 text-dark">{{ owner_club.name }}</span>
                         <i class="bi bi-eye-fill"></i>
                     </a>
                 </li>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -5,8 +5,22 @@
 
 {% block content %}
 <main class="flex-grow-1">
+<div class="d-lg-none mb-3">
+    <select id="mobile-profile-tabs" class="profile-tabs-select form-select bg-dark text-white">
+        <option value="tab-account">Mi cuenta</option>
+        {% if is_owner %}
+        <option value="tab-plans">Planes</option>
+        <option value="tab-support">Soporte</option>
+        {% else %}
+        <option value="tab-bookings">Reservas</option>
+        <option value="tab-favorites">Favoritos</option>
+        <option value="tab-reviews">Reseñas</option>
+        <option value="tab-support">Soporte</option>
+        {% endif %}
+    </select>
+</div>
 <div class="d-flex flex-grow-1 mt-5 container-fluid col-12">
-    <div class="profile-tabs">
+    <div class="profile-tabs d-none d-lg-block">
         <div class="profile-tab active" data-target="tab-account">Mi cuenta</div>
         {% if is_owner %}
         <div class="profile-tab" data-target="tab-plans">Planes</div>


### PR DESCRIPTION
## Summary
- replace profile and dashboard tabs with mobile-friendly dropdowns
- hide club name in header when logged in
- tweak tab styles and behavior for responsive use

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689579262064832192934e4c6dfe3319