### PR TITLE
feat: auto scroll message thread and autosize input

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -707,8 +707,9 @@ class ClubMessageForm(UniformFieldsMixin, forms.ModelForm):
                 attrs={
                     'class': 'form-control form-control-sm w-100',
                     'rows': 1,
-                    'style': 'height:30px; max-height:30px;',
-                    'placeholder': 'Mensaje...'
+                    'style': 'height:30px;',
+                    'placeholder': 'Mensaje...',
+                    'data-autosize': 'true'
                 }
             )
         }

--- a/static/css/conversation.css
+++ b/static/css/conversation.css
@@ -5,7 +5,6 @@
   border-radius: 0.25rem;
 }
 #message-form textarea {
-  max-height: 30px;
   padding-right: 2rem;
 }
 #message-form button[type="submit"] {

--- a/static/js/message-submit.js
+++ b/static/js/message-submit.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('message-form');
+  const thread = document.getElementById('message-thread');
+
+  const scrollToBottom = () => {
+    if (thread) {
+      thread.scrollTop = thread.scrollHeight;
+    }
+  };
+
+  if (form && thread) {
+    const textarea = form.querySelector('textarea[data-autosize]');
+    if (textarea && typeof autosize === 'function') {
+      autosize(textarea);
+    }
+    scrollToBottom();
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const content = textarea.value.trim();
+      if (!content) return;
+
+      const url = form.action || window.location.href;
+      const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
+      const formData = new FormData();
+      formData.append('content', content);
+
+      try {
+        await fetch(url, {
+          method: 'POST',
+          headers: {
+            'X-CSRFToken': csrftoken,
+            'X-Requested-With': 'XMLHttpRequest'
+          },
+          body: formData
+        });
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'd-flex justify-content-end mb-2 message-row';
+        wrapper.innerHTML = `
+          <div class="p-1 rounded message-bubble bg-dark text-white">
+            <div>${content}</div>
+          </div>
+        `;
+        thread.appendChild(wrapper);
+        const timestamp = document.createElement('div');
+        timestamp.className = 'text-center text-muted small';
+        timestamp.textContent = 'justo ahora';
+        thread.appendChild(timestamp);
+
+        form.reset();
+        if (typeof autosize !== 'undefined') {
+          autosize.update(textarea);
+        }
+        scrollToBottom();
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  } else {
+    scrollToBottom();
+  }
+});

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -40,7 +40,7 @@
     </div>
       {% if club %}
       <div class="col-md-8">
-        <div class="mb-3">
+        <div id="message-thread" class="mb-3 overflow-auto" style="height: 400px;">
           {% for m in messages %}
             <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row">
               <div class="p-1 rounded message-bubble {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}bg-light{% endif %}">
@@ -77,4 +77,6 @@
 
 {% block extra_js %}
 <script src="{% static 'js/message-like.js' %}"></script>
+<script src="https://cdn.jsdelivr.net/npm/autosize@4.0.2/dist/autosize.min.js"></script>
+<script src="{% static 'js/message-submit.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- keep conversation messages within a scrollable `#message-thread`
- auto-scroll to bottom after sending messages
- use autosize library so message form textarea expands with content

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cc498f9ec8321a64c5589213c611e