### PR TITLE
Show province clubs when filtering by region

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -6,7 +6,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth.models import User, Group
 from PIL import Image
 
-from .models import Club, ClubPhoto, ClubPost, Miembro, Pago, Competidor
+from apps.clubs.models import Club, ClubPhoto, ClubPost, Miembro, Pago, Competidor
 from datetime import date
 
 
@@ -155,6 +155,31 @@ class SearchResultsTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Sevilla Club")
         self.assertNotContains(response, "Madrid Club")
+
+    def test_region_filter_includes_provinces(self):
+        Club.objects.create(
+            name="Castellon Club",
+            city="Castellón de la Plana",
+            region="Castellón",
+            country="España",
+            address="addr",
+            phone="1",
+            email="cas@example.com",
+        )
+        Club.objects.create(
+            name="Alicante Club",
+            city="Alicante",
+            region="Alicante",
+            country="España",
+            address="addr",
+            phone="1",
+            email="ali@example.com",
+        )
+        url = reverse("search_results")
+        response = self.client.get(url, {"region": "Comunidad Valenciana"})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Castellon Club")
+        self.assertContains(response, "Alicante Club")
 
 class ClubPhotoResizeTests(TestCase):
     def test_photo_resized_on_save(self):

--- a/apps/clubs/views/search.py
+++ b/apps/clubs/views/search.py
@@ -39,7 +39,10 @@ def search_results(request):
         if city:
             coaches = coaches.filter(ciudad__iexact=city)
         if region:
-            coaches = coaches.filter(club__region__iexact=region)
+            region_filter = Q(club__region__iexact=region)
+            for province in REGION_PROVINCES.get(region, []):
+                region_filter |= Q(club__region__iexact=province)
+            coaches = coaches.filter(region_filter)
         if country:
             coaches = coaches.filter(club__country__iexact=country)
 
@@ -91,7 +94,10 @@ def search_results(request):
     if city:
         clubs = clubs.filter(city__iexact=city)
     if region:
-        clubs = clubs.filter(region__iexact=region)
+        region_filter = Q(region__iexact=region)
+        for province in REGION_PROVINCES.get(region, []):
+            region_filter |= Q(region__iexact=province)
+        clubs = clubs.filter(region_filter)
     if country:
         clubs = clubs.filter(country__iexact=country)
 


### PR DESCRIPTION
## Summary
- expand region filtering to include clubs whose `region` matches any province in the autonomous community
- cover region filtering with test ensuring Comunidad Valenciana shows Castellón and Alicante clubs

## Testing
- `pytest`
- `pytest apps/clubs/tests.py::SearchResultsTests::test_region_filter_includes_provinces -vv`


------
https://chatgpt.com/codex/tasks/task_e_6896995ac2f48321826b7a87b58cbb9f