### PR TITLE
Fix avatar update issues and expose profile avatar form

### DIFF
--- a/apps/core/templatetags/utils_filters.py
+++ b/apps/core/templatetags/utils_filters.py
@@ -1,4 +1,5 @@
 from django import template
+import os
 
 register = template.Library()
 
@@ -83,10 +84,20 @@ def youtube_embed(text):
 
 @register.filter
 def safe_url(file_field):
-    """Return the file URL or empty string if missing."""
+    """Return the file URL or empty string if missing.
+
+    Adds a simple cache-busting query parameter based on the file's
+    modification time so updated avatars/logos are reflected immediately
+    in the browser without requiring a hard refresh.
+    """
     try:
         if file_field:
-            return file_field.url
+            url = file_field.url
+            # Append the file's mtime to force browsers to fetch the latest version
+            if hasattr(file_field, "path") and os.path.exists(file_field.path):
+                mtime = int(os.path.getmtime(file_field.path))
+                return f"{url}?v={mtime}"
+            return url
     except (ValueError, AttributeError):
         return ""
     return ""

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static utils_filters %}
 <header
     class="navbar navbar-expand-lg bg-white {% if request.path != '/' %}border-bottom{% endif %}"
 >
@@ -36,13 +36,13 @@
                         <div class="selected d-flex align-items-center">
                             {% if user.owned_clubs.first and user.owned_clubs.first.logo %}
                             <img
-                                src="{{ user.owned_clubs.first.logo.url }}"
+                                src="{{ user.owned_clubs.first.logo|safe_url }}"
                                 alt="{{ user.username }}"
                                 class="nav-avatar-img"
                             />
                             {% elif user.profile.avatar %}
                             <img
-                                src="{{ user.profile.avatar.url }}"
+                                src="{{ user.profile.avatar|safe_url }}"
                                 alt="{{ user.username }}"
                                 class="nav-avatar-img"
                             />

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -42,6 +42,25 @@
             <form method="post" enctype="multipart/form-data" class="mt-4 profile-form">
                 {% csrf_token %}
 
+                {% if not is_owner %}
+                <h5 class="mb-3">Avatar</h5>
+                <div class="mb-5 text-center bg-dark p-3 rounded">
+                    <div class="avatar-dropzone mx-auto p-3">
+                        {{ form.avatar }}
+                        <div class="avatar-preview{% if profile.avatar|safe_url %} has-image{% endif %}"
+                            {% if profile.avatar|safe_url %}style="background-image:url('{{ profile.avatar|safe_url }}')"{% endif %}>
+                            <div class="avatar-dropzone-msg p-3">
+                                <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+                                <span>Arrastra una imagen o haz click </span>
+                            </div>
+                        </div>
+                    </div>
+                    {% if form.avatar.errors %}
+                    <div class="invalid-feedback d-block">{{ form.avatar.errors.as_text|striptags }}</div>
+                    {% endif %}
+                </div>
+                {% endif %}
+
                 <div class="row g-3">
 
                 {% if is_owner %}


### PR DESCRIPTION
## Summary
- prevent stale avatar/logo caches by appending file mtime
- show latest avatars in header using `safe_url`
- add avatar upload UI on profile page for non-owners

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f8e3b9aa88321a7a86bc658c555d9