### PR TITLE
Add cache-busting safe_url and profile avatar dropzone

### DIFF
--- a/apps/users/tests/test_profile_avatar_persistence.py
+++ b/apps/users/tests/test_profile_avatar_persistence.py
@@ -3,6 +3,7 @@ import tempfile
 from PIL import Image
 from django.contrib.auth.models import User
 from apps.clubs.models import Club
+from apps.core.templatetags.utils_filters import safe_url
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -36,10 +37,11 @@ class ProfileAvatarPersistenceTests(TestCase):
                 self.user.refresh_from_db()
                 self.assertEqual(response.status_code, 200)
                 self.assertTrue(self.user.profile.avatar.name)
-                self.assertContains(response, self.user.profile.avatar.url)
+                expected_url = safe_url(self.user.profile.avatar)
+                self.assertContains(response, expected_url)
 
                 # nav avatar in header should display the uploaded image
-                self.assertContains(response, self.user.profile.avatar.url)
+                self.assertContains(response, expected_url)
                 self.assertContains(response, 'class="nav-avatar-img"')
 
     @override_settings(ALLOWED_HOSTS=["testserver"])
@@ -75,7 +77,8 @@ class ProfileAvatarPersistenceTests(TestCase):
                 )
                 self.user.refresh_from_db()
                 response = self.client.get(reverse("club_profile", args=[club.slug]))
-                self.assertContains(response, self.user.profile.avatar.url)
+                expected_url = safe_url(self.user.profile.avatar)
+                self.assertContains(response, expected_url)
                 self.assertContains(response, 'class="nav-avatar-img"')
 
     @override_settings(ALLOWED_HOSTS=["testserver"])

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static utils_filters %}
 <header
     class="navbar navbar-expand-lg bg-white {% if request.path != '/' %}border-bottom{% endif %}"
 >
@@ -36,13 +36,13 @@
                         <div class="selected d-flex align-items-center">
                             {% if user.owned_clubs.first and user.owned_clubs.first.logo %}
                             <img
-                                src="{{ user.owned_clubs.first.logo.url }}"
+                                src="{{ user.owned_clubs.first.logo|safe_url }}"
                                 alt="{{ user.username }}"
                                 class="nav-avatar-img"
                             />
                             {% elif user.profile.avatar %}
                             <img
-                                src="{{ user.profile.avatar.url }}"
+                                src="{{ user.profile.avatar|safe_url }}"
                                 alt="{{ user.username }}"
                                 class="nav-avatar-img"
                             />

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -42,6 +42,28 @@
             <form method="post" enctype="multipart/form-data" class="mt-4 profile-form">
                 {% csrf_token %}
 
+                {% if not is_owner %}
+                <div class="mb-4 text-center">
+                    <div class="avatar-dropzone mx-auto">
+                        {{ form.avatar }}
+                        <div class="avatar-preview{% if user.profile.avatar|safe_url %} has-image{% endif %}"
+                            {% if user.profile.avatar|safe_url %}
+                                style="background-image:url('{{ user.profile.avatar|safe_url }}')"
+                            {% endif %}>
+                            <div class="avatar-dropzone-msg">
+                                <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+                                <span>Sube avatar</span>
+                            </div>
+                        </div>
+                    </div>
+                    {% if form.avatar.errors %}
+                    <div class="invalid-feedback d-block">
+                        {{ form.avatar.errors.as_text|striptags }}
+                    </div>
+                    {% endif %}
+                </div>
+                {% endif %}
+
                 <div class="row g-3">
 
                 {% if is_owner %}


### PR DESCRIPTION
## Summary
- Bust avatar and logo caches by appending file modification timestamps in `safe_url`
- Use `safe_url` for user avatars and club logos in the site header
- Add avatar upload dropzone to non-owner profile pages with preview and error display

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fd3dd6a6c83219a471d3a88ca4acf