### PR TITLE
Adjust booking button placement on mobile

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -10,7 +10,7 @@
         <div class="profile-header d-flex align-items-center mb-4 mt-4">
              {% include 'partials/_back-btn.html' %}
              {% include 'partials/_front-btn.html' %}
-            <div class="d-flex ms-auto justify-content-end gap-2 ">
+            <div class="d-none d-lg-flex ms-auto justify-content-end gap-2 ">
 
                 <button type="button" class="p-3 booking-btn fw-medium d-flex align-items-center gap-1 mb-1 ms-2 btn btn-dark " data-club-slug="{{ club.slug }}">
                     <svg class="w-[48px] h-[48px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
@@ -52,6 +52,13 @@
                               {% include 'partials/_verified-bronze.html' %}
                             {% endif %}
                         </h3>
+
+                        <button type="button" class="p-3 booking-btn fw-medium d-flex align-items-center gap-1 btn btn-dark mt-1 mb-1 mx-auto d-lg-none" data-club-slug="{{ club.slug }}">
+                            <svg class="w-[48px] h-[48px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                              <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h16m-8-3V4M7 7V4m10 3V4M5 20h14a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Zm3-7h.01v.01H8V13Zm4 0h.01v.01H12V13Zm4 0h.01v.01H16V13Zm-8 4h.01v.01H8V17Zm4 0h.01v.01H12V17Zm4 0h.01v.01H16V17Z"/>
+                            </svg>
+                          Reservar clase
+                        </button>
 
                         <li class="club-actions d-flex flex-row flex-lg-column flex-wrap justify-content-center align-items-center align-items-lg-start gap-2 mb-4">
 


### PR DESCRIPTION
## Summary
- Move booking button below club name for mobile and tablet viewports
- Hide desktop booking button on smaller screens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68963ff783f88321af6b177e12de7327