### PR TITLE
Add breadcrumb partial with category info

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -126,7 +126,10 @@ class SearchResultsTests(TestCase):
         url = reverse("search_results")
         response = self.client.get(url, {"q": "Sevilla"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual([c["name"] for c in response.context["breadcrumbs"]], ["España", "Andalucía", "Sevilla"])
+        self.assertEqual(
+            [c["name"] for c in response.context["breadcrumbs"]],
+            ["Clubs de Sevilla", "España", "Andalucía", "Sevilla"],
+        )
 
     def test_filter_by_region_without_query(self):
         Club.objects.create(

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -3,6 +3,7 @@ from django.http import HttpResponse
 from ..models import Club, Entrenador
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.urls import reverse
 from apps.clubs.forms import (
     ReseñaForm,
     ClubPostForm,
@@ -94,6 +95,20 @@ def club_profile(request, slug):
     for r in reseñas:
         r.edit_form = ReseñaForm(instance=r)
 
+    base_url = reverse('search_results')
+    category_label = f"Clubs de {club.get_category_display()}"
+    query_params = f"?category=club&q={club.get_category_display()}"
+    breadcrumbs = [
+        {'name': category_label, 'url': f"{base_url}{query_params}"}
+    ]
+    if club.country:
+        breadcrumbs.append({'name': club.country, 'url': f"{base_url}{query_params}&country={club.country}"})
+    if club.region:
+        breadcrumbs.append({'name': club.region, 'url': f"{base_url}{query_params}&country={club.country}&region={club.region}"})
+    if club.city:
+        breadcrumbs.append({'name': club.city, 'url': f"{base_url}{query_params}&country={club.country}&region={club.region}&city={club.city}"})
+    breadcrumbs.append({'name': club.name, 'url': None})
+
     return render(request, 'clubs/club_profile.html', {
         'club': club,
         'reseñas': reseñas,
@@ -109,6 +124,7 @@ def club_profile(request, slug):
         'register_form': register_form,
         'schedule_data': schedule_data,
         'booking_classes': club.booking_classes.all(),
+        'breadcrumbs': breadcrumbs,
 
     })
 

--- a/apps/clubs/views/search.py
+++ b/apps/clubs/views/search.py
@@ -49,10 +49,17 @@ def search_results(request):
 
         breadcrumbs = []
         base_url = reverse('search_results')
+        category_label = 'Entrenadores'
+        query_params = f"?category=entrenador"
+        if search_query:
+            category_label = f"{category_label} de {search_query}"
+            query_params += f"&q={search_query}"
+        breadcrumbs.append({'name': category_label, 'url': f"{base_url}{query_params}"})
+
         if country:
-            breadcrumbs.append({'name': country, 'url': f"{base_url}?country={country}"})
+            breadcrumbs.append({'name': country, 'url': f"{base_url}{query_params}&country={country}"})
         if region:
-            breadcrumbs.append({'name': region, 'url': f"{base_url}?country={country}&region={region}"})
+            breadcrumbs.append({'name': region, 'url': f"{base_url}{query_params}&country={country}&region={region}"})
         if city:
             breadcrumbs.append({'name': city, 'url': None})
 
@@ -117,10 +124,24 @@ def search_results(request):
 
     breadcrumbs = []
     base_url = reverse('search_results')
+    category_names = {
+        'club': 'Clubs',
+        'entrenador': 'Entrenadores',
+        'promotor': 'Promotores',
+        'servicio': 'Servicios',
+    }
+    category_key = selected_category or 'club'
+    category_label = category_names.get(category_key, category_key.title())
+    query_params = f"?category={category_key}"
+    if search_query:
+        category_label = f"{category_label} de {search_query}"
+        query_params += f"&q={search_query}"
+    breadcrumbs.append({'name': category_label, 'url': f"{base_url}{query_params}"})
+
     if country:
-        breadcrumbs.append({'name': country, 'url': f"{base_url}?country={country}"})
+        breadcrumbs.append({'name': country, 'url': f"{base_url}{query_params}&country={country}"})
     if region:
-        breadcrumbs.append({'name': region, 'url': f"{base_url}?country={country}&region={region}"})
+        breadcrumbs.append({'name': region, 'url': f"{base_url}{query_params}&country={country}&region={region}"})
     if city:
         breadcrumbs.append({'name': city, 'url': None})
 

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -6,21 +6,8 @@
 <main class="flex-grow-1">
 
     <div class="container-fluid mb-5 col-12 px-3 my-3" id="profile-container">
+        {% include 'partials/_breadcrumb.html' %}
         <div class="profile-header d-flex align-items-center mb-4 mt-4">
-            <span class="small d-flex text-center justify-content-center align-items-center">
-                <a href="{% url 'home' %}" class="text-muted text-decoration-none  hover-underline">Inicio</a>
-                
-                <span class="ms-1 me-1 text-muted fw-light">></span>
-                <a href="{% url 'home' %}" class="text-muted text-decoration-none  hover-underline">Clubs de boxeo</a>
-            <span class="ms-1 me-1 text-muted fw-light">></span> 
-                <a href="{% url 'search_results' %}?q={{ club.country|urlencode }}" class="text-muted text-decoration-none  hover-underline">{{ club.country }}</a>
-                {% if club.region %}
-              <span class="ms-1 me-1 text-muted fw-light">></span>
-                    <a href="{% url 'search_results' %}?q={{ club.region|urlencode }}" class="text-muted text-decoration-none  hover-underline">{{ club.region }}</a>
-                {% endif %}
-          <span class="ms-1 me-1 text-muted fw-light">></span>
-                <a href="{% url 'search_results' %}?q={{ club.city|urlencode }}" class="text-muted text-decoration-none  hover-underline">{{ club.city }}</a>
-            </span>
             <div class="d-none d-lg-flex ms-auto justify-content-end gap-2 ">
 
                 <button type="button" class="p-3 booking-btn fw-medium d-flex align-items-center gap-1 mb-1 ms-2 btn btn-dark " data-club-slug="{{ club.slug }}">

--- a/templates/clubs/search_results.html
+++ b/templates/clubs/search_results.html
@@ -5,20 +5,7 @@
 
 {% block content %}
 <div class="container-fluid mb-5 px-3 my-3 col-12">
-    {% if breadcrumbs %}
-    <nav aria-label="breadcrumb" class="mb-3">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a class="text-muted text-decoration-none  hover-underline" href="{% url 'home' %}">Inicio</a></li>
-            {% for crumb in breadcrumbs %}
-                {% if forloop.last %}
-                <li class="breadcrumb-item active text-muted text-decoration-none  hover-underline " aria-current="page">{{ crumb.name }}</li>
-                {% else %}
-                <li class="text-muted text-decoration-none  hover-underline breadcrumb-item"><a href="{{ crumb.url }}">{{ crumb.name }}</a></li>
-                {% endif %}
-            {% endfor %}
-        </ol>
-    </nav>
-    {% endif %}
+    {% include 'partials/_breadcrumb.html' %}
 
     <!-- Fila superior con volver y filtro -->
 

--- a/templates/partials/_breadcrumb.html
+++ b/templates/partials/_breadcrumb.html
@@ -1,0 +1,14 @@
+{% if breadcrumbs %}
+<nav aria-label="breadcrumb" class="mb-3">
+  <ol class="breadcrumb small text-muted mb-0">
+    <li class="breadcrumb-item"><a class="text-muted text-decoration-none hover-underline small" href="{% url 'home' %}">Inicio</a></li>
+    {% for crumb in breadcrumbs %}
+      {% if crumb.url %}
+        <li class="breadcrumb-item"><a class="text-muted text-decoration-none hover-underline small" href="{{ crumb.url }}">{{ crumb.name }}</a></li>
+      {% else %}
+        <li class="breadcrumb-item active text-muted small" aria-current="page">{{ crumb.name }}</li>
+      {% endif %}
+    {% endfor %}
+  </ol>
+</nav>
+{% endif %}


### PR DESCRIPTION
## Summary
- create reusable `_breadcrumb` partial with muted small styling
- show selected category in search breadcrumbs and reuse partial in club profiles
- update tests for new breadcrumb format

## Testing
- `python manage.py test` *(no tests detected)*
- `python manage.py test apps.clubs` *(failed: expected str, bytes or os.PathLike object, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_68968b964c388321bee78c4177c46962