### PR TITLE
Enforce required fields on profile forms

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -236,7 +236,7 @@ def dashboard(request):
     elif booking_filter in ['active', 'confirmed', 'cancelled']:
         bookings = bookings.filter(status=booking_filter)
 
-    form = ClubForm(instance=club)
+    form = ClubForm(instance=club, require_all=True, exclude_required=['door', 'logo'])
 
     return render(
         request,
@@ -280,13 +280,19 @@ def club_edit(request, slug):
         data = request.POST.copy()
         for field in ['slug', 'country', 'region', 'city', 'postal_code', 'street', 'number', 'door', 'prefijo', 'phone', 'email']:
             data.setdefault(field, getattr(club, field))
-        form = ClubForm(data, request.FILES, instance=club)
+        form = ClubForm(
+            data,
+            request.FILES,
+            instance=club,
+            require_all=True,
+            exclude_required=['door', 'logo'],
+        )
         if form.is_valid():
             form.save()
             messages.success(request, 'Club actualizado correctamente.')
             return redirect('club_dashboard')
     else:
-        form = ClubForm(instance=club)
+        form = ClubForm(instance=club, require_all=True, exclude_required=['door', 'logo'])
     return render(request, 'clubs/club_form.html', {'form': form, 'club': club})
 
 
@@ -533,7 +539,12 @@ def miembro_create(request, slug):
     if not has_club_permission(request.user, club):
         return HttpResponseForbidden()
     if request.method == 'POST':
-        form = MiembroForm(request.POST, request.FILES)
+        form = MiembroForm(
+            request.POST,
+            request.FILES,
+            require_all=True,
+            exclude_required=['notas', 'avatar', 'edad'],
+        )
         if form.is_valid():
             miembro = form.save(commit=False)
             miembro.club = club
@@ -544,7 +555,7 @@ def miembro_create(request, slug):
                 return HttpResponse(html)
             return redirect('club_dashboard')
     else:
-        form = MiembroForm()
+        form = MiembroForm(require_all=True, exclude_required=['notas', 'avatar', 'edad'])
     template = 'clubs/_miembro_form.html' if request.headers.get('x-requested-with') == 'XMLHttpRequest' else 'clubs/miembro_form.html'
     return render(request, template, {'form': form, 'club': club})
 
@@ -555,7 +566,13 @@ def miembro_update(request, pk):
     if not has_club_permission(request.user, miembro.club):
         return HttpResponseForbidden()
     if request.method == 'POST':
-        form = MiembroForm(request.POST, request.FILES, instance=miembro)
+        form = MiembroForm(
+            request.POST,
+            request.FILES,
+            instance=miembro,
+            require_all=True,
+            exclude_required=['notas', 'avatar', 'edad'],
+        )
         if form.is_valid():
             form.save()
             messages.success(request, 'Miembro actualizado correctamente.')
@@ -563,7 +580,7 @@ def miembro_update(request, pk):
                 return HttpResponse(status=204)
             return redirect('club_dashboard')
     else:
-        form = MiembroForm(instance=miembro)
+        form = MiembroForm(instance=miembro, require_all=True, exclude_required=['notas', 'avatar', 'edad'])
     template = 'clubs/_miembro_form.html' if request.headers.get('x-requested-with') == 'XMLHttpRequest' else 'clubs/miembro_form.html'
     return render(request, template, {
         'form': form,

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -182,7 +182,12 @@ def member_signup(request, slug):
     """Allow public users to register as club members."""
     club = get_object_or_404(Club, slug=slug)
     if request.method == 'POST':
-        form = MiembroForm(request.POST, request.FILES)
+        form = MiembroForm(
+            request.POST,
+            request.FILES,
+            require_all=True,
+            exclude_required=['notas', 'fuente', 'estado', 'avatar', 'edad'],
+        )
         if form.is_valid():
             miembro = form.save(commit=False)
             miembro.club = club
@@ -192,7 +197,7 @@ def member_signup(request, slug):
                 return HttpResponse(status=204)
             return redirect('club_profile', slug=club.slug)
     else:
-        form = MiembroForm()
+        form = MiembroForm(require_all=True, exclude_required=['notas', 'fuente', 'estado', 'avatar', 'edad'])
     template = 'clubs/_miembro_public_form.html' if request.headers.get('x-requested-with') == 'XMLHttpRequest' else 'clubs/miembro_form.html'
     return render(request, template, {'form': form, 'club': club})
 

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -204,6 +204,7 @@
                   value="{{ feature.id }}"
                   class="d-none"
                   {% if feature in club.features.all %}checked{% endif %}
+                  {% if forloop.first %}required{% endif %}
                 />
                 {% if feature.icon %}
                 <img


### PR DESCRIPTION
## Summary
- Ensure Miembro forms enforce required fields based on context
- Require club profile forms to fill all fields except door and logo and at least one feature
- Mark feature checkboxes as required in dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689929626efc8321845dbbca090aa21d