### PR TITLE
Adjust profile and dashboard layout for mobile

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -8,7 +8,6 @@
 }
 .profile-tabs {
     min-width: 200px;
-    overflow-x: auto;
 }
 .profile-tab {
   padding: 0.5rem 1rem;
@@ -22,7 +21,20 @@
 }
 .profile-content {
     flex: 1;
+}
+
+@media (max-width: 991.98px) {
+  .profile-tabs,
+  .profile-content {
     overflow-x: auto;
+  }
+}
+
+@media (min-width: 992px) {
+  .profile-tabs,
+  .profile-content {
+    overflow-x: visible;
+  }
 }
 .profile-section {
     display: none;
@@ -330,13 +342,15 @@
 /* Gallery styles */
 .gallery-grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 10px;
 }
 
 .gallery-item {
   position: relative;
-  height: 150px;
+  min-width: 200px;
+  min-height: 200px;
+  height: 200px;
   overflow: hidden;
 }
 

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -33,23 +33,21 @@
         {% endif %}
 
         <ul class="navbar-nav align-items-center ms-auto">
-                {% if user.is_authenticated and user.owned_clubs.first %}
-                {% with owner_club=user.owned_clubs.first %}
+                {% if user.is_authenticated %}
                 <li class="nav-item d-flex align-items-center ms-2">
+                    {% if user.owned_clubs.first %}
+                    {% with owner_club=user.owned_clubs.first %}
                     <a
                         href="{% url 'club_profile' owner_club.slug %}"
-                        class="fw-bold d-flex align-items-center"
+                        class="text-dark d-flex align-items-center me-3"
                     >
                         <i class="bi bi-eye-fill"></i>
                         <span class="ms-2 d-none d-lg-inline">{{ owner_club.name }}</span>
                     </a>
-                </li>
-                {% endwith %}
-                {% endif %}
-                {% if user.is_authenticated %}
-                <li class="nav-item">
+                    {% endwith %}
+                    {% endif %}
                     <div
-                        class="custom-dropdown p-0 small ms-4"
+                        class="custom-dropdown p-0 small"
                         id="user-dropdown"
                     >
                         <div class="selected d-flex align-items-center">
@@ -71,7 +69,7 @@
                             </div>
                             {% endif %}
                         </div>
-                        <div class="dropdown-menu" id="user-menu">
+                        <div class="dropdown-menu m-5 m-lg-0" id="user-menu">
                             <button
                                 type="button"
                                 id="sidebar-close"


### PR DESCRIPTION
## Summary
- Restrict horizontal scrolling on profile/dashboard to mobile and tablet
- Enforce 200x200px minimum size for dashboard gallery thumbnails
- Align header eye icon next to avatar and add mobile dropdown margin

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68957fbaa7b08321909b926cc72697aa