### PR TITLE
Add breadcrumb navigation to club profile

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -7,6 +7,19 @@
 
     <div class="container-fluid mb-5 col-12 px-3 my-3" id="profile-container">
         <div class="profile-header d-flex align-items-center mb-4 mt-4">
+            <span class="text-muted small d-flex text-center justify-content-center align-items-center">
+                <a href="{% url 'home' %}" class="text-muted text-decoration-none">Inicio</a>
+                &gt;
+                <a href="{% url 'home' %}" class="text-muted text-decoration-none">Clubs de boxeo</a>
+                &gt;
+                <a href="{% url 'search_results' %}?q={{ club.country|urlencode }}" class="text-muted text-decoration-none">{{ club.country }}</a>
+                {% if club.region %}
+                    &gt;
+                    <a href="{% url 'search_results' %}?q={{ club.region|urlencode }}" class="text-muted text-decoration-none">{{ club.region }}</a>
+                {% endif %}
+                &gt;
+                <a href="{% url 'search_results' %}?q={{ club.city|urlencode }}" class="text-muted text-decoration-none">{{ club.city }}</a>
+            </span>
             <div class="d-none d-lg-flex ms-auto justify-content-end gap-2 ">
 
                 <button type="button" class="p-3 booking-btn fw-medium d-flex align-items-center gap-1 mb-1 ms-2 btn btn-dark " data-club-slug="{{ club.slug }}">


### PR DESCRIPTION
## Summary
- add breadcrumb navigation linking to location-specific search results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68967e65b9e8832192d6db8d14c6657c