### PR TITLE
Ajustes de diseño en bandeja de mensajes

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -705,9 +705,9 @@ class ClubMessageForm(UniformFieldsMixin, forms.ModelForm):
         widgets = {
             'content': forms.Textarea(
                 attrs={
-                    'class': 'form-control form-control-sm w-100',
+                    'class': 'form-control w-100 border-0',
                     'rows': 1,
-                    'style': 'height:30px; max-height:30px;',
+                    'style': 'height:40px; max-height:40px; resize:none;',
                     'placeholder': 'Mensaje...'
                 }
             )

--- a/static/css/conversation.css
+++ b/static/css/conversation.css
@@ -1,17 +1,27 @@
 #message-form {
   position: relative;
-  background-color: #f8f9fa;
-  padding: 0.25rem;
-  border-radius: 0.25rem;
+  background-color: #fff;
+  padding: 0.25rem 0.75rem;
+  border-radius: 2rem;
+  border: 1px solid #ced4da;
 }
 #message-form textarea {
-  max-height: 30px;
-  padding-right: 2rem;
+  max-height: 45px;
+  padding-right: 2.5rem;
+  border: none;
+  background-color: transparent;
+  resize: none;
+  outline: none;
+  box-shadow: none;
+}
+#message-form textarea:focus {
+  outline: none;
+  box-shadow: none;
 }
 #message-form button[type="submit"] {
   position: absolute;
   top: 50%;
-  right: 0.25rem;
+  right: 0.75rem;
   transform: translateY(-50%);
 }
 

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -3,76 +3,84 @@
 {% load utils_filters %}
 {% block body_class %}d-flex flex-column min-vh-100{% endblock %}
 {% block content %}
-<div class="container my-4">
-  <div class="row">
-    <div class="col-md-4 mb-3">
-      <h5 class="mb-3">Mis mensajes</h5>
-      <div class="list-group">
-        {% for conv in conversations %}
-          {% if user == conv.club.owner %}
-            <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}" class="p-3 list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club and conv.user == conversant %}bg-light text-dark{% endif %}">
-          {% else %}
-            <a href="{% url 'conversation' %}?club={{ conv.club.slug }}" class="list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club %}bg-dark text-white{% endif %}">
-          {% endif %}
-            {% if conv.club.logo %}
-              <img src="{{ conv.club.logo.url }}" class="rounded-circle me-3" style="min-width:40px;min-height:40px;object-fit:cover;" alt="{{ conv.club.name }}">
+<main class="flex-grow-1">
+  <div class="container my-4 h-100">
+    <div class="row h-100">
+      <div class="col-md-4 mb-3">
+        <h5 class="mb-3">Mis mensajes</h5>
+        <div class="list-group">
+          {% for conv in conversations %}
+            {% if user == conv.club.owner %}
+              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}" class="p-3 list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club and conv.user == conversant %}bg-light text-dark{% endif %}">
             {% else %}
-              <div class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center me-3" style="min-width:40px;min-height:40px;">
-                {{ conv.club.name|first|upper }}
-              </div>
+              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}" class="list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club %}bg-dark text-white{% endif %}">
             {% endif %}
-            <div class="flex-grow-1">
-              <div class="fw-bold">
-                {% if user == conv.club.owner %}
-                  {{ conv.user.username }}
-                {% else %}
-                  {{ conv.club.name }}
-                {% endif %}
+              {% if conv.club.logo %}
+                <img src="{{ conv.club.logo.url }}" class="rounded-circle me-3" style="min-width:40px;min-height:40px;object-fit:cover;" alt="{{ conv.club.name }}">
+              {% else %}
+                <div class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center me-3" style="min-width:40px;min-height:40px;">
+                  {{ conv.club.name|first|upper }}
+                </div>
+              {% endif %}
+              <div class="flex-grow-1">
+                <div class="fw-bold">
+                  {% if user == conv.club.owner %}
+                    {{ conv.user.username }}
+                  {% else %}
+                    {{ conv.club.name }}
+                  {% endif %}
+                </div>
+                <div class="text-muted small">{{ conv.content|truncatechars:40 }}</div>
               </div>
-              <div class="text-muted small">{{ conv.content|truncatechars:40 }}</div>
-            </div>
-            <small class="text-muted ms-3">{{ conv.created_at|timesince }} atrás</small>
-          </a>
-        {% empty %}
-          <p>No hay mensajes.</p>
-        {% endfor %}
-      </div>
-    </div>
-      {% if club %}
-      <div class="col-md-8">
-        <div class="mb-3" id="message-container" style="max-height:60vh; overflow-y:auto;">
-          {% for m in messages %}
-            <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row">
-              <div class="p-1 rounded message-bubble {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}bg-light{% endif %}">
-                <div>{{ m.content }}</div>
-              </div>
-              <div class="message-actions ms-1">
-                <button class="btn p-0 reply-btn">
-                  <i class="bi bi-reply"></i>
-                </button>
-                <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
-                  <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
-                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-            <div class="text-center text-muted small">{{ m.created_at|message_timestamp }}</div>
+              <small class="text-muted ms-3">{{ conv.created_at|timesince }} atrás</small>
+            </a>
           {% empty %}
             <p>No hay mensajes.</p>
           {% endfor %}
         </div>
-        <form method="post" id="message-form" class="bg-light rounded">
-          {% csrf_token %}
-          {{ form.content }}
-          <button type="submit" class="btn btn-dark d-flex align-items-center">
-            <i class="bi bi-send-fill"></i>
-          </button>
-        </form>
       </div>
-      {% endif %}
+      <div class="col-md-8 d-flex flex-column h-100">
+        {% if club %}
+          <div class="mb-3 flex-grow-1" id="message-container" style="max-height:60vh; overflow-y:auto;">
+            {% for m in messages %}
+              <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row">
+                <div class="p-1 rounded message-bubble {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}bg-light{% endif %}">
+                  <div>{{ m.content }}</div>
+                </div>
+                <div class="message-actions ms-1">
+                  <button class="btn p-0 reply-btn">
+                    <i class="bi bi-reply"></i>
+                  </button>
+                  <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
+                    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
+                      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div class="text-center text-muted small">{{ m.created_at|message_timestamp }}</div>
+            {% empty %}
+              <p>No hay mensajes.</p>
+            {% endfor %}
+          </div>
+          <form method="post" id="message-form">
+            {% csrf_token %}
+            {{ form.content }}
+            <button type="submit" class="btn btn-dark d-flex align-items-center">
+              <i class="bi bi-send-fill"></i>
+            </button>
+          </form>
+        {% else %}
+          <div class="d-flex flex-column justify-content-center align-items-center text-center flex-grow-1 text-muted">
+            <i class="bi bi-chat-dots fs-1 mb-3"></i>
+            <h4>Bandeja de entrada</h4>
+            <p>Selecciona una conversación.</p>
+          </div>
+        {% endif %}
+      </div>
+    </div>
   </div>
-</div>
+</main>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
## Summary
- Centrar la vista de bandeja con altura completa y footer fijo.
- Mostrar placeholder con icono y texto cuando no hay conversación seleccionada.
- Rediseñar el campo de mensaje: sin fondo gris ni resalte azul, bordes redondeados e input más grande.

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689cd1fe972083219a424d3f5a811715