### PR TITLE
Improve messages conversation active styling

### DIFF
--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -11,29 +11,52 @@
         <div class="list-group ">
           {% for conv in conversations %}
             {% if user == conv.club.owner %}
-              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}" class="p-3 list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club and conv.user == conversant %} text-dark{% endif %}">
-            {% else %}
-              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}" class="list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club %} bg-dark text-dark{% endif %}">
-            {% endif %}
-              {% if conv.club.logo %}
-                <img src="{{ conv.club.logo.url }}" class="rounded-circle me-3" style="min-width:40px;min-height:40px;object-fit:cover;" alt="{{ conv.club.name }}">
-              {% else %}
-                <div class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center me-3" style="min-width:40px;min-height:40px;">
-                  {{ conv.club.name|first|upper }}
-                </div>
-              {% endif %}
-              <div class="flex-grow-1">
-                <div class="fw-bold">
-                  {% if user == conv.club.owner %}
-                    {{ conv.user.username }}
-                  {% else %}
-                    {{ conv.club.name }}
-                  {% endif %}
-                </div>
-              <div class="{% if conv.club == club and user == conv.club.owner and conv.user == conversant or conv.club == club and user != conv.club.owner %}text-dark small{% else %}text-muted small{% endif %}">{{ conv.content|truncatechars:40 }}</div>
+              {% with is_active=conv.club == club and conv.user == conversant %}
+              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}" class="p-3 list-group-item list-group-item-action d-flex align-items-center{% if is_active %} bg-dark text-white{% endif %}">
+                {% if conv.club.logo %}
+                  <img src="{{ conv.club.logo.url }}" class="rounded-circle me-3{% if is_active %} bg-white p-1{% endif %}" style="min-width:40px;min-height:40px;object-fit:cover;" alt="{{ conv.club.name }}">
+                {% else %}
+                  <div class="rounded-circle d-flex align-items-center justify-content-center me-3 {% if is_active %}bg-white text-dark{% else %}bg-dark text-white{% endif %}" style="min-width:40px;min-height:40px;">
+                    {{ conv.club.name|first|upper }}
                   </div>
-              <small class="{% if conv.club == club and user == conv.club.owner and conv.user == conversant or conv.club == club and user != conv.club.owner %}text-dark{% else %}text-muted{% endif %} ms-3">{{ conv.created_at|timesince }} </small>
-            </a>
+                {% endif %}
+                <div class="flex-grow-1">
+                  <div class="fw-bold">
+                    {% if user == conv.club.owner %}
+                      {{ conv.user.username }}
+                    {% else %}
+                      {{ conv.club.name }}
+                    {% endif %}
+                  </div>
+                <div class="{% if is_active %}text-white small{% else %}text-muted small{% endif %}">{{ conv.content|truncatechars:40 }}</div>
+                    </div>
+                <small class="{% if is_active %}text-white{% else %}text-muted{% endif %} ms-3">{{ conv.created_at|time_since_short }}</small>
+              </a>
+              {% endwith %}
+            {% else %}
+              {% with is_active=conv.club == club %}
+              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}" class="list-group-item list-group-item-action d-flex align-items-center{% if is_active %} bg-dark text-white{% endif %}">
+                {% if conv.club.logo %}
+                  <img src="{{ conv.club.logo.url }}" class="rounded-circle me-3{% if is_active %} bg-white p-1{% endif %}" style="min-width:40px;min-height:40px;object-fit:cover;" alt="{{ conv.club.name }}">
+                {% else %}
+                  <div class="rounded-circle d-flex align-items-center justify-content-center me-3 {% if is_active %}bg-white text-dark{% else %}bg-dark text-white{% endif %}" style="min-width:40px;min-height:40px;">
+                    {{ conv.club.name|first|upper }}
+                  </div>
+                {% endif %}
+                <div class="flex-grow-1">
+                  <div class="fw-bold">
+                    {% if user == conv.club.owner %}
+                      {{ conv.user.username }}
+                    {% else %}
+                      {{ conv.club.name }}
+                    {% endif %}
+                  </div>
+                <div class="{% if is_active %}text-white small{% else %}text-muted small{% endif %}">{{ conv.content|truncatechars:40 }}</div>
+                    </div>
+                <small class="{% if is_active %}text-white{% else %}text-muted{% endif %} ms-3">{{ conv.created_at|time_since_short }}</small>
+              </a>
+              {% endwith %}
+            {% endif %}
           {% empty %}
             <p>No hay mensajes.</p>
           {% endfor %}


### PR DESCRIPTION
## Summary
- Highlight active conversation with dark background, white text and white avatar
- Show conversation timestamps with single time units using `time_since_short`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e08c8b3948321a635730b066771ad