### PR TITLE
feat: add chat reload progress bar

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -168,6 +168,17 @@ p {
     visibility: hidden;
 }
 
+#chat-progress-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 3px;
+    width: 0;
+    background-color: #333;
+    z-index: 2001;
+    transition: width 0.4s ease, opacity 0.3s ease;
+}
+
 /* Animación de shake y borde rojo */
 .form-error {
     animation: shake 0.3s;

--- a/static/js/chat-progress.js
+++ b/static/js/chat-progress.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const bar = document.getElementById('chat-progress-bar');
+    if (!bar) return;
+    requestAnimationFrame(() => {
+        bar.style.width = '100%';
+    });
+    bar.addEventListener('transitionend', () => {
+        bar.style.opacity = '0';
+    });
+});
+
+window.addEventListener('beforeunload', function () {
+    const bar = document.getElementById('chat-progress-bar');
+    if (!bar) return;
+    bar.style.opacity = '1';
+    bar.style.width = '0';
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,10 @@
         <div class="spinner-border" role="status"></div>
     </div>
 
+    {% if request.path == '/mensajes/' %}
+    <div id="chat-progress-bar"></div>
+    {% endif %}
+
     {% include 'partials/_header.html' %}
     {% if request.path != '/mensajes/' %}
     {% include 'partials/_messages.html' %}

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -171,6 +171,7 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="{% static 'js/chat-progress.js' %}"></script>
 <script src="{% static 'js/message-like.js' %}"></script>
 <script src="{% static 'js/message-submit.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show slim progress bar on mensajes page reload
- style progress bar and animate with JavaScript

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f68a4918083218065e96b52b12637