### PR TITLE
Fix dashboard feature saving and remove desktop horizontal scroll

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -7,7 +7,6 @@
 }
 .profile-tabs {
     min-width: 200px;
-    overflow-x: auto;
     margin:10px;
 
 }
@@ -23,7 +22,6 @@
 }
 .profile-content {
     flex: 1;
-    overflow-x: auto;
 }
 .profile-section {
     display: none;
@@ -104,6 +102,10 @@
   body.profile-page,
   body.dashboard-page {
     overflow-x: auto !important;
+  }
+  .profile-tabs,
+  .profile-content {
+    overflow-x: auto;
   }
   .navbar-nav .eye-icon {
     order: -1;

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -32,17 +32,17 @@
     <div class="profile-tab" data-target="tab-matchmaker">Matchmaker</div>
   </div>
   <div class="profile-content">
-    <div id="tab-profile" class="profile-section active">
-      <h4>Administrar Perfil</h4>
-      <div class="row g-3 mt-3">
-        <div class="col-lg-6">
-      <form
-        method="post"
-        action="{% url 'club_edit' club.slug %}"
-        enctype="multipart/form-data"
-        class="profile-form "
-      >
+      <div id="tab-profile" class="profile-section active">
+        <h4>Administrar Perfil</h4>
+        <form
+          method="post"
+          action="{% url 'club_edit' club.slug %}"
+          enctype="multipart/form-data"
+          class="profile-form "
+        >
         {% csrf_token %}
+        <div class="row g-3 mt-3">
+          <div class="col-lg-6">
         <h5 class="mb-3  ">Logotipo</h5>
         <div class="mb-5 text-center bg-dark p-3   rounded">
           <div class="avatar-dropzone avatar-dropzone-square mx-auto p-3">
@@ -164,16 +164,8 @@
             {% endif %}
           </div>
         </div>
-
-
-
-
-        <button type="submit" class="btn btn-dark mt-4">Guardar</button>
-      </form>
-
-
-        </div>
-        <div class="col-lg-6 d-flex justify-content-end ps-5">
+      </div>
+      <div class="col-lg-6 d-flex justify-content-end ps-5">
           <!-- Features -->
           <div class="form-field">
 
@@ -237,6 +229,8 @@
         </div>
 
       </div>
+        <button type="submit" class="btn btn-dark mt-4">Guardar</button>
+      </form>
 
     </div>
     <div id="tab-gallery" class="profile-section">


### PR DESCRIPTION
## Summary
- ensure feature selections on dashboard are submitted by moving checkboxes inside the profile form
- prevent horizontal scroll bars on desktop for dashboard and profile pages while keeping them on smaller screens

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6896b211b7648321b1d4bbbfe4a899cb