### PR TITLE
Hide back/forward buttons on mobile

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -172,6 +172,13 @@ p {
     height: 25px;
 }
 
+@media (max-width: 767.98px) {
+    .back-button,
+    .front-button {
+        display: none !important;
+    }
+}
+
 
 .container-fluid {
     max-width: 1600px;


### PR DESCRIPTION
## Summary
- Hide back and forward navigation buttons on mobile using responsive CSS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68963e2263288321bcf3da07a45cd09a