### PR TITLE
Display unread message counts in club conversations

### DIFF
--- a/apps/clubs/views/messages.py
+++ b/apps/clubs/views/messages.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, get_object_or_404, redirect
 from django.urls import reverse
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
-from django.db.models import Max, Q
+from django.db.models import Max, Q, Count
 from django.http import JsonResponse
 
 from ..models import Club, ClubMessage
@@ -15,32 +15,75 @@ def conversation(request):
     slug = request.GET.get('club')
     user_id = request.GET.get('user')
 
-    ClubMessage.objects.filter(
-        (
-            Q(user=request.user, sender_is_club=True)
-            | Q(club__owner=request.user, sender_is_club=False)
-        )
-        & Q(is_read=False)
-    ).update(is_read=True)
+    club = None
+    conversant = None
+    messages_qs = ClubMessage.objects.none()
+    form = None
 
-    latest_ids = (
-        ClubMessage.objects.filter(
-            Q(user=request.user) | Q(club__owner=request.user)
+    if slug:
+        club = get_object_or_404(Club, slug=slug)
+
+        if request.user == club.owner and user_id is not None:
+            conversant = get_object_or_404(User, pk=user_id)
+        else:
+            conversant = request.user
+
+        messages_qs = (
+            ClubMessage.objects.filter(club=club, user=conversant)
+            .select_related('user')
+            .order_by('created_at')
         )
-        .values('club', 'user')
-        .annotate(last_id=Max('id'))
-        .values_list('last_id', flat=True)
+        unread_filter = Q(is_read=False)
+        if request.user == club.owner:
+            unread_filter &= Q(sender_is_club=False)
+        else:
+            unread_filter &= Q(sender_is_club=True)
+        messages_qs.filter(unread_filter).update(is_read=True)
+
+        if request.method == 'POST':
+            form = ClubMessageForm(request.POST)
+            if form.is_valid():
+                msg = form.save(commit=False)
+                msg.club = club
+                msg.user = conversant
+                msg.sender_is_club = request.user == club.owner
+                msg.is_read = True
+                msg.save()
+                url = reverse('conversation') + f'?club={club.slug}'
+                if request.user == club.owner:
+                    url += f'&user={conversant.id}'
+                return redirect(url)
+        else:
+            form = ClubMessageForm()
+
+    conversation_filter = Q(user=request.user) | Q(club__owner=request.user)
+    unread_counter_filter = (
+        Q(is_read=False)
+        & (
+            (Q(user=request.user) & Q(sender_is_club=True))
+            | (Q(club__owner=request.user) & Q(sender_is_club=False))
+        )
     )
+    latest = (
+        ClubMessage.objects.filter(conversation_filter)
+        .values('club', 'user')
+        .annotate(
+            last_id=Max('id'),
+            unread_count=Count('id', filter=unread_counter_filter),
+        )
+    )
+    latest_ids = [item['last_id'] for item in latest]
     conversations = (
         ClubMessage.objects.filter(id__in=latest_ids)
         .select_related('club', 'user')
         .order_by('-created_at')
     )
-
-    club = None
-    conversant = None
-    messages_qs = ClubMessage.objects.none()
-    form = None
+    unread_lookup = {
+        (item['club'], item['user']): item['unread_count']
+        for item in latest
+    }
+    for conv in conversations:
+        conv.unread_count = unread_lookup.get((conv.club_id, conv.user_id), 0)
 
     if not slug:
         context = {
@@ -51,42 +94,6 @@ def conversation(request):
             'conversations': conversations,
         }
         return render(request, 'clubs/conversation.html', context)
-
-    club = get_object_or_404(Club, slug=slug)
-
-    if request.user == club.owner and user_id is not None:
-        conversant = get_object_or_404(User, pk=user_id)
-    else:
-        conversant = request.user
-
-    messages_qs = (
-        ClubMessage.objects.filter(club=club, user=conversant)
-        .select_related('user')
-        .order_by('created_at')
-    )
-    unread_filter = Q(is_read=False)
-    if request.user == club.owner:
-        unread_filter &= Q(sender_is_club=False)
-    else:
-        unread_filter &= Q(sender_is_club=True)
-    messages_qs.filter(unread_filter).update(is_read=True)
-
-    if request.method == 'POST':
-        form = ClubMessageForm(request.POST)
-        if form.is_valid():
-            msg = form.save(commit=False)
-            msg.club = club
-            msg.user = conversant
-            msg.sender_is_club = request.user == club.owner
-            msg.is_read = True
-            msg.save()
-            url = reverse('conversation') + f'?club={club.slug}'
-            if request.user == club.owner:
-                url += f'&user={conversant.id}'
-            return redirect(url)
-    else:
-        form = ClubMessageForm()
-
     context = {
         'club': club,
         'messages': messages_qs,

--- a/static/css/conversation.css
+++ b/static/css/conversation.css
@@ -29,3 +29,11 @@
 .message-row:hover .message-actions {
   display: flex;
 }
+
+.badge-unread {
+  background-color: #dc3545;
+  color: #fff;
+  font-size: 0.75rem;
+  margin-left: 0.5rem;
+  border-radius: 6px;
+}

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -24,9 +24,16 @@
             <div class="flex-grow-1">
               <div class="fw-bold">
                 {% if user == conv.club.owner %}
-                  {{ conv.user.username }} - {{ conv.club.name }}
+                  {{ conv.user.username }}
+                  {% if conv.unread_count %}
+                    <span class="badge badge-unread">{{ conv.unread_count }}</span>
+                  {% endif %}
+                  - {{ conv.club.name }}
                 {% else %}
                   {{ conv.club.name }}
+                  {% if conv.unread_count %}
+                    <span class="badge badge-unread">{{ conv.unread_count }}</span>
+                  {% endif %}
                 {% endif %}
               </div>
               <div class="text-muted small">{{ conv.content|truncatechars:40 }}</div>

--- a/templates/clubs/message_inbox.html
+++ b/templates/clubs/message_inbox.html
@@ -21,9 +21,16 @@
         <div class="flex-grow-1">
           <div class="fw-bold">
             {% if user == m.club.owner %}
-              {{ m.user.username }} - {{ m.club.name }}
+              {{ m.user.username }}
+              {% if m.unread_count %}
+                <span class="badge badge-unread">{{ m.unread_count }}</span>
+              {% endif %}
+              - {{ m.club.name }}
             {% else %}
               {{ m.club.name }}
+              {% if m.unread_count %}
+                <span class="badge badge-unread">{{ m.unread_count }}</span>
+              {% endif %}
             {% endif %}
           </div>
           <div class="text-muted small">{{ m.content|truncatechars:40 }}</div>


### PR DESCRIPTION
## Summary
- compute conversation unread counts grouped by club and user
- show unread message badge in conversation and inbox templates
- style unread badge to match existing design

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cc40080c483218d61ab792e75b32a