### PR TITLE
Make club profile tabs sticky on scroll

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -334,13 +334,21 @@
 
 
 
- /* Estilo de los tabs */
- .custom-tab-menu .nav-link {
-       color: #000 !important;
-       padding: 0.75rem 1rem;
-       background-color: transparent;
-       border: none;
-       border-bottom: 1px solid transparent;
+/* Sticky tab menu */
+#clubTabs {
+      position: sticky;
+      top: 0;
+      z-index: 1020;
+      background-color: #ffffff;
+}
+
+/* Estilo de los tabs */
+.custom-tab-menu .nav-link {
+      color: #000 !important;
+      padding: 0.75rem 1rem;
+      background-color: transparent;
+      border: none;
+      border-bottom: 1px solid transparent;
        margin-right: 1rem;
        transition: background-color 0.2s ease, border-color 0.2s ease;
  }

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -181,7 +181,7 @@
                     {% endif %}
                 </div>
                 <!-- Menú de pestañas -->
-                <ul class="border-bottom nav custom-tab-menu mb-3  justify-content-center"
+                <ul class="border-bottom nav custom-tab-menu mb-3 justify-content-center sticky-top bg-white"
                     id="clubTabs"
                     role="tablist">
                     <li class="nav-item" role="presentation">


### PR DESCRIPTION
## Summary
- Keep the club profile tab menu visible by making it sticky with Bootstrap and custom styles.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896bc3048148321a87c6f5c8f45de65