### PR TITLE
Sync club logo with profile avatar from dashboard

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -90,7 +90,14 @@ def dashboard(request):
             exclude_required=['door', 'logo'],
         )
         if form.is_valid():
-            form.save()
+            club = form.save()
+            # If the club owner uploads a new logo, mirror it to the user's
+            # profile avatar so it is reflected in the header and other
+            # profile references immediately.
+            if 'logo' in form.changed_data and club.logo:
+                profile = request.user.profile
+                profile.avatar = club.logo
+                profile.save(update_fields=['avatar'])
             messages.success(request, 'Club actualizado correctamente.')
             return redirect('club_dashboard')
     else:


### PR DESCRIPTION
## Summary
- Update dashboard view so when a club owner uploads a new logo it is also stored as the user's avatar, ensuring header and club profile immediately show the new image

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc3b5d7248321b37b0ba2700aad9a