### PR TITLE
Update breadcrumbs for boxing search

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -128,7 +128,7 @@ class SearchResultsTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             [c["name"] for c in response.context["breadcrumbs"]],
-            ["Clubs de Sevilla", "España", "Andalucía", "Sevilla"],
+            ["Clubs de Boxeo", "España", "Andalucía", "Sevilla"],
         )
 
     def test_filter_by_region_without_query(self):

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -96,18 +96,18 @@ def club_profile(request, slug):
         r.edit_form = ReseñaForm(instance=r)
 
     base_url = reverse('search_results')
-    category_label = f"Clubs de {club.get_category_display()}"
-    query_params = f"?category=club&q={club.get_category_display()}"
+    category_label = "Clubs de Boxeo"
+    query_params = "?category=club"
     breadcrumbs = [
         {'name': category_label, 'url': f"{base_url}{query_params}"}
     ]
-    if club.country:
-        breadcrumbs.append({'name': club.country, 'url': f"{base_url}{query_params}&country={club.country}"})
+    country_label = club.country or 'España'
+    breadcrumbs.append({'name': country_label, 'url': f"{base_url}{query_params}&country={country_label}"})
     if club.region:
-        breadcrumbs.append({'name': club.region, 'url': f"{base_url}{query_params}&country={club.country}&region={club.region}"})
+        breadcrumbs.append({'name': club.region, 'url': f"{base_url}{query_params}&country={country_label}&region={club.region}"})
     if club.city:
-        breadcrumbs.append({'name': club.city, 'url': f"{base_url}{query_params}&country={club.country}&region={club.region}&city={club.city}"})
-    breadcrumbs.append({'name': club.name, 'url': None})
+        breadcrumbs.append({'name': club.city, 'url': f"{base_url}{query_params}&country={country_label}&region={club.region}&city={club.city}"})
+    breadcrumbs.append({'name': club.name, 'url': reverse('club_profile', args=[club.slug])})
 
     return render(request, 'clubs/club_profile.html', {
         'club': club,

--- a/apps/clubs/views/search.py
+++ b/apps/clubs/views/search.py
@@ -49,17 +49,16 @@ def search_results(request):
 
         breadcrumbs = []
         base_url = reverse('search_results')
-        category_label = 'Entrenadores'
+        category_label = 'Entrenadores de Boxeo'
         query_params = f"?category=entrenador"
         if search_query:
-            category_label = f"{category_label} de {search_query}"
             query_params += f"&q={search_query}"
         breadcrumbs.append({'name': category_label, 'url': f"{base_url}{query_params}"})
 
-        if country:
-            breadcrumbs.append({'name': country, 'url': f"{base_url}{query_params}&country={country}"})
+        country_label = country or 'España'
+        breadcrumbs.append({'name': country_label, 'url': f"{base_url}{query_params}&country={country_label}"})
         if region:
-            breadcrumbs.append({'name': region, 'url': f"{base_url}{query_params}&country={country}&region={region}"})
+            breadcrumbs.append({'name': region, 'url': f"{base_url}{query_params}&country={country_label}&region={region}"})
         if city:
             breadcrumbs.append({'name': city, 'url': None})
 
@@ -131,17 +130,16 @@ def search_results(request):
         'servicio': 'Servicios',
     }
     category_key = selected_category or 'club'
-    category_label = category_names.get(category_key, category_key.title())
+    category_label = f"{category_names.get(category_key, category_key.title())} de Boxeo"
     query_params = f"?category={category_key}"
     if search_query:
-        category_label = f"{category_label} de {search_query}"
         query_params += f"&q={search_query}"
     breadcrumbs.append({'name': category_label, 'url': f"{base_url}{query_params}"})
 
-    if country:
-        breadcrumbs.append({'name': country, 'url': f"{base_url}{query_params}&country={country}"})
+    country_label = country or 'España'
+    breadcrumbs.append({'name': country_label, 'url': f"{base_url}{query_params}&country={country_label}"})
     if region:
-        breadcrumbs.append({'name': region, 'url': f"{base_url}{query_params}&country={country}&region={region}"})
+        breadcrumbs.append({'name': region, 'url': f"{base_url}{query_params}&country={country_label}&region={region}"})
     if city:
         breadcrumbs.append({'name': city, 'url': None})
 

--- a/templates/clubs/search_coaches.html
+++ b/templates/clubs/search_coaches.html
@@ -5,20 +5,7 @@
 
 {% block content %}
 <div class="container-fluid px-3 my-5 col-10">
-    {% if breadcrumbs %}
-    <nav aria-label="breadcrumb" class="mb-3">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'home' %}">Inicio</a></li>
-            {% for crumb in breadcrumbs %}
-                {% if forloop.last %}
-                <li class="breadcrumb-item active" aria-current="page">{{ crumb.name }}</li>
-                {% else %}
-                <li class="breadcrumb-item"><a href="{{ crumb.url }}">{{ crumb.name }}</a></li>
-                {% endif %}
-            {% endfor %}
-        </ol>
-    </nav>
-    {% endif %}
+    {% include 'partials/_breadcrumb.html' %}
 
     <div class="d-flex justify-content-end align-items-center mb-3">
         {% include 'partials/_filter-options.html' %}

--- a/templates/partials/_breadcrumb.html
+++ b/templates/partials/_breadcrumb.html
@@ -1,6 +1,6 @@
 {% if breadcrumbs %}
 <nav aria-label="breadcrumb" class="mb-3">
-  <ol class="breadcrumb small text-muted mb-0">
+  <ol class="breadcrumb small text-muted mb-0" style="--bs-breadcrumb-divider: '>';">
     <li class="breadcrumb-item"><a class="text-muted text-decoration-none hover-underline small" href="{% url 'home' %}">Inicio</a></li>
     {% for crumb in breadcrumbs %}
       {% if crumb.url %}


### PR DESCRIPTION
## Summary
- Show breadcrumb divider `>` and include a dropdown-based "de Boxeo" step with "España".
- Link last breadcrumb to club profile and reuse the breadcrumb partial across search templates.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689693211060832195d1acadd4749420