### PR TITLE
Remove navigation arrows and center booking button

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -7,19 +7,6 @@
 <main class="flex-grow-1">
 
     <div class="container-fluid mb-5 col-12 px-3 my-3" id="profile-container">
-        <div class="profile-header d-flex align-items-center mb-4 mt-4">
-             {% include 'partials/_back-btn.html' %}
-             {% include 'partials/_front-btn.html' %}
-            <div class="d-flex ms-auto justify-content-end gap-2 ">
-
-                <button type="button" class="p-3 booking-btn fw-medium d-flex align-items-center gap-1 mb-1 ms-2 btn btn-dark " data-club-slug="{{ club.slug }}">
-                    <svg class="w-[48px] h-[48px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
-                      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h16m-8-3V4M7 7V4m10 3V4M5 20h14a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Zm3-7h.01v.01H8V13Zm4 0h.01v.01H12V13Zm4 0h.01v.01H16V13Zm-8 4h.01v.01H8V17Zm4 0h.01v.01H12V17Zm4 0h.01v.01H16V17Z"/>
-                    </svg>
-                  Reservar clase
-                </button>
-            </div>
-        </div>
         <div class="row">
             <!-- Columna Izquierda: Info del Club -->
             <div class="col-lg-2 ">
@@ -52,6 +39,15 @@
                               {% include 'partials/_verified-bronze.html' %}
                             {% endif %}
                         </h3>
+
+                        <div class="d-flex justify-content-center my-3 w-100">
+                            <button type="button" class="p-3 booking-btn fw-medium d-flex align-items-center gap-1 btn btn-dark" data-club-slug="{{ club.slug }}">
+                                <svg class="w-[48px] h-[48px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                                  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h16m-8-3V4M7 7V4m10 3V4M5 20h14a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Zm3-7h.01v.01H8V13Zm4 0h.01v.01H12V13Zm4 0h.01v.01H16V13Zm-8 4h.01v.01H8V17Zm4 0h.01v.01H12V17Zm4 0h.01v.01H16V17Z"/>
+                                </svg>
+                              Reservar clase
+                            </button>
+                        </div>
 
                         <li class="club-actions d-flex flex-row flex-lg-column flex-wrap justify-content-center align-items-center align-items-lg-start gap-2 mb-4">
 


### PR DESCRIPTION
## Summary
- Remove back and forward navigation arrows from club profile
- Center "Reservar clase" button below club name

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68963ac44c048321b23ff0a3ec2f626f