### PR TITLE
style competitor type radio as black

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -379,7 +379,7 @@ class CompetidorForm(UniformFieldsMixin, forms.ModelForm):
     fecha_nacimiento = forms.DateField(required=False, label='Fecha de nacimiento')
     tipo_competidor = forms.ChoiceField(
         choices=[('amateur', 'Amateur'), ('profesional', 'Profesional')],
-        widget=forms.RadioSelect,
+        widget=forms.RadioSelect(attrs={"class": "form-check-input"}),
         required=False,
         label='Tipo'
     )

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -700,8 +700,8 @@ select option[value="España"] {
 
 /* Larger radio buttons for competitor type */
 .profile-form input[name="tipo_competidor"] {
-  width: 1.3em;
-  height: 1.3em;
+  width: 1em;
+  height: 1em;
   border-radius: 50%;
 }
 .profile-form input[name="tipo_competidor"]:checked {


### PR DESCRIPTION
## Summary
- ensure competitor type uses radio inputs with Bootstrap styles
- align competitor type radio size and color with matchmaker dashboard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68995694d450832196d1cf3c0be0b542