### PR TITLE
Show club name on desktop and sync dropdown tabs

### DIFF
--- a/static/js/profile-tabs.js
+++ b/static/js/profile-tabs.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const tabs = document.querySelectorAll('.profile-tab');
   const sections = document.querySelectorAll('.profile-section');
-  const select = document.querySelector('.profile-tabs-select');
+  const selects = document.querySelectorAll('.profile-tabs-select');
   const storageKey = 'activeTab:' + window.location.pathname;
 
   function activate(tab) {
@@ -12,17 +12,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const sec = document.getElementById(target);
     if (sec) sec.classList.add('active');
     localStorage.setItem(storageKey, target);
-    if (select) select.value = target;
+    selects.forEach(s => (s.value = target));
   }
 
   tabs.forEach(t => {
     t.addEventListener('click', () => activate(t));
   });
 
-  if (select) {
-    select.addEventListener('change', () => {
-      const tab = document.querySelector(`.profile-tab[data-target="${select.value}"]`);
-      if (tab) activate(tab);
+  if (selects.length) {
+    selects.forEach(sel => {
+      sel.addEventListener('change', () => {
+        const tab = document.querySelector(`.profile-tab[data-target="${sel.value}"]`);
+        if (tab) activate(tab);
+      });
     });
   }
 

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -38,9 +38,10 @@
                 <li class="nav-item d-flex align-items-center ms-2">
                     <a
                         href="{% url 'club_profile' owner_club.slug %}"
-                        class="fw-bold"
+                        class="fw-bold d-flex align-items-center"
                     >
                         <i class="bi bi-eye-fill"></i>
+                        <span class="ms-2 d-none d-lg-inline">{{ owner_club.name }}</span>
                     </a>
                 </li>
                 {% endwith %}


### PR DESCRIPTION
## Summary
- Display club name next to eye icon in header on desktop
- Support tab switching via dropdown on profile and dashboard pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68957bc96bbc83219f9f9730ebfd6c48