### PR TITLE
Fix member signup registration and add confirmation toast

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -11,7 +11,6 @@ from datetime import date
 from allauth.socialaccount.models import SocialApp
 from django.contrib.sites.models import Site
 from django import forms
-from unittest.mock import patch
 
 
 class ClubPlanTests(TestCase):
@@ -513,19 +512,8 @@ class MemberSignupDefaultsTests(TestCase):
         )
 
     def test_signup_sets_default_fields(self):
-        class SimpleForm(forms.ModelForm):
-            class Meta:
-                model = Miembro
-                fields = ['nombre', 'apellidos']
-
-            def __init__(self, *args, **kwargs):
-                kwargs.pop('require_all', None)
-                kwargs.pop('exclude_required', None)
-                super().__init__(*args, **kwargs)
-
         url = reverse('club_member_signup', args=[self.club.slug])
-        with patch('apps.clubs.views.public.MiembroForm', SimpleForm):
-            response = self.client.post(url, {'nombre': 'Juan', 'apellidos': 'Pérez'})
+        response = self.client.post(url, {'nombre': 'Juan', 'apellidos': 'Pérez'})
         self.assertEqual(response.status_code, 302)
         miembro = Miembro.objects.get()
         self.assertEqual(miembro.club, self.club)

--- a/apps/clubs/views/public.py
+++ b/apps/clubs/views/public.py
@@ -186,8 +186,6 @@ def member_signup(request, slug):
         form = MiembroForm(
             request.POST,
             request.FILES,
-            require_all=True,
-            exclude_required=['notas', 'fuente', 'estado', 'avatar', 'edad', 'region', 'localidad', 'street', 'number', 'door', 'codigo_postal'],
         )
         if form.is_valid():
             miembro = form.save(commit=False)
@@ -202,7 +200,7 @@ def member_signup(request, slug):
                 return HttpResponse(status=204)
             return redirect('club_profile', slug=club.slug)
     else:
-        form = MiembroForm(require_all=True, exclude_required=['notas', 'fuente', 'estado', 'avatar', 'edad', 'region', 'localidad', 'street', 'number', 'door', 'codigo_postal'])
+        form = MiembroForm()
     template = 'clubs/_miembro_public_form.html' if request.headers.get('x-requested-with') == 'XMLHttpRequest' else 'clubs/miembro_form.html'
     return render(request, template, {'form': form, 'club': club})
 

--- a/static/js/member-signup-modal.js
+++ b/static/js/member-signup-modal.js
@@ -25,10 +25,18 @@ document.addEventListener('DOMContentLoaded', () => {
             const form = modalEl.querySelector('form');
             form.addEventListener('submit', e => {
               e.preventDefault();
+              if (!confirm('¿Confirmas tu inscripción?')) return;
               const fd = new FormData(form);
               fetch(form.action, { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }, body: fd })
-                .then(() => {
-                  modal.hide();
+                .then(res => {
+                  if (res.status === 204) {
+                    showToast('Inscripción completada con éxito');
+                    modal.hide();
+                  } else {
+                    return res.text().then(html => {
+                      modalEl.querySelector('.modal-body').innerHTML = html;
+                    });
+                  }
                 });
             });
             modal.show();
@@ -37,3 +45,19 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 });
+
+function showToast(message) {
+  let container = document.querySelector('.toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'toast-container position-fixed top-0 end-0 p-3';
+    document.body.appendChild(container);
+  }
+  const toast = document.createElement('div');
+  toast.className = 'toast bg-black text-bg-success border-0 mb-2';
+  toast.role = 'alert';
+  toast.innerHTML = `<div class="d-flex"><div class="toast-body">${message}</div>` +
+                    `<button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button></div>`;
+  container.appendChild(toast);
+  new bootstrap.Toast(toast).show();
+}


### PR DESCRIPTION
## Summary
- Allow public club member signup without requiring all fields
- Add confirmation prompt and success toast to signup modal
- Test that member signup stores default values correctly

## Testing
- `python manage.py test apps.clubs.tests.MemberSignupDefaultsTests`
- `pytest apps/clubs/tests.py` *(fails: MultipleObjectsReturned, NameError: 'Reseña', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689c695481488321a633872771c42234