### PR TITLE
Improve mobile club profile layout

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -186,7 +186,7 @@
  }
 
 
- .review-carousel {
+.review-carousel {
        position: relative;
        max-width: 700px;
        margin: auto;
@@ -195,7 +195,11 @@
        display: flex;
        flex-direction: column;
        justify-content: space-between;
- }
+}
+
+.club-logo {
+       height: 200px;
+}
 
 
 
@@ -468,12 +472,41 @@
 
 @media (max-width: 991.98px) {
       .club-actions {
-            flex-wrap: nowrap !important;
+            flex-wrap: wrap !important;
       }
 
       .club-actions button {
-            white-space: normal;
-            word-break: break-word;
+            white-space: nowrap;
+            word-break: keep-all;
             text-align: center;
+      }
+
+      .club-logo {
+            width: 150px;
+            height: 150px;
+            border-radius: 50%;
+            overflow: hidden;
+            margin: 0 auto;
+      }
+
+      .club-logo img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            border-radius: 50%;
+      }
+
+      .competitor-avatar,
+      .competitor-avatar-img {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            object-fit: cover;
+      }
+
+      .review-list-wrapper {
+            width: 66.6667%;
+            margin-left: auto;
+            margin-right: auto;
       }
 }

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -22,7 +22,7 @@
         <div class="row">
             <!-- Columna Izquierda: Info del Club -->
             <div class="col-lg-2 ">
-         <div class="position-relative bg-black club-logo d-flex align-items-center justify-content-center" style="height: 200px;">
+         <div class="position-relative bg-black club-logo d-flex align-items-center justify-content-center">
             {% if club.logo|safe_url %}
                 <img src="{{ club.logo|safe_url }}"
                     class="w-100 h-100"
@@ -335,7 +335,7 @@
                                 {% endif %}
                             </div>
                         {% for post in posts %}
-                          <div class="mt-3 mb-3 col-8 border rounded p-4 mx-auto">
+                          <div class="mt-3 mb-3 col-12 col-lg-8 border rounded p-4 mx-auto">
                                 <div class="d-flex mb-2   justify-content-center  ">
                                     {% if post.user.profile.avatar %}
                                         <img src="{{ post.user.profile.avatar.url }}"   alt="{{ post.user.username }}"  class="review-avatar-img rounded-circle">
@@ -537,7 +537,7 @@
                     <!-- Comentarios -->
                     <div class="p-3 tab-pane fade" id="comments">
                         <div class="row">
-                            <div class="col-lg-12 ">
+                            <div class="col-lg-12 review-list-wrapper">
                                 <div class=" d-flex justify-content-between align-items-center  flex-wrap mb-4 ">
                                     <div class="">
                                         {% if not reseña_existente %}


### PR DESCRIPTION
## Summary
- Make posts span full width on mobile while keeping desktop layout
- Center review section on small screens
- Refine mobile styles for club logo, competitor avatars, and action buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68961360cfe083219e33e52bda750f19