### PR TITLE
fix: limit mensajes layout and show reply user

### DIFF
--- a/apps/clubs/views/messages.py
+++ b/apps/clubs/views/messages.py
@@ -88,7 +88,15 @@ def conversation(request):
                     'created_at': message_timestamp(msg.created_at),
                     'sender_is_club': msg.sender_is_club,
                     'like_url': reverse('message_like', args=[msg.pk]),
-                    'reply_to': msg.reply_to.content if msg.reply_to else None,
+                    'sender': msg.club.name if msg.sender_is_club else msg.user.username,
+                    'reply_to': (
+                        {
+                            'content': msg.reply_to.content,
+                            'sender': msg.reply_to.club.name if msg.reply_to.sender_is_club else msg.reply_to.user.username,
+                        }
+                        if msg.reply_to
+                        else None
+                    ),
                 }
                 return JsonResponse(data)
             url = reverse('conversation') + f'?club={club.slug}'

--- a/static/css/conversation.css
+++ b/static/css/conversation.css
@@ -40,7 +40,7 @@
 }
 
 .conversation-container {
-  height: 100vh;
+  height: 100%;
 }
 
 

--- a/static/js/message-submit.js
+++ b/static/js/message-submit.js
@@ -7,12 +7,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const textarea = form.querySelector('textarea');
   const replyPreview = document.getElementById('reply-preview');
   const replyText = document.getElementById('reply-content');
+  const replyUsername = document.getElementById('reply-username');
   const replyClose = document.getElementById('reply-close');
   const replyInput = form.querySelector('[name="reply_to"]');
 
   const clearReplyPreview = () => {
     replyPreview?.classList.add('d-none');
     if (replyText) replyText.textContent = '';
+    if (replyUsername) replyUsername.textContent = '';
     if (replyInput) replyInput.value = '';
   };
   replyClose?.addEventListener('click', () => {
@@ -30,8 +32,10 @@ document.addEventListener('DOMContentLoaded', () => {
         text = span ? span.textContent.trim() : contentElem.textContent.trim();
       }
       const id = row?.dataset.id;
+      const sender = row?.dataset.sender || '';
       if (text) {
         if (replyText) replyText.textContent = text;
+        if (replyUsername) replyUsername.textContent = sender;
         if (replyInput) replyInput.value = id || '';
         replyPreview?.classList.remove('d-none');
         textarea?.focus();
@@ -80,7 +84,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const row = document.createElement('div');
         row.className = 'd-flex justify-content-end mb-2 message-row';
         row.dataset.id = data.id;
-        const quote = data.reply_to ? `<div class="bg-light p-1 rounded mb-1 text-dark">${data.reply_to}</div>` : '';
+        row.dataset.sender = data.sender;
+        const quote = data.reply_to ? `<div class="bg-light p-1 rounded mb-1 text-dark"><div class="fw-medium">${data.reply_to.sender}</div>${data.reply_to.content}</div>` : '';
         const bubble = `
           <div class="p-1 rounded message-bubble col-md-5 text-wrap text-break bg-dark text-white">
             ${quote}

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
 {% load static %}
 {% load utils_filters %}
-{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
+{% block body_class %}d-flex flex-column vh-100 overflow-hidden{% endblock %}
 {% block content %}
-<main class="flex-grow-1" >
-  <div class="container my-4 h-100 conversation-container">
+<main class="flex-grow-1">
+  <div class="container h-100 py-4 conversation-container">
     <div class="row  h-100 border" >
       <div class="col-md-4 p-0">
         <h5 class="border-bottom fw-medium p-3 ">Conversaciones recientes </h5>
@@ -96,12 +96,12 @@
               <span class="fw-bold">{{ club.name }}</span>
             {% endif %}
           </div>
-          <div class="mb-3 flex-grow-1 p-3 " id="message-container" style="max-height:60vh; overflow-y:auto;">
+          <div class="mb-3 flex-grow-1 p-3" id="message-container" style="overflow-y:auto;">
             {% for m in messages %}
               {% ifchanged m.created_at|date:"Y-m-d" %}
                 <div class="text-center text-muted small my-2">{{ m.created_at|message_day }}</div>
               {% endifchanged %}
-              <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row" data-id="{{ m.id }}">
+              <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row" data-id="{{ m.id }}" data-sender="{% if m.sender_is_club %}{{ m.club.name }}{% else %}{{ m.user.username }}{% endif %}">
                 {% if m.sender_is_club %}
                   <div class="message-actions me-1">
                  <button class="btn p-0 reply-btn">
@@ -132,7 +132,16 @@
                 {% endif %}
                 <div class="rounded message-bubble text-wrap text-break {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}border{% endif %}">
                   {% if m.reply_to %}
-                    <div class="message-reply bg-secondary rounded  text-white mb-2">{{ m.reply_to.content }}</div>
+                  <div class="message-reply bg-secondary rounded text-white mb-2">
+                    <div class="fw-medium">
+                      {% if m.reply_to.sender_is_club %}
+                        {{ m.reply_to.club.name }}
+                      {% else %}
+                        {{ m.reply_to.user.username }}
+                      {% endif %}
+                    </div>
+                    {{ m.reply_to.content }}
+                  </div>
                   {% endif %}
                   <div class="message-content d-flex justify-content-between align-items-center">
                   <span >{{ m.content }}</span>
@@ -177,12 +186,13 @@
               <p>No hay mensajes.</p>
             {% endfor %}
           </div>
-          <div id="reply-preview" class="border-top py-2 px-3 d-none d-flex align-items-center">
-            <div id="reply-text" class="bg-light p-2 rounded flex-grow-1 d-flex align-items-start">
-              <span id="reply-content" class="flex-grow-1 text-break"></span>
+            <div id="reply-preview" class="border-top py-2 px-3 d-none d-flex align-items-center">
+              <div id="reply-text" class="bg-light p-2 rounded flex-grow-1 d-flex flex-column">
+                <span id="reply-username" class="fw-medium"></span>
+                <span id="reply-content" class="flex-grow-1 text-break"></span>
+              </div>
               <button type="button" id="reply-close" class="btn-close ms-2"></button>
             </div>
-          </div>
           <form method="post" id="message-form" class="m-4 ">
             {% csrf_token %}
             {{ form.content }}


### PR DESCRIPTION
## Summary
- prevent page scroll on `/mensajes` with full-height layout and chat-only scrolling
- show username above quoted message when replying

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e66b5aa708321a346eb1772bd2b85