### PR TITLE
Ensure member registration persists

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -372,6 +372,36 @@ class DashboardMemberFilterTests(TestCase):
         members = list(res.context['members'])
         self.assertEqual(members[0], self.member1)
 
+
+class DashboardMemberCreateTests(TestCase):
+    def setUp(self):
+        Group.objects.get_or_create(name='ClubOwner')
+        self.owner = User.objects.create_user(username='owner2', password='pass')
+        self.club = Club.objects.create(
+            name='Club', city='C', address='A', phone='1', email='e@e.com', owner=self.owner
+        )
+        self.client.login(username='owner2', password='pass')
+
+    def test_member_is_saved(self):
+        url = reverse('miembro_create', args=[self.club.slug])
+        data = {
+            'nombre': 'Ana',
+            'apellidos': 'Doe',
+            'fecha_nacimiento': '2000-01-01',
+            'sexo': 'F',
+            'guardia': 'diestro',
+            'altura': '160',
+            'peso': '55',
+            'prefijo': '+34',
+            'telefono': '612345678',
+            'email': 'ana@example.com',
+            'nacionalidad': 'España',
+            'fuente': 'directa',
+            'estado': 'activo',
+        }
+        self.client.post(url, data)
+        self.assertEqual(self.club.miembros.count(), 1)
+
 class DashboardMatchmakerTests(TestCase):
     def setUp(self):
         Group.objects.get_or_create(name='ClubOwner')

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -535,19 +535,20 @@ def miembro_create(request, slug):
             request.POST,
             request.FILES,
             require_all=True,
-            exclude_required=['notas', 'avatar', 'edad'],
+            exclude_required=['notas', 'avatar', 'edad', 'region', 'localidad', 'street', 'number', 'door', 'codigo_postal'],
         )
         if form.is_valid():
             miembro = form.save(commit=False)
             miembro.club = club
             miembro.save()
+            form.save_m2m()
             messages.success(request, 'Miembro añadido correctamente.')
             if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 html = render_to_string('clubs/_miembro_row.html', {'m': miembro}, request=request)
                 return HttpResponse(html)
             return redirect('club_dashboard')
     else:
-        form = MiembroForm(require_all=True, exclude_required=['notas', 'avatar', 'edad'])
+        form = MiembroForm(require_all=True, exclude_required=['notas', 'avatar', 'edad', 'region', 'localidad', 'street', 'number', 'door', 'codigo_postal'])
     template = 'clubs/_miembro_form.html' if request.headers.get('x-requested-with') == 'XMLHttpRequest' else 'clubs/miembro_form.html'
     return render(request, template, {'form': form, 'club': club})
 

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -187,7 +187,7 @@ def member_signup(request, slug):
             request.POST,
             request.FILES,
             require_all=True,
-            exclude_required=['notas', 'fuente', 'estado', 'avatar', 'edad'],
+            exclude_required=['notas', 'fuente', 'estado', 'avatar', 'edad', 'region', 'localidad', 'street', 'number', 'door', 'codigo_postal'],
         )
         if form.is_valid():
             miembro = form.save(commit=False)
@@ -196,12 +196,13 @@ def member_signup(request, slug):
             miembro.estado = 'activo'
             miembro.fecha_inscripcion = timezone.now().date()
             miembro.save()
+            form.save_m2m()
             messages.success(request, 'Inscripción guardada correctamente.')
             if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 return HttpResponse(status=204)
             return redirect('club_profile', slug=club.slug)
     else:
-        form = MiembroForm(require_all=True, exclude_required=['notas', 'fuente', 'estado', 'avatar', 'edad'])
+        form = MiembroForm(require_all=True, exclude_required=['notas', 'fuente', 'estado', 'avatar', 'edad', 'region', 'localidad', 'street', 'number', 'door', 'codigo_postal'])
     template = 'clubs/_miembro_public_form.html' if request.headers.get('x-requested-with') == 'XMLHttpRequest' else 'clubs/miembro_form.html'
     return render(request, template, {'form': form, 'club': club})
 


### PR DESCRIPTION
## Summary
- Relax required fields for member creation and signup so records always save
- Save form M2M data when creating members
- Add regression test for member creation

## Testing
- `pytest`
- `python manage.py test apps.clubs.tests.DashboardMemberCreateTests`


------
https://chatgpt.com/codex/tasks/task_e_689a4d3fb49c83218db0f107b1f6d775