### PR TITLE
Adjust club profile avatars for mobile

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -26,7 +26,7 @@
        font-weight: 600;
  }
 
- .badge-outline {
+.badge-outline {
        font-weight: 600;
        font-size: 0.75rem;
        background-color: transparent;
@@ -34,10 +34,15 @@
        border-radius: 6px;
        padding: 0px 2px 0 2px;
        border: 1px solid black;
- }
+}
 
- /* Verified label next to club name */
- .badge-verified {
+/* Club logo */
+.club-logo {
+       height: 200px;
+}
+
+/* Verified label next to club name */
+.badge-verified {
        display: inline-flex;
        align-items: center;
        justify-content: center;
@@ -467,13 +472,32 @@
  }
 
 @media (max-width: 991.98px) {
+      .club-logo {
+            width: 100px;
+            height: 100px !important;
+            border-radius: 50%;
+            overflow: hidden;
+            margin: 0 auto;
+      }
+
+      .club-logo img {
+            border-radius: 50%;
+      }
+
       .club-actions {
             flex-wrap: nowrap !important;
       }
 
       .club-actions button {
             white-space: normal;
-            word-break: break-word;
+            word-break: keep-all;
+            overflow-wrap: break-word;
             text-align: center;
+      }
+
+      .competitor-avatar,
+      .competitor-avatar-img {
+            width: 50px;
+            height: 50px;
       }
 }

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -22,7 +22,7 @@
         <div class="row">
             <!-- Columna Izquierda: Info del Club -->
             <div class="col-lg-2 ">
-         <div class="position-relative bg-black club-logo d-flex align-items-center justify-content-center" style="height: 200px;">
+         <div class="position-relative bg-black club-logo d-flex align-items-center justify-content-center">
             {% if club.logo|safe_url %}
                 <img src="{{ club.logo|safe_url }}"
                     class="w-100 h-100"


### PR DESCRIPTION
## Summary
- Center club avatar and size to 100x100 with rounded style on mobile and tablet
- Prevent word splits in club info buttons and enlarge competitor avatars

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689616d2bde083218a3b8f6bb2f0bedb