### PR TITLE
Unify messaging UX for owners and users

### DIFF
--- a/static/js/message-submit.js
+++ b/static/js/message-submit.js
@@ -93,7 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
             <div class="text-end text-white small mt-1">${data.created_at}</div>
           </div>`;
         const actions = `
-          <div class="message-actions ${data.sender_is_club ? 'me-1' : 'ms-1'}">
+          <div class="message-actions ms-1">
             <button class="btn p-0 reply-btn">
               <i class="bi bi-reply" style="transform:scaleX(-1);"></i>
             </button>
@@ -103,7 +103,7 @@ document.addEventListener('DOMContentLoaded', () => {
               </svg>
             </button>
           </div>`;
-        row.innerHTML = data.sender_is_club ? actions + bubble : bubble + actions;
+        row.innerHTML = bubble + actions;
 
       container.appendChild(row);
       scrollToBottom();

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -10,68 +10,35 @@
         <h5 class="border-bottom fw-medium p-3 mb-0" >Conversaciones recientes </h5>
         <div class="list-group rounded-0 flex-grow-1 overflow-auto ">
           {% for conv in conversations %}
-            {% if user == conv.club.owner %}
-              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}&user={{ conv.user.id }}"
-                 class="p-3 list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club and conv.user == conversant %} bg-dark text-white{% endif %}">
-                {% if conv.club.logo %}
-                  <img src="{{ conv.club.logo.url }}"
-                       class="rounded-circle me-3{% if conv.club == club and conv.user == conversant %} bg-white p-1{% endif %}"
-                       style="min-width:40px;min-height:40px;object-fit:cover;"
-                       alt="{{ conv.club.name }}">
-                {% else %}
-                  <div class="rounded-circle d-flex align-items-center justify-content-center me-3 {% if conv.club == club and conv.user == conversant %}bg-white text-dark{% else %}bg-dark text-white{% endif %}"
-                       style="min-width:40px;min-height:40px;">
-                    {{ conv.club.name|first|upper }}
-                  </div>
-                {% endif %}
-                <div class="col-md-10">
-                  <div class="fw-bold">
-                    {% if user == conv.club.owner %}
-                      {{ conv.user.username }}
-                    {% else %}
-                      {{ conv.club.name }}
-                    {% endif %}
-                  </div>
-                  <div class="col-md-7 {% if conv.club == club and conv.user == conversant %}text-white small{% else %}text-muted small{% endif %} text-truncate">
-                    {{ conv.content }}
-                  </div>
-                  <small style="font-size:12px;" class="me-4 position-absolute end-0 top-50 translate-middle-y text-nowrap ms-2{% if conv.club == club and conv.user == conversant %} text-white{% else %} text-muted{% endif %}">
-                    {{ conv.created_at|time_since_short }}
-                  </small>
+            <a href="{% url 'conversation' %}?club={{ conv.club.slug }}{% if user == conv.club.owner %}&user={{ conv.user.id }}{% endif %}"
+               class="p-3 list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club and (user != conv.club.owner or conv.user == conversant) %} bg-dark text-white{% endif %}">
+              {% if conv.club.logo %}
+                <img src="{{ conv.club.logo.url }}"
+                     class="rounded-circle me-3{% if conv.club == club and (user != conv.club.owner or conv.user == conversant) %} bg-white p-1{% endif %}"
+                     style="min-width:40px;min-height:40px;object-fit:cover;"
+                     alt="{{ conv.club.name }}">
+              {% else %}
+                <div class="rounded-circle d-flex align-items-center justify-content-center me-3 {% if conv.club == club and (user != conv.club.owner or conv.user == conversant) %}bg-white text-dark{% else %}bg-dark text-white{% endif %}"
+                     style="min-width:40px;min-height:40px;">
+                  {{ conv.club.name|first|upper }}
                 </div>
-
-              </a>
-            {% else %}
-              <a href="{% url 'conversation' %}?club={{ conv.club.slug }}"
-                 class="list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club %} bg-dark text-white{% endif %}">
-                {% if conv.club.logo %}
-                  <img src="{{ conv.club.logo.url }}"
-                       class="rounded-circle me-3{% if conv.club == club %} bg-white p-1{% endif %}"
-                       style="min-width:40px;min-height:40px;object-fit:cover;"
-                       alt="{{ conv.club.name }}">
-                {% else %}
-                  <div class="rounded-circle d-flex align-items-center justify-content-center me-3 {% if conv.club == club %}bg-white text-dark{% else %}bg-dark text-white{% endif %}"
-                       style="min-width:40px;min-height:40px;">
-                    {{ conv.club.name|first|upper }}
-                  </div>
-                {% endif %}
-                <div class="col-md-10">
-                  <div class="fw-bold">
-                    {% if user == conv.club.owner %}
-                      {{ conv.user.username }}
-                    {% else %}
-                      {{ conv.club.name }}
-                    {% endif %}
-                  </div>
-                  <div class="{% if conv.club == club %}text-white small{% else %}text-muted small{% endif %} text-truncate">
-                    {{ conv.content }}
-                  </div>
+              {% endif %}
+              <div class="col-md-10 position-relative">
+                <div class="fw-bold">
+                  {% if user == conv.club.owner %}
+                    {{ conv.user.username }}
+                  {% else %}
+                    {{ conv.club.name }}
+                  {% endif %}
                 </div>
-                <small class="{% if conv.club == club %}text-white{% else %}text-muted{% endif %} small ms-3">
+                <div class="col-md-7 {% if conv.club == club and (user != conv.club.owner or conv.user == conversant) %}text-white small{% else %}text-muted small{% endif %} text-truncate">
+                  {{ conv.content }}
+                </div>
+                <small style="font-size:12px;" class="position-absolute end-0 top-50 translate-middle-y text-nowrap ms-2{% if conv.club == club and (user != conv.club.owner or conv.user == conversant) %} text-white{% else %} text-muted{% endif %}">
                   {{ conv.created_at|time_since_short }}
                 </small>
-              </a>
-            {% endif %}
+              </div>
+            </a>
           {% empty %}
             <p>No hay mensajes.</p>
           {% endfor %}
@@ -102,34 +69,6 @@
                 <div class="text-center text-muted small my-2">{{ m.created_at|message_day }}</div>
               {% endifchanged %}
               <div class="d-flex {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}justify-content-end{% else %}justify-content-start{% endif %} mb-2 message-row" data-id="{{ m.id }}" data-sender="{% if m.sender_is_club %}{{ m.club.name }}{% else %}{{ m.user.username }}{% endif %}">
-                {% if m.sender_is_club %}
-                  <div class="message-actions me-1">
-                 <button class="btn p-0 reply-btn">
-                        <svg class="w-6 h-6  "
-                            aria-hidden="true"
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="18"
-                            height="18"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}
-                            style="transform:scaleX(-1);"
-                            {% endif %}>
-                          <path stroke="currentColor"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                d="M14.5 8.046H11V6.119c0-.921-.9-1.446-1.524-.894l-5.108 4.49a1.2 1.2 0 0 0 0 1.739l5.108 4.49c.624.556 1.524.027 1.524-.893v-1.928h2a3.023 3.023 0 0 1 3 3.046V19a5.593 5.593 0 0 0-1.5-10.954Z"/>
-                        </svg>
-                      </button>
-
-                    <button class="btn p-0 message-like {% if user.is_authenticated and user in m.likes.all %}liked{% endif %}" data-url="{% url 'message_like' m.pk %}">
-                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24">
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
-                      </svg>
-                    </button>
-                  </div>
-                {% endif %}
                 <div class="rounded message-bubble text-wrap text-break {% if user == club.owner and m.sender_is_club or user != club.owner and not m.sender_is_club %}bg-dark text-white{% else %}border{% endif %}">
                   {% if m.reply_to %}
                   <div class="message-reply rounded text-white mb-2">
@@ -153,9 +92,8 @@
 
 
                 </div>
-                {% if not m.sender_is_club %}
-                  <div class="message-actions ms-1">
-                   <button class="btn p-0 reply-btn">
+                <div class="message-actions ms-1">
+                 <button class="btn p-0 reply-btn">
                       <svg class="w-6 h-6  "
                           aria-hidden="true"
                           xmlns="http://www.w3.org/2000/svg"
@@ -180,7 +118,6 @@
                       </svg>
                     </button>
                   </div>
-                {% endif %}
               </div>
             {% empty %}
               <p>No hay mensajes.</p>


### PR DESCRIPTION
## Summary
- Standardize conversation list markup so owners and members see the same layout
- Show reply and like controls to the right of every message bubble
- Update dynamic message script to render actions consistently

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f5ca22eb4832196e5431bb80a5ef0