### PR TITLE
Alinear dropdown de perfil con dashboard y permitir scroll móvil

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -3,8 +3,7 @@
     gap: 2rem;
 }
 .profile-tabs-select {
-    background-color: #000;
-    color: #fff;
+    text-align-last: right;
 }
 .profile-tabs {
     min-width: 200px;
@@ -98,6 +97,18 @@
   color: #666;
   pointer-events: none;
   transition: transform 0.2s, font-size 0.2s, color 0.2s;
+}
+
+@media (max-width: 991.98px) {
+  html,
+  body.profile-page,
+  body.dashboard-page {
+    overflow-x: auto !important;
+  }
+  .navbar-nav .eye-icon {
+    order: -1;
+    margin-right: auto;
+  }
 }
 
 .profile-form .checkbox-field label {

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static utils_filters %}
 
-{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
+{% block body_class %}d-flex flex-column min-vh-100 dashboard-page{% endblock %}
 
 {% block content %}
 <main class="flex-grow-1">

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -35,7 +35,7 @@
         <ul class="navbar-nav align-items-center ms-auto">
                 {% if user.is_authenticated and user.owned_clubs.first %}
                 {% with owner_club=user.owned_clubs.first %}
-                <li class="nav-item d-flex align-items-center ms-2">
+                <li class="nav-item d-flex align-items-center ms-2 eye-icon">
                     <a
                         href="{% url 'club_profile' owner_club.slug %}"
                         class="fw-bold d-flex align-items-center"

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %}
 {% load static utils_filters %}
 
-{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
+{% block body_class %}d-flex flex-column min-vh-100 profile-page{% endblock %}
 
 {% block content %}
 <main class="flex-grow-1">
-<div class="d-lg-none mb-3">
-    <select id="mobile-profile-tabs" class="profile-tabs-select form-select bg-dark text-white">
+<div class="d-lg-none ps-2 pe-2 pt-2 d-flex justify-content-end">
+    <select id="mobile-profile-tabs" class="profile-tabs-select form-select w-auto text-end">
         <option value="tab-account">Mi cuenta</option>
         {% if is_owner %}
         <option value="tab-plans">Planes</option>


### PR DESCRIPTION
## Summary
- Ajustar el dropdown móvil de perfil para igualar el estilo del dashboard y alinear texto a la derecha
- Habilitar scroll horizontal en móvil y tablet para /perfil y /dashboard, además de mover el icono de ojo a la izquierda

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68960089c3688321ba4bf841aef07eae