### PR TITLE
Improve messages page UX

### DIFF
--- a/static/js/message-submit.js
+++ b/static/js/message-submit.js
@@ -1,8 +1,25 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('message-form');
   if (!form) return;
-  const container = form.previousElementSibling;
+
+  const container = document.getElementById('message-container');
   const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
+  const textarea = form.querySelector('textarea');
+
+  const scrollToBottom = () => {
+    container?.scrollTo({ top: container.scrollHeight });
+  };
+
+  scrollToBottom();
+
+  if (textarea) {
+    textarea.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        form.requestSubmit();
+      }
+    });
+  }
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -45,6 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       container.appendChild(row);
       container.appendChild(timestamp);
+      scrollToBottom();
 
       const likeBtn = row.querySelector('.message-like');
       if (likeBtn) {

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -40,7 +40,7 @@
     </div>
       {% if club %}
       <div class="col-md-8">
-        <div class="mb-3">
+        <div class="mb-3" id="message-container" style="max-height:60vh; overflow-y:auto;">
           {% for m in messages %}
             <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row">
               <div class="p-1 rounded message-bubble {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}bg-light{% endif %}">


### PR DESCRIPTION
## Summary
- Add scrollable container to messages view to keep conversation area tidy
- Enhance message submission script with auto-scroll and Enter-to-send support

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689cc6a2a284832193850bdfa7b53cf3