### PR TITLE
Use dropdown for competitor type

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -378,8 +378,7 @@ class CompetidorForm(UniformFieldsMixin, forms.ModelForm):
     )
     fecha_nacimiento = forms.DateField(required=False, label='Fecha de nacimiento')
     tipo_competidor = forms.ChoiceField(
-        choices=[('amateur', 'Amateur'), ('profesional', 'Profesional')],
-        widget=forms.RadioSelect(attrs={"class": "form-check-input"}),
+        choices=[('', ''), ('amateur', 'Amateur'), ('profesional', 'Profesional')],
         required=False,
         label='Tipo'
     )

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -698,21 +698,6 @@ select option[value="España"] {
   white-space: nowrap;
 }
 
-/* Larger radio buttons for competitor type */
-.profile-form input[name="tipo_competidor"] {
-  width: 1em;
-  height: 1em;
-  border-radius: 50%;
-}
-.profile-form input[name="tipo_competidor"]:checked {
-  background-color: #000;
-  border-color: #000;
-}
-.profile-form input[name="tipo_competidor"] + .form-check-label {
-  font-size: 1rem;
-  font-weight: 500;
-}
-
 /* Booking class table adjustments */
 .booking-class-title {
   text-transform: uppercase;

--- a/static/js/age-category.js
+++ b/static/js/age-category.js
@@ -1,18 +1,20 @@
 function initAgeCategory(root = document) {
   const birthInput = root.querySelector('input[name="fecha_nacimiento"]');
-  const select = root.querySelector('select[name="modalidad"]');
-  const tipoRadios = root.querySelectorAll('input[name="tipo_competidor"]');
-  const modalidadField = select ? select.closest('.form-field') : null;
+  const modalidadSelect = root.querySelector('select[name="modalidad"]');
+  const tipoSelect = root.querySelector('select[name="tipo_competidor"]');
+  const modalidadField = modalidadSelect ? modalidadSelect.closest('.form-field') : null;
   if (!birthInput) return;
 
   const updateVisibility = () => {
-    const checked = root.querySelector('input[name="tipo_competidor"]:checked');
+    const value = tipoSelect ? tipoSelect.value : '';
     if (modalidadField) {
-      modalidadField.style.display = checked && checked.value === 'amateur' ? '' : 'none';
+      modalidadField.style.display = value === 'amateur' ? '' : 'none';
     }
   };
 
-  tipoRadios.forEach(r => r.addEventListener('change', updateVisibility));
+  if (tipoSelect) {
+    tipoSelect.addEventListener('change', updateVisibility);
+  }
 
   const getAge = () => {
     const val = birthInput.value;
@@ -49,14 +51,13 @@ function initAgeCategory(root = document) {
         value = 'profesional';
       }
     }
-    if (tipoRadios.length) {
-      tipoRadios.forEach(r => {
-        r.checked = r.value === type;
-      });
+    if (tipoSelect) {
+      tipoSelect.value = type;
+      tipoSelect.dispatchEvent(new Event('change'));
     }
-    if (select) {
-      select.value = type === 'amateur' ? value : '';
-      select.dispatchEvent(new Event('change'));
+    if (modalidadSelect) {
+      modalidadSelect.value = type === 'amateur' ? value : '';
+      modalidadSelect.dispatchEvent(new Event('change'));
     }
     updateVisibility();
   };

--- a/templates/clubs/_competidor_form.html
+++ b/templates/clubs/_competidor_form.html
@@ -105,14 +105,9 @@
       </div>
       <div class="col-12 col-md-6">
         <div class="form-field">
-          <div class="d-flex justify-content-center gap-3">
-            {% for radio in form.tipo_competidor %}
-            <div class="form-check form-check-inline">
-              {{ radio.tag }}
-              <label class="form-check-label fw-bold">{{ radio.choice_label }}</label>
-            </div>
-            {% endfor %}
-          </div>
+          {{ form.tipo_competidor }}
+          <button type="button" class="clear-btn bi bi-x"></button>
+          <label for="{{ form.tipo_competidor.id_for_label }}">{{ form.tipo_competidor.label }}</label>
           {% if form.tipo_competidor.errors %}
           <div class="invalid-feedback d-block">
             {{ form.tipo_competidor.errors.as_text|striptags }}


### PR DESCRIPTION
## Summary
- Replace CompetidorForm `tipo_competidor` radios with a dropdown select
- Update competitor form template and age-category script accordingly
- Drop obsolete radio button styles

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68995858d01c8321b6590af20540a962