### PR TITLE
Adapt member forms with region-based city list and phone init

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -563,6 +563,9 @@ class MiembroForm(UniformFieldsMixin, forms.ModelForm):
             region_field.widget.attrs['placeholder'] = 'Comunidad Autónoma'
 
         # Set default labels for new fields
+        email_field = self.fields.get('email')
+        if email_field:
+            email_field.label = 'Correo electrónico'
         if 'localidad' in self.fields:
             self.fields['localidad'].label = 'Ciudad'
         if 'codigo_postal' in self.fields:

--- a/static/js/member-location.js
+++ b/static/js/member-location.js
@@ -1,0 +1,66 @@
+// Handles dependent dropdown for region and city in member forms
+function initMemberLocationSelects(root = document) {
+  const region = root.querySelector('#id_region');
+  const city = root.querySelector('#id_localidad');
+  if (!region || !city) return;
+
+  const citiesByRegion = {
+    'Andalucía': ['Almería', 'Cádiz', 'Córdoba', 'Granada', 'Huelva', 'Jaén', 'Málaga', 'Sevilla'],
+    'Aragón': ['Huesca', 'Teruel', 'Zaragoza'],
+    'Asturias': ['Oviedo'],
+    'Islas Baleares': ['Palma de Mallorca'],
+    'Canarias': ['Las Palmas de Gran Canaria', 'Santa Cruz de Tenerife'],
+    'Cantabria': ['Santander'],
+    'Castilla-La Mancha': ['Albacete', 'Ciudad Real', 'Cuenca', 'Guadalajara', 'Toledo'],
+    'Castilla y León': ['Ávila', 'Burgos', 'León', 'Palencia', 'Salamanca', 'Segovia', 'Soria', 'Valladolid', 'Zamora'],
+    'Cataluña': ['Barcelona', 'Girona', 'Lleida', 'Tarragona'],
+    'Comunidad Valenciana': ['Alicante', 'Castellón de la Plana', 'Valencia'],
+    'Extremadura': ['Badajoz', 'Cáceres'],
+    'Galicia': ['A Coruña', 'Lugo', 'Ourense', 'Pontevedra'],
+    'Madrid': ['Madrid'],
+    'Murcia': ['Murcia'],
+    'Navarra': ['Pamplona'],
+    'País Vasco': ['Vitoria-Gasteiz', 'San Sebastián', 'Bilbao'],
+    'La Rioja': ['Logroño'],
+    'Ceuta': ['Ceuta'],
+    'Melilla': ['Melilla']
+  };
+
+  const cityInitial = city.value;
+  if (cityInitial) city.dataset.initial = cityInitial;
+
+  function clearOptions(select) {
+    select.innerHTML = '<option value=""></option>';
+  }
+
+  function populateCityOptions(options) {
+    const currentCity = city.dataset.initial || city.value;
+    clearOptions(city);
+    options.forEach(function (c) {
+      const opt = document.createElement('option');
+      opt.value = c;
+      opt.textContent = c;
+      city.appendChild(opt);
+    });
+    city.disabled = options.length === 0;
+    if (options.includes(currentCity)) {
+      city.value = currentCity;
+    }
+    city.dataset.initial = '';
+  }
+
+  function updateCitiesForRegion() {
+    const selectedRegion = region.value;
+    const options = citiesByRegion[selectedRegion] || [];
+    populateCityOptions(options);
+  }
+
+  region.addEventListener('change', updateCitiesForRegion);
+  updateCitiesForRegion();
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  initMemberLocationSelects();
+});
+
+window.initMemberLocationSelects = initMemberLocationSelects;

--- a/static/js/member-modal.js
+++ b/static/js/member-modal.js
@@ -35,6 +35,12 @@ document.addEventListener('DOMContentLoaded', () => {
               if (window.initSelectLabels) {
                 window.initSelectLabels(editEl);
               }
+              if (window.initPhoneInputs) {
+                window.initPhoneInputs(editEl);
+              }
+              if (window.initMemberLocationSelects) {
+                window.initMemberLocationSelects(editEl);
+              }
               const form = editEl.querySelector('form');
               form.addEventListener('submit', e => {
                 e.preventDefault();
@@ -107,6 +113,12 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             if (window.initSelectLabels) {
               window.initSelectLabels(addEl);
+            }
+            if (window.initPhoneInputs) {
+              window.initPhoneInputs(addEl);
+            }
+            if (window.initMemberLocationSelects) {
+              window.initMemberLocationSelects(addEl);
             }
             const form = addEl.querySelector('form');
             form.addEventListener('submit', e => {

--- a/static/js/member-signup-modal.js
+++ b/static/js/member-signup-modal.js
@@ -16,6 +16,12 @@ document.addEventListener('DOMContentLoaded', () => {
             if (window.initSelectLabels) {
               window.initSelectLabels(modalEl);
             }
+            if (window.initPhoneInputs) {
+              window.initPhoneInputs(modalEl);
+            }
+            if (window.initMemberLocationSelects) {
+              window.initMemberLocationSelects(modalEl);
+            }
             const form = modalEl.querySelector('form');
             form.addEventListener('submit', e => {
               e.preventDefault();

--- a/static/js/phone-prefix.js
+++ b/static/js/phone-prefix.js
@@ -1,7 +1,10 @@
 // Initialize intl-tel-input on phone fields
-document.addEventListener('DOMContentLoaded', function () {
-  const phoneInputs = document.querySelectorAll('input.phone-input');
+function initPhoneInputs(root = document) {
+  const phoneInputs = root.querySelectorAll('input.phone-input');
   phoneInputs.forEach(function (input) {
+    if (input.dataset.phoneInitialized) return;
+    input.dataset.phoneInitialized = 'true';
+
     const iti = window.intlTelInput(input, {
       initialCountry: 'es',
       separateDialCode: true,
@@ -10,11 +13,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const itiContainer = input.closest('.iti');
     const cleanCountryNames = () => {
-      itiContainer
-        ?.querySelectorAll('.iti__country-name')
-        .forEach(el => {
-          el.textContent = el.textContent.replace(/\s*\([^)]*\)/, '');
-        });
+      itiContainer?.querySelectorAll('.iti__country-name').forEach(el => {
+        el.textContent = el.textContent.replace(/\s*\([^)]*\)/, '');
+      });
     };
     cleanCountryNames();
     input.addEventListener('open:countrydropdown', cleanCountryNames);
@@ -38,48 +39,47 @@ document.addEventListener('DOMContentLoaded', function () {
       }
       input.dispatchEvent(new Event('input', { bubbles: true }));
     });
-  });
 
-  const format = (input) => {
-    const prefijo = input.closest('.form-field')?.querySelector('input.prefijo-input')?.value || '';
-    let digits = input.value.replace(/\D/g, '');
-    if (prefijo === '+34') {
-      digits = digits.slice(0, 9);
-    } else {
-      digits = digits.slice(0, 15);
-    }
-    const parts = [];
-    if (digits.length > 0) parts.push(digits.slice(0, 3));
-    if (digits.length >= 4) parts.push(digits.slice(3, 5));
-    if (digits.length >= 6) parts.push(digits.slice(5, 7));
-    if (digits.length >= 8) parts.push(digits.slice(7, 9));
-    if (digits.length > 9) parts.push(digits.slice(9));
-    input.value = parts.filter(Boolean).join(' ').trim();
-  };
+    const format = () => {
+      const prefijo = input.closest('.form-field')?.querySelector('input.prefijo-input')?.value || '';
+      let digits = input.value.replace(/\D/g, '');
+      if (prefijo === '+34') {
+        digits = digits.slice(0, 9);
+      } else {
+        digits = digits.slice(0, 15);
+      }
+      const parts = [];
+      if (digits.length > 0) parts.push(digits.slice(0, 3));
+      if (digits.length >= 4) parts.push(digits.slice(3, 5));
+      if (digits.length >= 6) parts.push(digits.slice(5, 7));
+      if (digits.length >= 8) parts.push(digits.slice(7, 9));
+      if (digits.length > 9) parts.push(digits.slice(9));
+      input.value = parts.filter(Boolean).join(' ').trim();
+    };
 
-  phoneInputs.forEach(function (input) {
-    format(input);
-    input.addEventListener('input', function () {
-      format(input);
-    });
-  });
+    format();
+    input.addEventListener('input', format);
 
-  const isValidSpanishPhone = (input) => {
-    const prefijo = input.closest('.form-field')?.querySelector('input.prefijo-input')?.value || '';
-    const digits = input.value.replace(/\D/g, '');
-    if (prefijo === '+34' && digits && !['6', '7', '9'].includes(digits.charAt(0))) {
-      alert('Introduce un número de teléfono válido');
-      return false;
-    }
-    return true;
-  };
+    const isValidSpanishPhone = () => {
+      const prefijo = input.closest('.form-field')?.querySelector('input.prefijo-input')?.value || '';
+      const digits = input.value.replace(/\D/g, '');
+      if (prefijo === '+34' && digits && !['6', '7', '9'].includes(digits.charAt(0))) {
+        alert('Introduce un número de teléfono válido');
+        return false;
+      }
+      return true;
+    };
 
-  phoneInputs.forEach(function (input) {
     input.form?.addEventListener('submit', function (e) {
-      if (!isValidSpanishPhone(input)) {
+      if (!isValidSpanishPhone()) {
         e.preventDefault();
       }
     });
   });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  initPhoneInputs();
 });
 
+window.initPhoneInputs = initPhoneInputs;

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -69,7 +69,7 @@
       <div class="form-field">
         {{ form.email }}
         <button type="button" class="clear-btn bi bi-x"></button>
-        <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
+        <label for="{{ form.email.id_for_label }}">Correo electrónico</label>
         {% if form.email.errors %}
         <div class="invalid-feedback d-block">
           {{ form.email.errors.as_text|striptags }}

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -677,6 +677,7 @@
     <script src="{% static 'js/post-like.js' %}"></script>
     <script src="{% static 'js/gallery-slideshow.js' %}"></script>
     <script src="{% static 'js/schedule-status.js' %}"></script>
+    <script src="{% static 'js/member-location.js' %}"></script>
     <script src="{% static 'js/member-signup-modal.js' %}"></script>
     <script src="{% static 'js/booking-modal.js' %}"></script>
     <script src="{% static 'js/club-tabs.js' %}"></script>

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1646,6 +1646,7 @@
 <script src="{% static 'js/feature-select.js' %}"></script>
 <script src="{% static 'js/avatar-dropzone.js' %}"></script>
 <script src="{% static 'js/location-select.js' %}"></script>
+<script src="{% static 'js/member-location.js' %}"></script>
 <script src="{% static 'js/schedule-form.js' %}"></script>
 <script src="{% static 'js/gallery-manager.js' %}"></script>
 <script src="{% static 'js/delete-confirm.js' %}"></script>

--- a/templates/clubs/miembro_form.html
+++ b/templates/clubs/miembro_form.html
@@ -65,7 +65,7 @@
         <div class="form-field">
           {{ form.email }}
           <button type="button" class="clear-btn bi bi-x"></button>
-          <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
+          <label for="{{ form.email.id_for_label }}">Correo electrónico</label>
           {% if form.email.errors %}
           <div class="invalid-feedback d-block">
             {{ form.email.errors.as_text|striptags }}
@@ -105,6 +105,17 @@
           {% if form.nacionalidad.errors %}
           <div class="invalid-feedback d-block">
             {{ form.nacionalidad.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="form-field">
+          {{ form.region }}
+          <label for="{{ form.region.id_for_label }}">{{ form.region.label }}</label>
+          {% if form.region.errors %}
+          <div class="invalid-feedback d-block">
+            {{ form.region.errors.as_text|striptags }}
           </div>
           {% endif %}
         </div>
@@ -221,4 +232,5 @@
 {% endblock %}
 {% block extra_js %}
 <script src="{% static 'js/avatar-dropzone.js' %}"></script>
+<script src="{% static 'js/member-location.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Show "Correo electrónico" label and include region dropdown in member forms
- Populate cities based on selected comunidad and export phone field init for dynamic forms
- Initialize phone and location scripts when member modals load

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6897566275148321b91f95efaf0b26c0