### PR TITLE
Hide navigation buttons on mobile and move booking button

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -10,15 +10,6 @@
         <div class="profile-header d-flex align-items-center mb-4 mt-4">
              {% include 'partials/_back-btn.html' %}
              {% include 'partials/_front-btn.html' %}
-            <div class="d-flex ms-auto justify-content-end gap-2 ">
-
-                <button type="button" class="p-3 booking-btn fw-medium d-flex align-items-center gap-1 mb-1 ms-2 btn btn-dark " data-club-slug="{{ club.slug }}">
-                    <svg class="w-[48px] h-[48px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
-                      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h16m-8-3V4M7 7V4m10 3V4M5 20h14a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Zm3-7h.01v.01H8V13Zm4 0h.01v.01H12V13Zm4 0h.01v.01H16V13Zm-8 4h.01v.01H8V17Zm4 0h.01v.01H12V17Zm4 0h.01v.01H16V17Z"/>
-                    </svg>
-                  Reservar clase
-                </button>
-            </div>
         </div>
         <div class="row">
             <!-- Columna Izquierda: Info del Club -->
@@ -55,8 +46,14 @@
 
                         <li class="club-actions d-flex flex-row flex-lg-column flex-wrap justify-content-center align-items-center align-items-lg-start gap-2 mb-4">
 
+                              <button type="button" class="p-3 booking-btn fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1 btn btn-dark" data-club-slug="{{ club.slug }}">
+                                  <svg class="w-[48px] h-[48px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h16m-8-3V4M7 7V4m10 3V4M5 20h14a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Zm3-7h.01v.01H8V13Zm4 0h.01v.01H12V13Zm4 0h.01v.01H16V13Zm-8 4h.01v.01H8V17Zm4 0h.01v.01H12V17Zm4 0h.01v.01H16V17Z"/>
+                                  </svg>
+                                Reservar clase
+                              </button>
 
-                            <button type="button" class="signup-member-btn fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1" data-club-slug="{{ club.slug }}">
+                              <button type="button" class="signup-member-btn fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1" data-club-slug="{{ club.slug }}">
                                 <svg class="w-[48px] h-[48px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="none" viewBox="0 0 24 24">
                                   <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 12h4m-2 2v-4M4 18v-1a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3v1a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1Zm8-10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
                                 </svg>

--- a/templates/partials/_back-btn.html
+++ b/templates/partials/_back-btn.html
@@ -1,6 +1,6 @@
 <a
   href="#"
-  class="back-button align-items-start my-2 fs-3"
+  class="back-button align-items-start my-2 fs-3 d-none d-lg-inline-flex"
   onclick="window.history.back(); return false;"
 >
   <svg

--- a/templates/partials/_front-btn.html
+++ b/templates/partials/_front-btn.html
@@ -1,10 +1,9 @@
 <a
   href="#"
-  class="front-button align-items-start ms-2 my-2 fs-3"
+  class="front-button align-items-start ms-2 my-2 fs-3 d-none"
   onclick="window.history.forward(); return false;"
-
 >
-<svg
+  <svg
     fill="#000000"
     width="256px"
     height="256px"
@@ -12,7 +11,7 @@
     id="right-arrow"
     xmlns="http://www.w3.org/2000/svg"
     class="icon line"
->
+  >
     <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
     <g
       id="SVGRepo_tracerCarrier"
@@ -42,11 +41,13 @@
       state.idx = window.history.length - 1;
       window.history.replaceState(state, document.title);
     }
-    if (state.idx < window.history.length - 1) {
-      const btn = document.querySelector(".front-button");
-      if (btn) {
-        btn.style.display = "flex";
-      }
+    const btn = document.querySelector(".front-button");
+    if (
+      window.innerWidth >= 992 &&
+      state.idx < window.history.length - 1 &&
+      btn
+    ) {
+      btn.classList.remove("d-none");
     }
   });
 </script>


### PR DESCRIPTION
## Summary
- Hide back and forward navigation buttons on mobile and tablet
- Display forward button on desktop only when forward navigation exists
- Relocate "Reservar clase" button beneath the club name in club profile

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68963633c8b48321b490e7de4d81bdda