### PR TITLE
Enhance form UX with global styling and clear actions

### DIFF
--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -1,0 +1,134 @@
+/* Global form styling to match profile forms */
+
+.form-field {
+  position: relative;
+  margin-bottom: 1.3rem;
+}
+
+.form-field input:not([type="checkbox"]),
+.form-field textarea,
+.form-field select {
+  width: 100%;
+  padding: 0.75rem 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: none;
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.form-field select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PScwIDAgMTAgNicgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJz48cG9seWdvbiBwb2ludHM9JzAgMCA1IDYgMTAgMCcgZmlsbD0nIzY2NicvPjwvc3ZnPg==");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 10px 6px;
+  padding-right: 1.5rem;
+}
+
+.form-field input[type="checkbox"] {
+  width: auto;
+  margin-right: 0.5rem;
+}
+
+.form-field input:focus,
+.form-field textarea:focus,
+.form-field select:focus {
+  outline: none;
+  border-color: #000;
+  box-shadow: none;
+}
+
+.form-field label {
+  font-size: 12px;
+  position: absolute;
+  left: 0;
+  margin-left: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: white;
+  padding: 0 0.25rem;
+  color: #666;
+  pointer-events: none;
+  transition: transform 0.2s, font-size 0.2s, color 0.2s;
+}
+
+.checkbox-field {
+  display: flex;
+  align-items: center;
+}
+
+.checkbox-field label {
+  position: static;
+  transform: none;
+  padding: 0;
+}
+
+.form-field .form-check-label {
+  position: static;
+  transform: none;
+  padding: 0;
+}
+
+.form-field input:not(:placeholder-shown) ~ label,
+.form-field input:focus ~ label,
+.form-field textarea:not(:placeholder-shown) ~ label,
+.form-field textarea:focus ~ label,
+.form-field select.has-value ~ label,
+.form-field select:focus ~ label {
+  top: 0;
+  transform: translateY(-50%);
+  font-size: 0.7rem;
+  color: #000;
+}
+
+.form-field .clear-btn {
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1rem;
+  display: none;
+  margin-right: 3px;
+}
+
+.with-toggle .clear-btn {
+  right: 40px;
+}
+
+.toggle-password {
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+textarea + .clear-btn {
+  display: none !important;
+}
+
+/* Phone field prefix tweaks */
+.phone-field .iti--separate-dial-code .iti__flag-container,
+.phone-field .iti--separate-dial-code .iti__selected-flag,
+.phone-field .iti--separate-dial-code .iti__selected-dial-code {
+  background: none;
+}
+
+.phone-field .iti--separate-dial-code .iti__flag-container {
+  padding: 0;
+}
+
+.phone-field .iti--separate-dial-code .iti__selected-flag {
+  box-sizing: border-box;
+  border-right: 1px solid #ddd;
+  padding: 0 10px;
+}
+

--- a/static/js/clear-input.js
+++ b/static/js/clear-input.js
@@ -1,13 +1,24 @@
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll(".form-field").forEach((field) => {
     const input = field.querySelector("input:not(.prefijo-input), textarea, select");
-    const btn = field.querySelector(".clear-btn");
-    if (!input || !btn) return;
+    if (!input) return;
 
-    // Remove clear button for textareas
-    if (input.tagName === "TEXTAREA") {
-      btn.remove();
-      return;
+    // Skip textareas completely
+    if (input.tagName === "TEXTAREA") return;
+
+    let btn = field.querySelector(".clear-btn");
+
+    // Create clear button if not present
+    if (!btn) {
+      btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "clear-btn bi bi-x";
+      const label = field.querySelector("label");
+      if (label) {
+        field.insertBefore(btn, label);
+      } else {
+        field.appendChild(btn);
+      }
     }
 
     // Make clear button not tabbable

--- a/static/js/select-label.js
+++ b/static/js/select-label.js
@@ -2,10 +2,17 @@ function initSelectLabels(root = document) {
   root.querySelectorAll('.form-field select').forEach(select => {
     if (select.dataset.initSelectLabels) return;
 
-    const placeholder = select.querySelector('option[value=""]');
-    if (placeholder) {
-      placeholder.hidden = true;
+    let placeholder = select.querySelector('option[value=""]');
+    if (!placeholder) {
+      placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = '------';
+      select.insertBefore(placeholder, select.firstChild);
+      select.selectedIndex = 0;
+    } else if (!placeholder.textContent.trim()) {
+      placeholder.textContent = '------';
     }
+    placeholder.hidden = true;
 
     const update = () => {
       select.classList.toggle('has-value', select.value !== '');


### PR DESCRIPTION
## Summary
- add automatic clear buttons to all form fields
- show floating '------' placeholder for dropdowns by default
- apply profile-style layout globally through new forms.css

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6897dc0d136483219ec5308ff0925918