### PR TITLE
Fix conversation page height and scrolling

### DIFF
--- a/static/css/conversation.css
+++ b/static/css/conversation.css
@@ -68,3 +68,8 @@
   overflow-wrap: anywhere;
   max-width:50%;
 }
+
+.conversation-container {
+  height: 100%;
+  overflow: hidden;
+}

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 {% load utils_filters %}
-{% block body_class %}d-flex flex-column   {% endblock %}
+{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
 {% block content %}
 <main class="flex-grow-1">
   <div class="container h-100 py-4 conversation-container">


### PR DESCRIPTION
## Summary
- Ensure the messages page body spans the full viewport height
- Restrict overflow to the conversation pane so only messages scroll

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e6c8f424c832182f3ad3d71a5351b