### PR TITLE
Assign defaults for public member signup

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -10,6 +10,8 @@ from apps.clubs.models import Club, ClubPhoto, ClubPost, Miembro, Pago, Competid
 from datetime import date
 from allauth.socialaccount.models import SocialApp
 from django.contrib.sites.models import Site
+from django import forms
+from unittest.mock import patch
 
 
 class ClubPlanTests(TestCase):
@@ -472,3 +474,31 @@ class MessageConversationTests(TestCase):
         self.client.login(username='normal', password='pass')
         user_inbox = self.client.get(reverse('conversation'))
         self.assertContains(user_inbox, 'hello')
+
+
+class MemberSignupDefaultsTests(TestCase):
+    def setUp(self):
+        self.club = Club.objects.create(
+            name='Club', city='C', address='A', phone='612345678', email='club@example.com'
+        )
+
+    def test_signup_sets_default_fields(self):
+        class SimpleForm(forms.ModelForm):
+            class Meta:
+                model = Miembro
+                fields = ['nombre', 'apellidos']
+
+            def __init__(self, *args, **kwargs):
+                kwargs.pop('require_all', None)
+                kwargs.pop('exclude_required', None)
+                super().__init__(*args, **kwargs)
+
+        url = reverse('club_member_signup', args=[self.club.slug])
+        with patch('apps.clubs.views.public.MiembroForm', SimpleForm):
+            response = self.client.post(url, {'nombre': 'Juan', 'apellidos': 'Pérez'})
+        self.assertEqual(response.status_code, 302)
+        miembro = Miembro.objects.get()
+        self.assertEqual(miembro.club, self.club)
+        self.assertEqual(miembro.fuente, 'directa')
+        self.assertEqual(miembro.estado, 'activo')
+        self.assertEqual(miembro.fecha_inscripcion, date.today())

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -15,6 +15,7 @@ from apps.users.forms import RegistroUsuarioForm
 from apps.users.models import Follow
 from django.contrib.contenttypes.models import ContentType
 from apps.clubs.spain import REGION_PROVINCES, CITY_TO_PROVINCE
+from django.utils import timezone
 
 PROVINCE_TO_REGION = {p: r for r, ps in REGION_PROVINCES.items() for p in ps}
 CITY_TO_REGION = {c: PROVINCE_TO_REGION.get(p) for c, p in CITY_TO_PROVINCE.items()}
@@ -191,6 +192,9 @@ def member_signup(request, slug):
         if form.is_valid():
             miembro = form.save(commit=False)
             miembro.club = club
+            miembro.fuente = 'directa'
+            miembro.estado = 'activo'
+            miembro.fecha_inscripcion = timezone.now().date()
             miembro.save()
             messages.success(request, 'Inscripción guardada correctamente.')
             if request.headers.get('x-requested-with') == 'XMLHttpRequest':


### PR DESCRIPTION
## Summary
- Ensure public member signups default to "Directa" source, "activo" status, and current registration date
- Cover public signup defaults with a unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899fc24c22483218a00901cc9cc380d