### PR TITLE
Refine messages styling to dark theme

### DIFF
--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -10,9 +10,9 @@
       <div class="list-group">
         {% for conv in conversations %}
           {% if user == conv.club.owner %}
-            <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}" class="list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club and conv.user == conversant %}active text-white{% endif %}">
+            <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}" class="list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club and conv.user == conversant %}bg-dark text-white{% endif %}">
           {% else %}
-            <a href="{% url 'conversation' %}?club={{ conv.club.slug }}" class="list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club %}active text-white{% endif %}">
+            <a href="{% url 'conversation' %}?club={{ conv.club.slug }}" class="list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club %}bg-dark text-white{% endif %}">
           {% endif %}
             {% if conv.club.logo %}
               <img src="{{ conv.club.logo.url }}" class="rounded-circle me-3" style="width:40px;height:40px;object-fit:cover;" alt="{{ conv.club.name }}">
@@ -65,7 +65,7 @@
         <form method="post" id="message-form" class="bg-light p-2 rounded">
           {% csrf_token %}
           {{ form.content }}
-          <button type="submit" class="btn btn-primary d-flex align-items-center">
+          <button type="submit" class="btn btn-dark d-flex align-items-center">
             <i class="bi bi-send-fill"></i>
           </button>
         </form>

--- a/templates/partials/_messages_modal.html
+++ b/templates/partials/_messages_modal.html
@@ -19,7 +19,7 @@
               class="col-12 d-flex {% if user == m.club.owner and m.sender_is_club or user != m.club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %}"
             >
               <div
-                class="p-1 rounded {% if user == m.club.owner and m.sender_is_club or user != m.club.owner and not m.sender_is_club %}bg-primary text-white{% else %}bg-light{% endif %}"
+                class="p-1 rounded {% if user == m.club.owner and m.sender_is_club or user != m.club.owner and not m.sender_is_club %}bg-dark text-white{% else %}bg-light{% endif %}"
               >
                 <div>{{ m.content }}</div>
                 <div class="d-flex align-items-center gap-1 mt-1">


### PR DESCRIPTION
## Summary
- use dark background for selected conversations
- switch message send button to dark style
- darken own messages in modal

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cc8320ce483219781a3e0f27924b8