### PR TITLE
Remove extra fields from new member modal form

### DIFF
--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -53,19 +53,6 @@
   </div>
   <div class="row g-3">
     <div class="col-md-6">
-      <div class="form-field phone-field">
-        {{ form.prefijo }}
-        {{ form.telefono }}
-        <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
-        {% if form.telefono.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.telefono.errors.as_text|striptags }}
-        </div>
-        {% endif %}
-      </div>
-    </div>
-    <div class="col-md-6">
       <div class="form-field">
         {{ form.email }}
         <button type="button" class="clear-btn bi bi-x"></button>
@@ -79,7 +66,7 @@
     </div>
   </div>
   <div class="row g-3">
-    <div class="col-md-3">
+    <div class="col-md-6">
       <div class="form-field">
         {{ form.fecha_nacimiento }}
         <button type="button" class="clear-btn bi bi-x"></button>
@@ -91,7 +78,7 @@
         {% endif %}
       </div>
     </div>
-    <div class="col-md-3">
+    <div class="col-md-6">
       <div class="form-field">
         {{ form.sexo }}
         <button type="button" class="clear-btn bi bi-x"></button>
@@ -103,77 +90,33 @@
         {% endif %}
       </div>
     </div>
-    <div class="col-md-6">
-      <div class="form-field">
-        {{ form.nacionalidad }}
-        <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.nacionalidad.id_for_label }}"
-          >{{ form.nacionalidad.label }}</label
-        >
-        {% if form.nacionalidad.errors %}
-        <div class="invalid-feedback d-block">
-          {{ form.nacionalidad.errors.as_text|striptags }}
-        </div>
-        {% endif %}
-      </div>
-    </div>
   </div>
   <div class="row g-3">
     <div class="col-md-6">
       <div class="form-field">
-        {{ form.localidad }}
+        {{ form.altura }}
         <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.localidad.id_for_label }}"
-          >{{ form.localidad.label }}</label
-        >
-        {% if form.localidad.errors %}
+        <label for="{{ form.altura.id_for_label }}">{{ form.altura.label }}</label>
+        {% if form.altura.errors %}
         <div class="invalid-feedback d-block">
-          {{ form.localidad.errors.as_text|striptags }}
+          {{ form.altura.errors.as_text|striptags }}
         </div>
         {% endif %}
       </div>
     </div>
     <div class="col-md-6">
       <div class="form-field">
-        {{ form.codigo_postal }}
+        {{ form.peso }}
         <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.codigo_postal.id_for_label }}"
-          >{{ form.codigo_postal.label }}</label
-        >
-        {% if form.codigo_postal.errors %}
+        <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
+        {% if form.peso.errors %}
         <div class="invalid-feedback d-block">
-          {{ form.codigo_postal.errors.as_text|striptags }}
+          {{ form.peso.errors.as_text|striptags }}
         </div>
         {% endif %}
       </div>
     </div>
   </div>
-    <div class="row g-3">
-      <div class="col-md-6">
-        <div class="form-field">
-          {{ form.altura }}
-          <button type="button" class="clear-btn bi bi-x"></button>
-          <label for="{{ form.altura.id_for_label }}">{{ form.altura.label }}</label>
-          {% if form.altura.errors %}
-          <div class="invalid-feedback d-block">
-            {{ form.altura.errors.as_text|striptags }}
-          </div>
-          {% endif %}
-        </div>
-      </div>
-      <div class="col-md-6">
-        <div class="form-field">
-          {{ form.peso }}
-          <button type="button" class="clear-btn bi bi-x"></button>
-          <label for="{{ form.peso.id_for_label }}">{{ form.peso.label }}</label>
-          {% if form.peso.errors %}
-          <div class="invalid-feedback d-block">
-            {{ form.peso.errors.as_text|striptags }}
-          </div>
-          {% endif %}
-        </div>
-      </div>
-    </div>
   <div class="form-field">
     {{ form.edad }}
     <button type="button" class="clear-btn bi bi-x"></button>


### PR DESCRIPTION
## Summary
- Hide País, localidad, código postal and teléfono inputs from the new member modal form.

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6896cc3375ec8321ac94001fd4c33bdc