### PR TITLE
Style chat timestamps on messages page

### DIFF
--- a/apps/core/templatetags/utils_filters.py
+++ b/apps/core/templatetags/utils_filters.py
@@ -103,35 +103,11 @@ def get_list(querydict, key):
 
 @register.filter
 def message_timestamp(value):
-    """Return a friendly timestamp for chat messages."""
+    """Return only the time portion of ``value`` in 24h format."""
     if not value:
         return ""
 
     from django.utils import timezone
 
     value = timezone.localtime(value)
-    now = timezone.localtime(timezone.now())
-
-    if value.date() == now.date():
-        return value.strftime("%H:%M")
-
-    start_of_week = now - timezone.timedelta(days=now.weekday())
-    if value.date() >= start_of_week.date():
-        days = ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"]
-        return f"{days[value.weekday()]} {value.strftime('%H:%M')}"
-
-    months = [
-        "Jan",
-        "Feb",
-        "Mar",
-        "Apr",
-        "May",
-        "Jun",
-        "Jul",
-        "Aug",
-        "Sep",
-        "Oct",
-        "Nov",
-        "Dec",
-    ]
-    return f"{months[value.month - 1]} {value.day}, {value.year}, {value.strftime('%H:%M')}"
+    return value.strftime("%H:%M")

--- a/static/js/message-submit.js
+++ b/static/js/message-submit.js
@@ -80,7 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
           <div class="p-1 rounded message-bubble bg-dark text-white">
             ${quote}
             <div class="message-content">${data.content}</div>
-            <div class="text-end text-muted small mt-1">${data.created_at}</div>
+            <div class="text-end text-white small mt-1">${data.created_at}</div>
           </div>`;
         const actions = `
           <div class="message-actions ${data.sender_is_club ? 'me-1' : 'ms-1'}">

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -83,6 +83,9 @@
           </div>
             <div class="mb-3 flex-grow-1 p-3 " id="message-container" style="max-height:60vh; overflow-y:auto;">
               {% for m in messages %}
+                {% ifchanged m.created_at|date:"Y-m-d" %}
+                  <div class="text-center text-muted small my-2">{{ m.created_at|date:"d/m/Y" }}</div>
+                {% endifchanged %}
                 <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row" data-id="{{ m.id }}">
                   {% if m.sender_is_club %}
                   <div class="message-actions me-1">
@@ -101,7 +104,7 @@
                       <div class="message-reply bg-secondary rounded  text-white mb-2">{{ m.reply_to.content }}</div>
                        {% endif %}
                     <div class="message-content">{{ m.content }}</div>
-                    <div class="text-end text-muted small mt-1">{{ m.created_at|message_timestamp }}</div>
+                    <div class="text-end small mt-1 {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}text-white{% else %}text-black{% endif %}">{{ m.created_at|message_timestamp }}</div>
                   </div>
                   {% if not m.sender_is_club %}
                   <div class="message-actions ms-1">


### PR DESCRIPTION
## Summary
- Show only time for message timestamps
- Center date markers in conversations and color time white/black based on sender
- Align message submit script with new timestamp styling

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689e106c080883219a9734c63e9cf54c