### PR TITLE
Position owner's message actions on left

### DIFF
--- a/static/css/conversation.css
+++ b/static/css/conversation.css
@@ -32,7 +32,6 @@
 
 .message-actions {
   display: none;
-  margin-left: 0.25rem;
   gap: 0.25rem;
 }
 

--- a/static/js/message-submit.js
+++ b/static/js/message-submit.js
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const attachReplyHandler = (btn) => {
     btn.addEventListener('click', () => {
       const row = btn.closest('.message-row');
-      const text = row?.querySelector('.message-bubble div:last-child')?.textContent.trim();
+      const text = row?.querySelector('.message-content')?.textContent.trim();
       const id = row?.dataset.id;
       if (text) {
         if (replyText) replyText.textContent = text;
@@ -76,28 +76,26 @@ document.addEventListener('DOMContentLoaded', () => {
         row.className = 'd-flex justify-content-end mb-2 message-row';
         row.dataset.id = data.id;
         const quote = data.reply_to ? `<div class="bg-light p-1 rounded mb-1 text-dark">${data.reply_to}</div>` : '';
-        row.innerHTML = `
+        const bubble = `
           <div class="p-1 rounded message-bubble bg-dark text-white">
             ${quote}
-            <div>${data.content}</div>
-          </div>
-          <div class="message-actions ms-1">
+            <div class="message-content">${data.content}</div>
+            <div class="text-end text-muted small mt-1">${data.created_at}</div>
+          </div>`;
+        const actions = `
+          <div class="message-actions ${data.sender_is_club ? 'me-1' : 'ms-1'}">
             <button class="btn p-0 reply-btn">
-              <i class="bi bi-reply"></i>
+              <i class="bi bi-reply" ${data.sender_is_club ? 'style="transform:scaleX(-1);"' : ''}></i>
             </button>
             <button class="btn p-0 message-like" data-url="${data.like_url}">
               <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
                 <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
               </svg>
             </button>
-          </div>
-        `;
-      const timestamp = document.createElement('div');
-      timestamp.className = 'text-center text-muted small';
-      timestamp.textContent = data.created_at;
+          </div>`;
+        row.innerHTML = data.sender_is_club ? actions + bubble : bubble + actions;
 
       container.appendChild(row);
-      container.appendChild(timestamp);
       scrollToBottom();
 
       const likeBtn = row.querySelector('.message-like');

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -84,12 +84,26 @@
             <div class="mb-3 flex-grow-1 p-3 " id="message-container" style="max-height:60vh; overflow-y:auto;">
               {% for m in messages %}
                 <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row" data-id="{{ m.id }}">
+                  {% if m.sender_is_club %}
+                  <div class="message-actions me-1">
+                    <button class="btn p-0 reply-btn">
+                      <i class="bi bi-reply" style="transform:scaleX(-1);"></i>
+                    </button>
+                    <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
+                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
+                      </svg>
+                    </button>
+                  </div>
+                  {% endif %}
                   <div class="rounded message-bubble {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}border{% endif %}">
                     {% if m.reply_to %}
                       <div class="message-reply bg-secondary rounded  text-white mb-2">{{ m.reply_to.content }}</div>
                        {% endif %}
-                    <div>{{ m.content }}</div>
+                    <div class="message-content">{{ m.content }}</div>
+                    <div class="text-end text-muted small mt-1">{{ m.created_at|message_timestamp }}</div>
                   </div>
+                  {% if not m.sender_is_club %}
                   <div class="message-actions ms-1">
                     <button class="btn p-0 reply-btn">
                       <i class="bi bi-reply"></i>
@@ -100,8 +114,8 @@
                       </svg>
                     </button>
                   </div>
+                  {% endif %}
                 </div>
-                <div class="text-center text-muted small">{{ m.created_at|message_timestamp }}</div>
               {% empty %}
                 <p>No hay mensajes.</p>
               {% endfor %}


### PR DESCRIPTION
## Summary
- Flip owner reply icon and show reply/like buttons on message's left side
- Display message timestamps inside each bubble
- Update JS and CSS to support new layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e0b786ce083218ff0a53336b4d4dd