### PR TITLE
Adjust message UI

### DIFF
--- a/apps/core/templatetags/utils_filters.py
+++ b/apps/core/templatetags/utils_filters.py
@@ -50,6 +50,36 @@ def time_since_short(value):
     return f"hace {weeks} semanas"
 
 
+@register.filter
+def time_since_simple(value):
+    """Return time difference using a single unit (minutes, hours, days or weeks)."""
+    if not value:
+        return ""
+
+    from django.utils import timezone
+
+    now = timezone.now()
+    diff = now - value
+    seconds = int(diff.total_seconds())
+
+    minutes = seconds // 60
+    if minutes < 1:
+        return "1 minuto"
+    if minutes < 60:
+        return f"{minutes} minuto{'s' if minutes != 1 else ''}"
+
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours} hora{'s' if hours != 1 else ''}"
+
+    days = hours // 24
+    if days < 7:
+        return f"{days} día{'s' if days != 1 else ''}"
+
+    weeks = days // 7
+    return f"{weeks} semana{'s' if weeks != 1 else ''}"
+
+
 @register.filter(is_safe=True)
 def youtube_embed(text):
     """Replace YouTube links in ``text`` with embed iframe."""

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -10,35 +10,35 @@
         <h5 class="border-bottom fw-medium p-3 ">Conversaciones recientes </h5>
         <div class="list-group ">
           {% for conv in conversations %}
-            {% if user == conv.club.owner %}
-              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}" class="p-3 list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club and conv.user == conversant %} text-dark{% endif %}">
-            {% else %}
-              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}" class="list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club %} bg-dark text-dark{% endif %}">
-            {% endif %}
-              {% if conv.club.logo %}
-                <img src="{{ conv.club.logo.url }}" class="rounded-circle me-3" style="min-width:40px;min-height:40px;object-fit:cover;" alt="{{ conv.club.name }}">
+              {% if user == conv.club.owner %}
+                <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}" class="p-3 list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club and conv.user == conversant %} bg-dark text-white{% endif %}">
               {% else %}
-                <div class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center me-3" style="min-width:40px;min-height:40px;">
-                  {{ conv.club.name|first|upper }}
-                </div>
+                <a href="{% url 'conversation' %}?club={{ conv.club.slug }}" class="list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club %} bg-dark text-white{% endif %}">
               {% endif %}
-              <div class="flex-grow-1">
-                <div class="fw-bold">
-                  {% if user == conv.club.owner %}
-                    {{ conv.user.username }}
-                  {% else %}
-                    {{ conv.club.name }}
-                  {% endif %}
-                </div>
-              <div class="{% if conv.club == club and user == conv.club.owner and conv.user == conversant or conv.club == club and user != conv.club.owner %}text-dark small{% else %}text-muted small{% endif %}">{{ conv.content|truncatechars:40 }}</div>
+                {% if conv.club.logo %}
+                  <img src="{{ conv.club.logo.url }}" class="rounded-circle me-3" style="min-width:40px;min-height:40px;object-fit:cover;" alt="{{ conv.club.name }}">
+                {% else %}
+                  <div class="rounded-circle d-flex align-items-center justify-content-center me-3 {% if (user == conv.club.owner and conv.club == club and conv.user == conversant) or (user != conv.club.owner and conv.club == club) %}bg-white text-dark{% else %}bg-dark text-white{% endif %}" style="min-width:40px;min-height:40px;">
+                    {{ conv.club.name|first|upper }}
                   </div>
-              <small class="{% if conv.club == club and user == conv.club.owner and conv.user == conversant or conv.club == club and user != conv.club.owner %}text-dark{% else %}text-muted{% endif %} ms-3">{{ conv.created_at|timesince }} </small>
-            </a>
-          {% empty %}
-            <p>No hay mensajes.</p>
-          {% endfor %}
-        </div>
-      </div>
+                {% endif %}
+                <div class="flex-grow-1">
+                  <div class="fw-bold">
+                    {% if user == conv.club.owner %}
+                      {{ conv.user.username }}
+                    {% else %}
+                      {{ conv.club.name }}
+                    {% endif %}
+                  </div>
+                <div class="{% if (user == conv.club.owner and conv.club == club and conv.user == conversant) or (user != conv.club.owner and conv.club == club) %}text-white small{% else %}text-muted small{% endif %}">{{ conv.content|truncatechars:40 }}</div>
+                  </div>
+                <small class="{% if (user == conv.club.owner and conv.club == club and conv.user == conversant) or (user != conv.club.owner and conv.club == club) %}text-white{% else %}text-muted{% endif %} ms-3">{{ conv.created_at|time_since_simple }} </small>
+              </a>
+              {% empty %}
+                <p>No hay mensajes.</p>
+              {% endfor %}
+            </div>
+          </div>
       <div class="col-md-8 m-0 p-0 d-flex flex-column h-100 border-start">
         {% if club %}
           <div class="border-bottom p-3 d-flex align-items-center">
@@ -59,29 +59,49 @@
             {% endif %}
           </div>
             <div class="mb-3 flex-grow-1 p-3 " id="message-container" style="max-height:60vh; overflow-y:auto;">
-              {% for m in messages %}
-                <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row" data-id="{{ m.id }}">
-                  <div class="rounded message-bubble {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}border{% endif %}">
-                    {% if m.reply_to %}
-                      <div class="message-reply bg-secondary rounded  text-white mb-2">{{ m.reply_to.content }}</div>
-                       {% endif %}
-                    <div>{{ m.content }}</div>
+                {% for m in messages %}
+                  <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row" data-id="{{ m.id }}">
+                    {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}
+                      <div class="message-actions me-1">
+                        <button class="btn p-0 reply-btn">
+                          <i class="bi bi-reply" style="transform: scaleX(-1);"></i>
+                        </button>
+                        <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
+                          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
+                          </svg>
+                        </button>
+                      </div>
+                      <div class="rounded message-bubble bg-dark text-white">
+                        {% if m.reply_to %}
+                          <div class="message-reply bg-secondary rounded  text-white mb-2">{{ m.reply_to.content }}</div>
+                         {% endif %}
+                        <div>{{ m.content }}</div>
+                        <div class="text-end small text-muted mt-1">{{ m.created_at|message_timestamp }}</div>
+                      </div>
+                    {% else %}
+                      <div class="rounded message-bubble border">
+                        {% if m.reply_to %}
+                          <div class="message-reply bg-secondary rounded  text-white mb-2">{{ m.reply_to.content }}</div>
+                         {% endif %}
+                        <div>{{ m.content }}</div>
+                        <div class="text-end small text-muted mt-1">{{ m.created_at|message_timestamp }}</div>
+                      </div>
+                      <div class="message-actions ms-1">
+                        <button class="btn p-0 reply-btn">
+                          <i class="bi bi-reply"></i>
+                        </button>
+                        <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
+                          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
+                          </svg>
+                        </button>
+                      </div>
+                    {% endif %}
                   </div>
-                  <div class="message-actions ms-1">
-                    <button class="btn p-0 reply-btn">
-                      <i class="bi bi-reply"></i>
-                    </button>
-                    <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
-                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div class="text-center text-muted small">{{ m.created_at|message_timestamp }}</div>
-              {% empty %}
-                <p>No hay mensajes.</p>
-              {% endfor %}
+                {% empty %}
+                  <p>No hay mensajes.</p>
+                {% endfor %}
             </div>
           <div id="reply-preview" class="border-top py-2 px-3 d-none d-flex align-items-center">
             <div id="reply-text" class="bg-light p-2 rounded flex-grow-1"></div>


### PR DESCRIPTION
## Summary
- highlight active conversations with dark background and white text
- flip reply icon and reposition message actions for owner messages
- show simplified conversation timestamps using single time unit

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689df15a0d6883219fa30132a2c787a0