### PR TITLE
Handle AJAX message submission

### DIFF
--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -77,4 +77,5 @@
 
 {% block extra_js %}
 <script src="{% static 'js/message-like.js' %}"></script>
+<script src="{% static 'js/message-submit.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Return JSON when posting a new message via XMLHttpRequest in conversation view.
- Add message-submit.js to send messages asynchronously and append to DOM.
- Include new script in conversation template.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cc3fc7fc08321a235ecd3da051979