### PR TITLE
Add regional breadcrumbs and unified city list for search

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -113,6 +113,46 @@ class SearchResultsTests(TestCase):
         self.assertContains(response, "badge-verified-silver")
         self.assertContains(response, "badge-verified-bronze")
 
+    def test_breadcrumbs_for_city(self):
+        Club.objects.create(
+            name="Sevilla Club",
+            city="Sevilla",
+            region="Andalucía",
+            country="España",
+            address="addr",
+            phone="1",
+            email="sev@example.com",
+        )
+        url = reverse("search_results")
+        response = self.client.get(url, {"q": "Sevilla"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([c["name"] for c in response.context["breadcrumbs"]], ["España", "Andalucía", "Sevilla"])
+
+    def test_filter_by_region_without_query(self):
+        Club.objects.create(
+            name="Sevilla Club",
+            city="Sevilla",
+            region="Andalucía",
+            country="España",
+            address="addr",
+            phone="1",
+            email="sev@example.com",
+        )
+        Club.objects.create(
+            name="Madrid Club",
+            city="Madrid",
+            region="Madrid",
+            country="España",
+            address="addr",
+            phone="1",
+            email="mad@example.com",
+        )
+        url = reverse("search_results")
+        response = self.client.get(url, {"region": "Andalucía"})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Sevilla Club")
+        self.assertNotContains(response, "Madrid Club")
+
 class ClubPhotoResizeTests(TestCase):
     def test_photo_resized_on_save(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/apps/clubs/views/search.py
+++ b/apps/clubs/views/search.py
@@ -3,16 +3,30 @@ from django.shortcuts import render, redirect
 from django.db.models import Q, F, FloatField, Avg, Count, ExpressionWrapper
 from django.db.models.functions import Round
 from django.core.paginator import Paginator
+from django.urls import reverse
 from apps.clubs.models import Club, Entrenador
+from apps.clubs.spain import REGION_PROVINCES, CITY_TO_PROVINCE
+
+PROVINCE_TO_REGION = {p: r for r, ps in REGION_PROVINCES.items() for p in ps}
+CITY_TO_REGION = {c: PROVINCE_TO_REGION.get(p) for c, p in CITY_TO_PROVINCE.items()}
 
 
 def search_results(request):
     search_query = request.GET.get('q', '').strip()
     selected_category = request.GET.get('category', '').strip()
     sort_option = request.GET.get('sort', '').strip()
+    country = request.GET.get('country', '').strip()
+    region = request.GET.get('region', '').strip()
+    city = request.GET.get('city', '').strip()
 
-    # Rechazar búsquedas vacías o demasiado cortas
-    if not search_query or len(search_query) < 3:
+    if not city and search_query in CITY_TO_REGION:
+        city = search_query
+        region = region or CITY_TO_REGION.get(city, '')
+        country = country or 'España'
+
+    if not any([search_query, country, region, city]):
+        return redirect('home')
+    if search_query and len(search_query) < 3 and not any([country, region, city]):
         return redirect('home')
 
     if selected_category == 'entrenador':
@@ -22,10 +36,25 @@ def search_results(request):
             Q(ciudad__icontains=search_query) |
             Q(club__name__icontains=search_query)
         )
+        if city:
+            coaches = coaches.filter(ciudad__iexact=city)
+        if region:
+            coaches = coaches.filter(club__region__iexact=region)
+        if country:
+            coaches = coaches.filter(club__country__iexact=country)
 
         paginator = Paginator(coaches, 12)
         page_number = request.GET.get('page')
         page_obj = paginator.get_page(page_number)
+
+        breadcrumbs = []
+        base_url = reverse('search_results')
+        if country:
+            breadcrumbs.append({'name': country, 'url': f"{base_url}?country={country}"})
+        if region:
+            breadcrumbs.append({'name': region, 'url': f"{base_url}?country={country}&region={region}"})
+        if city:
+            breadcrumbs.append({'name': city, 'url': None})
 
         return render(request, 'clubs/search_coaches.html', {
             'coaches': page_obj,
@@ -33,18 +62,28 @@ def search_results(request):
             'search_query': search_query,
             'selected_category': selected_category,
             'sort_option': sort_option,
+            'country': country,
+            'region': region,
+            'city': city,
+            'breadcrumbs': breadcrumbs,
             'back_url': request.META.get('HTTP_REFERER', '/'),
         })
 
     # Base queryset solo clubes
     clubs = Club.objects.all()
 
-    # Búsqueda textual flexible
-    clubs = clubs.filter(
-        Q(name__icontains=search_query) |
-        Q(city__icontains=search_query) |
-        Q(address__icontains=search_query)
-    )
+    if search_query:
+        clubs = clubs.filter(
+            Q(name__icontains=search_query) |
+            Q(city__icontains=search_query) |
+            Q(address__icontains=search_query)
+        )
+    if city:
+        clubs = clubs.filter(city__iexact=city)
+    if region:
+        clubs = clubs.filter(region__iexact=region)
+    if country:
+        clubs = clubs.filter(country__iexact=country)
 
     # Filtro por categoría si se proporciona
     if selected_category:
@@ -76,11 +115,24 @@ def search_results(request):
     page_number = request.GET.get('page')
     page_obj = paginator.get_page(page_number)
 
+    breadcrumbs = []
+    base_url = reverse('search_results')
+    if country:
+        breadcrumbs.append({'name': country, 'url': f"{base_url}?country={country}"})
+    if region:
+        breadcrumbs.append({'name': region, 'url': f"{base_url}?country={country}&region={region}"})
+    if city:
+        breadcrumbs.append({'name': city, 'url': None})
+
     return render(request, 'clubs/search_results.html', {
         'clubs': page_obj,
         'page_obj': page_obj,
         'search_query': search_query,
         'selected_category': selected_category,
         'sort_option': sort_option,
+        'country': country,
+        'region': region,
+        'city': city,
+        'breadcrumbs': breadcrumbs,
         'back_url': request.META.get('HTTP_REFERER', '/'),
     })

--- a/static/js/geolocator.js
+++ b/static/js/geolocator.js
@@ -7,14 +7,29 @@ document.addEventListener('DOMContentLoaded', function () {
     const locationOption = document.getElementById('use-location-option');
     const list = document.getElementById('autocomplete-list');
 
-    const suggestions = [
-        "A Coruña", "Álava", "Albacete", "Alicante", "Almería", "Asturias", "Ávila", "Badajoz", "Baleares", "Barcelona",
-        "Burgos", "Cáceres", "Cádiz", "Cantabria", "Castellón", "Ciudad Real", "Córdoba", "Cuenca", "Girona", "Granada",
-        "Guadalajara", "Gipuzkoa", "Huelva", "Huesca", "Jaén", "La Rioja", "Las Palmas", "León", "Lérida", "Lugo", "Madrid",
-        "Málaga", "Murcia", "Navarra", "Ourense", "Palencia", "Pontevedra", "Salamanca", "Segovia", "Sevilla", "Soria",
-        "Tarragona", "Santa Cruz de Tenerife", "Teruel", "Toledo", "Valencia", "Valladolid", "Vizcaya", "Zamora", "Zaragoza",
-        "Ceuta", "Melilla"
-    ];
+    const citiesByRegion = {
+        'Andalucía': ['Almería', 'Cádiz', 'Córdoba', 'Granada', 'Huelva', 'Jaén', 'Málaga', 'Sevilla'],
+        'Aragón': ['Huesca', 'Teruel', 'Zaragoza'],
+        'Asturias': ['Oviedo'],
+        'Islas Baleares': ['Palma de Mallorca'],
+        'Canarias': ['Las Palmas de Gran Canaria', 'Santa Cruz de Tenerife'],
+        'Cantabria': ['Santander'],
+        'Castilla-La Mancha': ['Albacete', 'Ciudad Real', 'Cuenca', 'Guadalajara', 'Toledo'],
+        'Castilla y León': ['Ávila', 'Burgos', 'León', 'Palencia', 'Salamanca', 'Segovia', 'Soria', 'Valladolid', 'Zamora'],
+        'Cataluña': ['Barcelona', 'Girona', 'Lleida', 'Tarragona'],
+        'Comunidad Valenciana': ['Alicante', 'Castellón de la Plana', 'Valencia'],
+        'Extremadura': ['Badajoz', 'Cáceres'],
+        'Galicia': ['A Coruña', 'Lugo', 'Ourense', 'Pontevedra'],
+        'Madrid': ['Madrid'],
+        'Murcia': ['Murcia'],
+        'Navarra': ['Pamplona'],
+        'País Vasco': ['Vitoria-Gasteiz', 'San Sebastián', 'Bilbao'],
+        'La Rioja': ['Logroño'],
+        'Ceuta': ['Ceuta'],
+        'Melilla': ['Melilla']
+    };
+
+    const suggestions = Object.values(citiesByRegion).flat();
 
     function showSuggestions(query) {
         list.innerHTML = ''; // Limpiar lista

--- a/templates/clubs/search_coaches.html
+++ b/templates/clubs/search_coaches.html
@@ -5,6 +5,20 @@
 
 {% block content %}
 <div class="container-fluid px-3 my-5 col-10">
+    {% if breadcrumbs %}
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{% url 'home' %}">Inicio</a></li>
+            {% for crumb in breadcrumbs %}
+                {% if forloop.last %}
+                <li class="breadcrumb-item active" aria-current="page">{{ crumb.name }}</li>
+                {% else %}
+                <li class="breadcrumb-item"><a href="{{ crumb.url }}">{{ crumb.name }}</a></li>
+                {% endif %}
+            {% endfor %}
+        </ol>
+    </nav>
+    {% endif %}
 
     <div class="d-flex justify-content-end align-items-center mb-3">
         {% include 'partials/_filter-options.html' %}
@@ -40,7 +54,7 @@
         <ul class="pagination justify-content-center">
             {% if page_obj.has_previous %}
             <li class="page-item">
-                <a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}&page={{ page_obj.previous_page_number }}" aria-label="Anterior">
+                <a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}{% if country %}&country={{ country }}{% endif %}{% if region %}&region={{ region }}{% endif %}{% if city %}&city={{ city }}{% endif %}&page={{ page_obj.previous_page_number }}" aria-label="Anterior">
                     &laquo;
                 </a>
             </li>
@@ -51,12 +65,12 @@
             {% if page_obj.number == num %}
             <li class="page-item active"><span class="page-link">{{ num }}</span></li>
             {% else %}
-            <li class="page-item"><a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}&page={{ num }}">{{ num }}</a></li>
+            <li class="page-item"><a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}{% if country %}&country={{ country }}{% endif %}{% if region %}&region={{ region }}{% endif %}{% if city %}&city={{ city }}{% endif %}&page={{ num }}">{{ num }}</a></li>
             {% endif %}
             {% endfor %}
             {% if page_obj.has_next %}
             <li class="page-item">
-                <a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}&page={{ page_obj.next_page_number }}" aria-label="Siguiente">
+                <a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}{% if country %}&country={{ country }}{% endif %}{% if region %}&region={{ region }}{% endif %}{% if city %}&city={{ city }}{% endif %}&page={{ page_obj.next_page_number }}" aria-label="Siguiente">
                     &raquo;
                 </a>
             </li>

--- a/templates/clubs/search_results.html
+++ b/templates/clubs/search_results.html
@@ -5,6 +5,20 @@
 
 {% block content %}
 <div class="container-fluid mb-5 px-3 my-3 col-12">
+    {% if breadcrumbs %}
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{% url 'home' %}">Inicio</a></li>
+            {% for crumb in breadcrumbs %}
+                {% if forloop.last %}
+                <li class="breadcrumb-item active" aria-current="page">{{ crumb.name }}</li>
+                {% else %}
+                <li class="breadcrumb-item"><a href="{{ crumb.url }}">{{ crumb.name }}</a></li>
+                {% endif %}
+            {% endfor %}
+        </ol>
+    </nav>
+    {% endif %}
 
     <!-- Fila superior con volver y filtro -->
 
@@ -68,7 +82,7 @@
         <ul class="pagination justify-content-center">
             {% if page_obj.has_previous %}
             <li class="page-item">
-                <a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}&page={{ page_obj.previous_page_number }}" aria-label="Anterior">
+                <a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}{% if country %}&country={{ country }}{% endif %}{% if region %}&region={{ region }}{% endif %}{% if city %}&city={{ city }}{% endif %}&page={{ page_obj.previous_page_number }}" aria-label="Anterior">
                     &laquo;
                 </a>
             </li>
@@ -79,12 +93,12 @@
             {% if page_obj.number == num %}
             <li class="page-item active"><span class="page-link">{{ num }}</span></li>
             {% else %}
-            <li class="page-item"><a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}&page={{ num }}">{{ num }}</a></li>
+            <li class="page-item"><a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}{% if country %}&country={{ country }}{% endif %}{% if region %}&region={{ region }}{% endif %}{% if city %}&city={{ city }}{% endif %}&page={{ num }}">{{ num }}</a></li>
             {% endif %}
             {% endfor %}
             {% if page_obj.has_next %}
             <li class="page-item">
-                <a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}&page={{ page_obj.next_page_number }}" aria-label="Siguiente">
+                <a class="page-link" href="?q={{ search_query }}{% if selected_category %}&category={{ selected_category }}{% endif %}{% if sort_option %}&sort={{ sort_option }}{% endif %}{% if country %}&country={{ country }}{% endif %}{% if region %}&region={{ region }}{% endif %}{% if city %}&city={{ city }}{% endif %}&page={{ page_obj.next_page_number }}" aria-label="Siguiente">
                     &raquo;
                 </a>
             </li>

--- a/templates/partials/_filter-options.html
+++ b/templates/partials/_filter-options.html
@@ -1,6 +1,9 @@
      <form method="get" class="d-flex align-items-center" style="gap: 10px;">
     <input type="hidden" name="q" value="{{ search_query }}">
     <input type="hidden" name="sort" id="sort-input" value="{{ request.GET.sort|default:'' }}">
+    {% if country %}<input type="hidden" name="country" value="{{ country }}">{% endif %}
+    {% if region %}<input type="hidden" name="region" value="{{ region }}">{% endif %}
+    {% if city %}<input type="hidden" name="city" value="{{ city }}">{% endif %}
 
     <div class="custom-dropdown small" id="sort-dropdown">
         <div class="selected">


### PR DESCRIPTION
## Summary
- Use regional city list for search suggestions
- Support country/region/city filters with breadcrumbs
- Preserve location parameters in pagination and sorting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896874195288321a180d3ea004502ab