### PR TITLE
Show human-friendly dates in conversations

### DIFF
--- a/apps/core/templatetags/utils_filters.py
+++ b/apps/core/templatetags/utils_filters.py
@@ -111,3 +111,23 @@ def message_timestamp(value):
 
     value = timezone.localtime(value)
     return value.strftime("%H:%M")
+
+
+@register.filter
+def message_day(value):
+    """Return 'Hoy', 'Ayer' or formatted date for ``value``."""
+    if not value:
+        return ""
+
+    from datetime import timedelta
+    from django.utils import timezone
+
+    value_date = timezone.localtime(value).date()
+    today = timezone.localtime(timezone.now()).date()
+
+    if value_date == today:
+        return "Hoy"
+    if value_date == today - timedelta(days=1):
+        return "Ayer"
+
+    return value_date.strftime("%d/%m/%Y")

--- a/apps/core/tests.py
+++ b/apps/core/tests.py
@@ -1,6 +1,9 @@
-from django.test import SimpleTestCase
+from datetime import timedelta
 
-from .templatetags.utils_filters import youtube_embed
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from .templatetags.utils_filters import message_day, youtube_embed
 
 
 class YoutubeEmbedTests(SimpleTestCase):
@@ -22,4 +25,19 @@ class AyudaViewTests(SimpleTestCase):
         response = self.client.get('/ayuda/')
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'core/ayuda.html')
+
+
+class MessageDayFilterTests(SimpleTestCase):
+    def test_returns_hoy_for_today(self):
+        now = timezone.now()
+        self.assertEqual(message_day(now), 'Hoy')
+
+    def test_returns_ayer_for_yesterday(self):
+        yesterday = timezone.now() - timedelta(days=1)
+        self.assertEqual(message_day(yesterday), 'Ayer')
+
+    def test_returns_date_for_older(self):
+        old_date = timezone.now() - timedelta(days=2)
+        expected = timezone.localtime(old_date).date().strftime('%d/%m/%Y')
+        self.assertEqual(message_day(old_date), expected)
 

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -98,7 +98,7 @@
           <div class="mb-3 flex-grow-1 p-3 " id="message-container" style="max-height:60vh; overflow-y:auto;">
             {% for m in messages %}
               {% ifchanged m.created_at|date:"Y-m-d" %}
-                <div class="text-center text-muted small my-2">{{ m.created_at|date:"d/m/Y" }}</div>
+                <div class="text-center text-muted small my-2">{{ m.created_at|message_day }}</div>
               {% endifchanged %}
               <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row" data-id="{{ m.id }}">
                 {% if m.sender_is_club %}


### PR DESCRIPTION
## Summary
- add template filter to show "Hoy", "Ayer" or full date
- use new filter in conversation template to label message days
- cover message_day filter with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e13b49d2083219b93e482f4e18e0f