### PR TITLE
Prefer user avatar over club logo in header

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -91,13 +91,13 @@ def dashboard(request):
         )
         if form.is_valid():
             club = form.save()
-            # If the club owner uploads a new logo, mirror it to the user's
-            # profile avatar so it is reflected in the header and other
-            # profile references immediately.
+            # Si el propietario sube un nuevo logo y no tiene avatar de perfil,
+            # sincroniza el logo con el avatar para que aparezca en la cabecera.
             if 'logo' in form.changed_data and club.logo:
                 profile = request.user.profile
-                profile.avatar = club.logo
-                profile.save(update_fields=['avatar'])
+                if not profile.avatar:
+                    profile.avatar = club.logo
+                    profile.save(update_fields=['avatar'])
             messages.success(request, 'Club actualizado correctamente.')
             return redirect('club_dashboard')
     else:

--- a/apps/users/tests/test_profile_avatar_persistence.py
+++ b/apps/users/tests/test_profile_avatar_persistence.py
@@ -45,17 +45,27 @@ class ProfileAvatarPersistenceTests(TestCase):
     @override_settings(ALLOWED_HOSTS=["testserver"])
     def test_nav_avatar_on_owned_club_profile(self):
         """Nav avatar should use the uploaded profile image on owned club pages."""
-        club = Club.objects.create(
-            name="Club Avatar",
-            city="C",
-            address="A",
-            phone="1",
-            email="e@e.com",
-            owner=self.user,
-        )
         self.client.login(username="avataruser", password="pass")
         with tempfile.TemporaryDirectory() as tmpdir:
             with override_settings(MEDIA_ROOT=tmpdir):
+                # Create a club with a logo to ensure nav avatar prefers the
+                # user's profile avatar over the club logo.
+                img_logo = Image.new("RGB", (50, 50), "white")
+                buf_logo = io.BytesIO()
+                img_logo.save(buf_logo, format="JPEG")
+                buf_logo.seek(0)
+                logo_upload = SimpleUploadedFile("logo.jpg", buf_logo.getvalue(), content_type="image/jpeg")
+                club = Club.objects.create(
+                    name="Club Avatar",
+                    city="C",
+                    address="A",
+                    phone="1",
+                    email="e@e.com",
+                    owner=self.user,
+                    logo=logo_upload,
+                )
+
+                # Upload a profile avatar for the user.
                 img = Image.new("RGB", (50, 50), "white")
                 buf = io.BytesIO()
                 img.save(buf, format="JPEG")

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -34,15 +34,15 @@
                         id="user-dropdown"
                     >
                         <div class="selected d-flex align-items-center">
-                            {% if user.owned_clubs.first and user.owned_clubs.first.logo %}
+                            {% if user.profile.avatar %}
                             <img
-                                src="{{ user.owned_clubs.first.logo|safe_url }}"
+                                src="{{ user.profile.avatar|safe_url }}"
                                 alt="{{ user.username }}"
                                 class="nav-avatar-img"
                             />
-                            {% elif user.profile.avatar %}
+                            {% elif user.owned_clubs.first and user.owned_clubs.first.logo %}
                             <img
-                                src="{{ user.profile.avatar|safe_url }}"
+                                src="{{ user.owned_clubs.first.logo|safe_url }}"
                                 alt="{{ user.username }}"
                                 class="nav-avatar-img"
                             />


### PR DESCRIPTION
## Summary
- Show the user profile avatar in the navigation before falling back to the club logo
- Prevent club logo uploads from overwriting an existing profile avatar
- Cover avatar precedence with a regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc8fea9208321a60882b421e14395