### PR TITLE
Fix club logo dropzone and postal code field

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -321,6 +321,16 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
             raise forms.ValidationError('Selecciona al menos una característica.')
         return features
 
+    def clean_logo(self):
+        logo = self.cleaned_data.get('logo')
+        if not logo and self.instance and getattr(self.instance, 'logo', None):
+            return self.instance.logo
+        return logo
+
+    def clean_postal_code(self):
+        code = self.cleaned_data.get('postal_code', '')
+        return code.strip()
+
     def save(self, commit=True):
         instance = super().save(commit=False)
         region = self.cleaned_data.get('region')

--- a/static/js/avatar-dropzone.js
+++ b/static/js/avatar-dropzone.js
@@ -80,7 +80,9 @@ function initAvatarDropzones(root = document) {
       zone.classList.remove('dragover');
       const file = e.dataTransfer.files[0];
       if (file) {
-        input.files = e.dataTransfer.files;
+        const dt = new DataTransfer();
+        dt.items.add(file);
+        input.files = dt.files;
         showFile(file);
       }
     });


### PR DESCRIPTION
## Summary
- ensure avatar dropzone uploads dropped files correctly
- keep existing club logo and trim postal code in ClubForm

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fdba189c8832192d7e753396bf6e8