### PR TITLE
Improve messaging conversation layout and input

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -707,8 +707,9 @@ class ClubMessageForm(UniformFieldsMixin, forms.ModelForm):
                 attrs={
                     'class': 'form-control w-100 border-0',
                     'rows': 1,
-                    'style': 'height:40px; max-height:40px; resize:none; line-height:40px; padding-top:0; padding-bottom:0;',
-                    'placeholder': 'Mensaje...'
+                    'style': 'height:40px; max-height:40px; resize:none; line-height:40px; padding-top:0; padding-bottom:0; overflow:hidden; white-space:nowrap;',
+                    'placeholder': 'Mensaje...',
+                    'oninput': 'this.value=this.value.replace(/\n/g, "")'
                 }
             )
         }

--- a/static/js/message-submit.js
+++ b/static/js/message-submit.js
@@ -27,9 +27,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (textarea) {
     textarea.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter') {
         e.preventDefault();
-        form.requestSubmit();
+        if (!e.shiftKey) {
+          form.requestSubmit();
+        }
       }
     });
   }

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -11,7 +11,7 @@
         <div class="list-group ">
           {% for conv in conversations %}
             {% if user == conv.club.owner %}
-              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}" class="p-3 list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club and conv.user == conversant %}{% endif %}">
+              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}" class="p-3 list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club and conv.user == conversant %}bg-dark text-white{% endif %}">
             {% else %}
               <a href="{% url 'conversation' %}?club={{ conv.club.slug }}" class="list-group-item list-group-item-action d-flex align-items-center {% if conv.club == club %}bg-dark text-white{% endif %}">
             {% endif %}
@@ -39,9 +39,26 @@
           {% endfor %}
         </div>
       </div>
-      <div class="col-md-8 d-flex p-3 flex-column h-100 border-start">
+      <div class="col-md-8 d-flex flex-column h-100 border-start">
         {% if club %}
-          <div class="mb-3 flex-grow-1" id="message-container" style="max-height:60vh; overflow-y:auto;">
+          <div class="border-bottom p-3 d-flex align-items-center">
+            {% if user == club.owner %}
+              {% if conversant.profile.avatar %}
+                <img src="{{ conversant.profile.avatar.url }}" class="rounded-circle me-2" style="width:40px;height:40px;object-fit:cover;" alt="{{ conversant.username }}">
+              {% else %}
+                <div class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center me-2" style="width:40px;height:40px;">{{ conversant.username|first|upper }}</div>
+              {% endif %}
+              <span class="fw-bold">{{ conversant.username }}</span>
+            {% else %}
+              {% if club.logo %}
+                <img src="{{ club.logo.url }}" class="rounded-circle me-2" style="width:40px;height:40px;object-fit:cover;" alt="{{ club.name }}">
+              {% else %}
+                <div class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center me-2" style="width:40px;height:40px;">{{ club.name|first|upper }}</div>
+              {% endif %}
+              <span class="fw-bold">{{ club.name }}</span>
+            {% endif %}
+          </div>
+          <div class="mb-3 flex-grow-1 p-3" id="message-container" style="max-height:60vh; overflow-y:auto;">
             {% for m in messages %}
               <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row">
                 <div class="p-1 rounded message-bubble {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark p-1 rounded text-white{% else %}border p-1{% endif %}">
@@ -70,14 +87,14 @@
               <i class="bi bi-send-fill"></i>
             </button>
           </form>
-        {% else %}
-          <div class="d-flex flex-column justify-content-center align-items-center text-center flex-grow-1 text-muted">
-            <i class="bi bi-chat-dots fs-1 mb-3"></i>
-            <h4>Bandeja de entrada</h4>
-            <p>Selecciona una conversación.</p>
-          </div>
-        {% endif %}
-      </div>
+          {% else %}
+            <div class="d-flex flex-column justify-content-center align-items-center text-center flex-grow-1 text-muted p-3">
+              <i class="bi bi-chat-dots fs-1 mb-3"></i>
+              <h4>Bandeja de entrada</h4>
+              <p>Selecciona una conversación.</p>
+            </div>
+          {% endif %}
+        </div>
     </div>
   </div>
 </main>


### PR DESCRIPTION
## Summary
- Add avatar/name header in conversation view
- Highlight active conversation in sidebar with bg-dark
- Restrict message input to single line and prevent overflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d323c41c08321b074f8726ade5732