### PR TITLE
Refine reply preview and button behavior

### DIFF
--- a/static/css/conversation.css
+++ b/static/css/conversation.css
@@ -60,6 +60,11 @@
   white-space: pre-wrap;
 }
 
+#reply-content {
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
 .message-bubble {
   padding:10px 15px 10px 15px;
   word-wrap: break-word;

--- a/static/js/message-submit.js
+++ b/static/js/message-submit.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
   const textarea = form.querySelector('textarea');
   const replyPreview = document.getElementById('reply-preview');
-  const replyText = document.getElementById('reply-text');
+  const replyText = document.getElementById('reply-content');
   const replyClose = document.getElementById('reply-close');
   const replyInput = form.querySelector('[name="reply_to"]');
 
@@ -23,7 +23,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const attachReplyHandler = (btn) => {
     btn.addEventListener('click', () => {
       const row = btn.closest('.message-row');
-      const text = row?.querySelector('.message-content')?.textContent.trim();
+      const contentElem = row?.querySelector('.message-content');
+      let text = '';
+      if (contentElem) {
+        const span = contentElem.querySelector('span');
+        text = span ? span.textContent.trim() : contentElem.textContent.trim();
+      }
       const id = row?.dataset.id;
       if (text) {
         if (replyText) replyText.textContent = text;
@@ -85,7 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const actions = `
           <div class="message-actions ${data.sender_is_club ? 'me-1' : 'ms-1'}">
             <button class="btn p-0 reply-btn">
-              <i class="bi bi-reply" ${data.sender_is_club ? 'style="transform:scaleX(-1);"' : ''}></i>
+              <i class="bi bi-reply" style="transform:scaleX(-1);"></i>
             </button>
             <button class="btn p-0 message-like" data-url="${data.like_url}">
               <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -105,7 +105,7 @@
                 {% if m.sender_is_club %}
                   <div class="message-actions me-1">
                     <button class="btn p-0 reply-btn">
-                      <i class="bi bi-reply" style="transform:scaleX(-1);"></i>
+                      <i class="bi bi-reply"{% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %} style="transform:scaleX(-1);"{% endif %}></i>
                     </button>
                     <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
                       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
@@ -131,7 +131,7 @@
                 {% if not m.sender_is_club %}
                   <div class="message-actions ms-1">
                     <button class="btn p-0 reply-btn">
-                      <i class="bi bi-reply"></i>
+                      <i class="bi bi-reply"{% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %} style="transform:scaleX(-1);"{% endif %}></i>
                     </button>
                     <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
                       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
@@ -146,8 +146,10 @@
             {% endfor %}
           </div>
           <div id="reply-preview" class="border-top py-2 px-3 d-none d-flex align-items-center">
-            <div id="reply-text" class="bg-light p-2 rounded flex-grow-1"></div>
-            <button type="button" id="reply-close" class="btn-close ms-2"></button>
+            <div id="reply-text" class="bg-light p-2 rounded flex-grow-1 d-flex align-items-start">
+              <span id="reply-content" class="flex-grow-1 text-break"></span>
+              <button type="button" id="reply-close" class="btn-close ms-2"></button>
+            </div>
           </div>
           <form method="post" id="message-form" class="m-4 ">
             {% csrf_token %}


### PR DESCRIPTION
## Summary
- Hide message timestamps in reply preview and break long texts
- Flip reply icons for sent messages and move close button inside preview

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e218c79588321b6cac38895a3553d