### PR TITLE
Fix clear buttons and dropdown labels in miembro form

### DIFF
--- a/static/js/clear-input.js
+++ b/static/js/clear-input.js
@@ -1,5 +1,5 @@
-document.addEventListener("DOMContentLoaded", () => {
-  document.querySelectorAll(".form-field").forEach((field) => {
+function initClearInputs(root = document) {
+  root.querySelectorAll(".form-field").forEach((field) => {
     const input = field.querySelector("input:not(.prefijo-input), textarea");
     if (!input) return;
 
@@ -39,4 +39,10 @@ document.addEventListener("DOMContentLoaded", () => {
     input.addEventListener("input", toggle);
     toggle();
   });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  initClearInputs();
 });
+
+window.initClearInputs = initClearInputs;

--- a/templates/clubs/_miembro_form.html
+++ b/templates/clubs/_miembro_form.html
@@ -247,3 +247,14 @@
     </div>
   </div>
 </form>
+<script>
+  const form = document.currentScript.previousElementSibling;
+  if (form) {
+    if (window.initClearInputs) {
+      initClearInputs(form);
+    }
+    if (window.initSelectLabels) {
+      initSelectLabels(form);
+    }
+  }
+</script>


### PR DESCRIPTION
## Summary
- Expose `initClearInputs` helper and initialize on DOM load for dynamic forms
- Reinitialize clear buttons and select placeholders when miembro form partial is loaded

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6897e61b1b7083219dd2d541bcdfbd26