### PR TITLE
Adjust message badge styles

### DIFF
--- a/static/css/conversation.css
+++ b/static/css/conversation.css
@@ -88,3 +88,8 @@
   height: 100%;
   overflow: hidden;
 }
+
+/* Adjust verified badge position in messages */
+.conversation-container .badge-verified {
+  top: 1px;
+}

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -46,7 +46,7 @@
                 </small>
               </div>
               {% if user != conv.club.owner %}
-                <span class="badge ms-2">{{ conv.club.get_category_display }}</span>
+                <span class="badge ms-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %} bg-white text-dark{% endif %}">{{ conv.club.get_category_display }}</span>
               {% endif %}
             </a>
           {% empty %}


### PR DESCRIPTION
## Summary
- Ensure active message category badges show a white background with black text
- Raise verified badge by 2px within message conversations

## Testing
- `pytest` *(fails: django.db.utils.OperationalError: no such table: clubs_clubchat)*

------
https://chatgpt.com/codex/tasks/task_e_689f834966c0832196e31456115e760b