### PR TITLE
Refine messaging list badges and verification icons

### DIFF
--- a/static/css/club_profile.css
+++ b/static/css/club_profile.css
@@ -46,9 +46,15 @@
        display: inline-flex;
        align-items: center;
        justify-content: center;
-       position: relative;
-       top: 3px;
- }
+       vertical-align: middle;
+       line-height: 1;
+       margin-left: 0.25rem;
+}
+
+.badge-verified svg {
+       width: 16px;
+       height: 16px;
+}
 
 
  /* List groups */

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -24,7 +24,7 @@
                 </div>
               {% endif %}
               <div class="flex-grow-1 position-relative">
-                <div class="fw-bold d-flex align-items-center">
+                <div class="fw-bold d-flex align-items-center flex-wrap">
                   {% if user == conv.club.owner %}
                     {{ conv.user.username }}
                   {% else %}
@@ -46,7 +46,7 @@
                 </small>
               </div>
               {% if user != conv.club.owner %}
-                <span class="badge ms-2">{{ conv.club.get_category_display }}</span>
+                <span class="badge ms-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %} bg-white text-dark{% else %} bg-secondary text-white{% endif %}">{{ conv.club.get_category_display }}</span>
               {% endif %}
             </a>
           {% empty %}

--- a/templates/clubs/message_inbox.html
+++ b/templates/clubs/message_inbox.html
@@ -15,7 +15,7 @@
           </div>
         {% endif %}
         <div class="flex-grow-1">
-          <div class="fw-bold d-flex align-items-center">
+          <div class="fw-bold d-flex align-items-center flex-wrap">
             {% if user == m.club.owner %}
               {{ m.user.username }} - {{ m.club.name }}
             {% else %}

--- a/templates/partials/_verified-bronze.html
+++ b/templates/partials/_verified-bronze.html
@@ -1,6 +1,6 @@
 
                             <span class="badge-verified badge-verified-bronze" title="Verificado">
-   <svg class="w-6 h-6 text-gray-800 dark:text-white" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+   <svg class="text-gray-800 dark:text-white" width="16" height="16" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
      <defs>
        <!-- Gradiente bronce -->
        <linearGradient id="bronze-base" x1="0" y1="0" x2="1" y2="1">

--- a/templates/partials/_verified-gold.html
+++ b/templates/partials/_verified-gold.html
@@ -1,6 +1,6 @@
 
 <span class="badge-verified badge-verified-gold" title="Verificado">
-<svg class="w-6 h-6 text-gray-800 dark:text-white" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<svg class="text-gray-800 dark:text-white" width="16" height="16" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 <defs>
 <!-- Gradiente dorado -->
 <linearGradient id="gold-base" x1="0" y1="0" x2="1" y2="1">

--- a/templates/partials/_verified-silver.html
+++ b/templates/partials/_verified-silver.html
@@ -1,5 +1,5 @@
 <span class="badge-verified badge-shine-silver" title="Verificado">
-<svg class="w-6 h-6 text-gray-800 dark:text-white" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<svg class="text-gray-800 dark:text-white" width="16" height="16" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 <defs>
 <!-- Gradiente plateado -->
 <linearGradient id="silver-base" x1="0" y1="0" x2="1" y2="1">


### PR DESCRIPTION
## Summary
- Make verified badges smaller and vertically centered
- Show white category badge with dark text for active conversations
- Wrap long names in message list items

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689f80f4701c8321b7100453e58fbb9f