### PR TITLE
feat: pantalla completa para mensajes

### DIFF
--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -3,12 +3,12 @@
 {% load utils_filters %}
 {% block body_class %}d-flex flex-column min-vh-100{% endblock %}
 {% block content %}
-<main class="flex-grow-1">
-  <div class="container h-100 py-4 conversation-container">
-    <div class="row  h-100 border" >
-      <div class="col-md-4 p-0">
+<main class="flex-grow-1 overflow-hidden">
+  <div class="container-fluid h-100 p-0 conversation-container">
+    <div class="row h-100 border">
+      <div class="col-md-4 p-0 h-100 d-flex flex-column">
         <h5 class="border-bottom fw-medium p-3 ">Conversaciones recientes </h5>
-        <div class="list-group ">
+        <div class="list-group flex-grow-1 overflow-auto">
           {% for conv in conversations %}
             {% if user == conv.club.owner %}
               <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}"
@@ -193,7 +193,7 @@
               </div>
               <button type="button" id="reply-close" class="btn-close ms-2"></button>
             </div>
-          <form method="post" id="message-form" class="m-4 ">
+          <form method="post" id="message-form" class="p-3">
             {% csrf_token %}
             {{ form.content }}
             {{ form.reply_to }}


### PR DESCRIPTION
## Summary
- adaptar conversación para ocupar toda la pantalla sin scroll
- ajustar formulario de envío de mensajes con padding interno

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e733be4d8832195c44f86ba98f818