### PR TITLE
feat: add clear button and dropdown placeholder improvements

### DIFF
--- a/static/js/clear-input.js
+++ b/static/js/clear-input.js
@@ -1,16 +1,21 @@
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll(".form-field").forEach((field) => {
-    const input = field.querySelector("input:not(.prefijo-input), textarea, select");
-    const btn = field.querySelector(".clear-btn");
-    if (!input || !btn) return;
+    const input = field.querySelector("input:not(.prefijo-input), textarea");
+    if (!input) return;
 
-    // Remove clear button for textareas
-    if (input.tagName === "TEXTAREA") {
-      btn.remove();
-      return;
+    let btn = field.querySelector(".clear-btn");
+    if (!btn) {
+      btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "clear-btn bi bi-x";
+      const label = field.querySelector("label");
+      if (label) {
+        field.insertBefore(btn, label);
+      } else {
+        field.appendChild(btn);
+      }
     }
 
-    // Make clear button not tabbable
     btn.setAttribute("tabindex", "-1");
     btn.addEventListener("mousedown", (e) => e.preventDefault());
 
@@ -23,21 +28,15 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     btn.addEventListener("click", () => {
-      if (input.tagName === "SELECT") {
-        input.selectedIndex = 0;
-        input.dispatchEvent(new Event("change", { bubbles: true }));
-      } else {
-        input.value = "";
-        input.dispatchEvent(new Event("input", { bubbles: true }));
-      }
+      input.value = "";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
       toggle();
       input.focus();
     });
 
     input.addEventListener("focus", toggle);
     input.addEventListener("blur", toggle);
-    const eventName = input.tagName === "SELECT" ? "change" : "input";
-    input.addEventListener(eventName, toggle);
+    input.addEventListener("input", toggle);
     toggle();
   });
 });

--- a/static/js/select-label.js
+++ b/static/js/select-label.js
@@ -2,10 +2,15 @@ function initSelectLabels(root = document) {
   root.querySelectorAll('.form-field select').forEach(select => {
     if (select.dataset.initSelectLabels) return;
 
-    const placeholder = select.querySelector('option[value=""]');
-    if (placeholder) {
-      placeholder.hidden = true;
+    let placeholder = select.querySelector('option[value=""]');
+    if (!placeholder) {
+      const label = select.closest('.form-field').querySelector('label');
+      placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = label ? label.textContent : '';
+      select.insertBefore(placeholder, select.firstChild);
     }
+    placeholder.hidden = true;
 
     const update = () => {
       select.classList.toggle('has-value', select.value !== '');

--- a/templates/partials/_review_modal.html
+++ b/templates/partials/_review_modal.html
@@ -15,12 +15,15 @@
                                 <form method="POST" id="reseña-form">
                                     {% csrf_token %}
                                     {% if form.errors %}<div class="alert alert-danger">Por favor completa todos los campos obligatorios.</div>{% endif %}
-                                    <div class="mb-3">
+                                    <div class="form-field mb-3">
                                         <input type="text"
+                                               id="titulo"
                                                name="titulo"
                                                class="form-control"
-                                               placeholder="Título de la reseña"
+                                               placeholder=" "
                                                required>
+                                        <button type="button" class="clear-btn bi bi-x"></button>
+                                        <label for="titulo">Título de la reseña</label>
                                     </div>
                                     <div class="mb-3">
                                         <label class="form-label d-block mb-1">Instalaciones:</label>
@@ -53,12 +56,15 @@
                                                required
                                                id="input-variedad_clases">
                                     </div>
-                                    <div class="mb-3">
+                                    <div class="form-field mb-3">
                                         <textarea name="comentario"
+                                                  id="comentario"
                                                   class="form-control"
                                                   rows="4"
                                                   minlength="200"
-                                                  placeholder="¿Qué te ha gustado o qué mejorarías del club?"></textarea>
+                                                  placeholder=" "></textarea>
+                                        <button type="button" class="clear-btn bi bi-x"></button>
+                                        <label for="comentario">¿Qué te ha gustado o qué mejorarías del club?</label>
                                     </div>
                                     <button type="submit" class="btn btn-dark">Enviar Reseña</button>
                                 </form>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -247,19 +247,23 @@
         <div id="tab-support" class="profile-section">
             <h4 class="mb-3">Soporte Técnico</h4>
 
-               
-          <div class="col-lg-6"> 
+
+          <div class="col-lg-6">
             <form method="post" class="mt-4">
                 {% csrf_token %}
-                <div class="mb-3">
+                <div class="form-field mb-3">
                     <select class="form-select" name="support_option" id="support_option">
+                        <option value="">Selecciona una opción</option>
                         <option value="problema">Notificar de un problema</option>
                         <option value="eliminar">Eliminar mi perfil</option>
                         <option value="otros">Otros</option>
                     </select>
+                    <label for="support_option">Selecciona una opción</label>
                 </div>
-                <div class="mb-3">
-                    <textarea class="form-control" name="support_message" id="support_message" placeholder="Explica en detalle el problema"></textarea>
+                <div class="form-field mb-3">
+                    <textarea class="form-control" name="support_message" id="support_message" placeholder=" "></textarea>
+                    <button type="button" class="clear-btn bi bi-x"></button>
+                    <label for="support_message">Explica en detalle el problema</label>
                 </div>
                 <button type="submit" class="btn btn-dark">Enviar</button>
             </form>  </div>


### PR DESCRIPTION
## Summary
- auto-add clear button for text inputs and textareas
- default dropdown placeholder to label text
- update support and review forms with new clear buttons and labels

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897dfab82cc8321b90b23e3a17f6fa4