### PR TITLE
Style message bubbles and previews

### DIFF
--- a/static/css/conversation.css
+++ b/static/css/conversation.css
@@ -62,5 +62,6 @@
 
 .message-bubble {
   padding:5px 10px 5px 10px;
-
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
 }

--- a/static/js/message-submit.js
+++ b/static/js/message-submit.js
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
         row.dataset.id = data.id;
         const quote = data.reply_to ? `<div class="bg-light p-1 rounded mb-1 text-dark">${data.reply_to}</div>` : '';
         const bubble = `
-          <div class="p-1 rounded message-bubble bg-dark text-white">
+          <div class="p-1 rounded message-bubble col-md-5 text-wrap text-break bg-dark text-white">
             ${quote}
             <div class="message-content">${data.content}</div>
             <div class="text-end text-white small mt-1">${data.created_at}</div>

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -24,7 +24,7 @@
                     {{ conv.club.name|first|upper }}
                   </div>
                 {% endif %}
-                <div class="flex-grow-1">
+                <div class="col-md-10">
                   <div class="fw-bold">
                     {% if user == conv.club.owner %}
                       {{ conv.user.username }}
@@ -32,8 +32,8 @@
                       {{ conv.club.name }}
                     {% endif %}
                   </div>
-                  <div class="{% if conv.club == club and conv.user == conversant %}text-white small{% else %}text-muted small{% endif %}">
-                    {{ conv.content|truncatechars:40 }}
+                  <div class="{% if conv.club == club and conv.user == conversant %}text-white small{% else %}text-muted small{% endif %} text-truncate">
+                    {{ conv.content }}
                   </div>
                 </div>
                 <small class="{% if conv.club == club and conv.user == conversant %}text-white{% else %}text-muted{% endif %} ms-3">
@@ -54,7 +54,7 @@
                     {{ conv.club.name|first|upper }}
                   </div>
                 {% endif %}
-                <div class="flex-grow-1">
+                <div class="col-md-10">
                   <div class="fw-bold">
                     {% if user == conv.club.owner %}
                       {{ conv.user.username }}
@@ -62,8 +62,8 @@
                       {{ conv.club.name }}
                     {% endif %}
                   </div>
-                  <div class="{% if conv.club == club %}text-white small{% else %}text-muted small{% endif %}">
-                    {{ conv.content|truncatechars:40 }}
+                  <div class="{% if conv.club == club %}text-white small{% else %}text-muted small{% endif %} text-truncate">
+                    {{ conv.content }}
                   </div>
                 </div>
                 <small class="{% if conv.club == club %}text-white{% else %}text-muted{% endif %} ms-3">
@@ -113,7 +113,7 @@
                     </button>
                   </div>
                 {% endif %}
-                <div class="rounded message-bubble {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}border{% endif %}">
+                <div class="rounded message-bubble col-md-5 text-wrap text-break {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}border{% endif %}">
                   {% if m.reply_to %}
                     <div class="message-reply bg-secondary rounded  text-white mb-2">{{ m.reply_to.content }}</div>
                   {% endif %}


### PR DESCRIPTION
## Summary
- Limit conversation bubbles to 5 columns and wrap long text
- Truncate conversation previews with ellipsis and allocate 10 columns

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689e19052dc883219794d24ea5d567b4