### PR TITLE
Add animated in-message like indicator

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -181,6 +181,11 @@
 }
 
 /* Message likes */
+
+.message-bubble {
+  position: relative;
+}
+
 .message-like.liked svg path {
   fill: #e63946;
   stroke: #e63946;
@@ -188,6 +193,40 @@
 
 .message-like svg path {
   stroke: #000;
+}
+
+.message-like.inside {
+  position: absolute;
+  bottom: -8px;
+  left: -8px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: var(--bs-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.message-like.inside svg {
+  width: 16px;
+  height: 16px;
+}
+
+.message-like.inside.animating {
+  animation: like-pop 0.3s ease;
+}
+
+@keyframes like-pop {
+  0% {
+    transform: scale(0.2);
+  }
+  50% {
+    transform: scale(1.3);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 input::placeholder,

--- a/static/js/message-like.js
+++ b/static/js/message-like.js
@@ -1,8 +1,27 @@
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.message-like').forEach(btn => {
+  const attachMessageLike = (btn) => {
+    const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
+    btn._originalParent = btn.parentElement;
+    btn._bubble = btn.closest('.message-row')?.querySelector('.message-bubble');
+
+    const moveInside = () => {
+      if (!btn._bubble) return;
+      btn._bubble.appendChild(btn);
+      btn.classList.add('inside', 'animating');
+      btn.addEventListener('animationend', () => btn.classList.remove('animating'), { once: true });
+    };
+
+    const moveOutside = () => {
+      btn._originalParent?.appendChild(btn);
+      btn.classList.remove('inside');
+    };
+
+    if (btn.classList.contains('liked')) {
+      moveInside();
+    }
+
     btn.addEventListener('click', async () => {
       const url = btn.dataset.url;
-      const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
       const countSpan = btn.querySelector('.like-count');
 
       btn.classList.toggle('liked');
@@ -25,6 +44,11 @@ document.addEventListener('DOMContentLoaded', () => {
         if (res.ok) {
           const data = await res.json();
           btn.classList.toggle('liked', data.liked);
+          if (data.liked) {
+            moveInside();
+          } else {
+            moveOutside();
+          }
           if (countSpan) countSpan.textContent = data.count;
         } else {
           btn.classList.toggle('liked');
@@ -34,5 +58,8 @@ document.addEventListener('DOMContentLoaded', () => {
         btn.classList.toggle('liked');
       }
     });
-  });
+  };
+
+  document.querySelectorAll('.message-like').forEach(attachMessageLike);
+  window.attachMessageLike = attachMessageLike;
 });

--- a/static/js/message-submit.js
+++ b/static/js/message-submit.js
@@ -109,38 +109,8 @@ document.addEventListener('DOMContentLoaded', () => {
       scrollToBottom();
 
       const likeBtn = row.querySelector('.message-like');
-      if (likeBtn) {
-        likeBtn.addEventListener('click', async () => {
-          const url = likeBtn.dataset.url;
-          const countSpan = likeBtn.querySelector('.like-count');
-          likeBtn.classList.toggle('liked');
-          try {
-            const res = await fetch(url, {
-              method: 'POST',
-              headers: {
-                'X-CSRFToken': csrftoken,
-                'X-Requested-With': 'XMLHttpRequest'
-              },
-              credentials: 'same-origin'
-            });
-            if (res.redirected) {
-              const modal = document.getElementById('loginModal');
-              if (modal) new bootstrap.Modal(modal).show();
-              likeBtn.classList.toggle('liked');
-              return;
-            }
-            if (res.ok) {
-              const data = await res.json();
-              likeBtn.classList.toggle('liked', data.liked);
-              if (countSpan) countSpan.textContent = data.count;
-            } else {
-              likeBtn.classList.toggle('liked');
-            }
-          } catch (err) {
-            console.error(err);
-            likeBtn.classList.toggle('liked');
-          }
-        });
+      if (likeBtn && window.attachMessageLike) {
+        window.attachMessageLike(likeBtn);
       }
 
       const replyBtn = row.querySelector('.reply-btn');


### PR DESCRIPTION
## Summary
- Move liked heart icons to message bubble bottom-left with animation
- Provide shared like handler to position heart inside bubbles
- Enable dynamic messages to use new animated like behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e9ebe71688321ae8356f994ac9bd2