### PR TITLE
Fix phone prefix dropdown width

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -175,28 +175,36 @@
 }
 
 /* Phone field prefix tweaks */
+
 .profile-form .phone-field .iti--separate-dial-code .iti__flag-container,
 .profile-form .phone-field .iti--separate-dial-code .iti__selected-flag,
 .profile-form .phone-field .iti--separate-dial-code .iti__selected-dial-code {
   background: none;
 }
 
+.profile-form .phone-field .iti--separate-dial-code .iti__flag-container,
+.profile-form .phone-field .iti--separate-dial-code .iti__selected-flag {
+  width: 70px;
+}
+
 .profile-form .phone-field .iti--separate-dial-code .iti__flag-container {
-  padding: 0 10px;
+  padding: 0;
 }
 
 .profile-form .phone-field .iti--separate-dial-code .iti__selected-flag {
+  box-sizing: border-box;
   border-right: 1px solid #ddd;
-  padding: 0 15px 0 15px;
+  padding: 0 10px;
   right:10px;
 }
 
 .profile-form .phone-field label {
-  margin-left: 90px;
+  margin-left: 80px;
 }
 
 .profile-form .phone-field .iti {
   width: 100%;
+  --iti-flag-container-width: 70px;
 }
 
 .profile-form .phone-field input.phone-input {


### PR DESCRIPTION
## Summary
- set fixed 70px width for phone prefix dropdown
- adjust label spacing and prefix container settings

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6897d029dbd083218bada72ad8b7336a