### PR TITLE
Preserve club logo when editing profile

### DIFF
--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -80,7 +80,12 @@ def dashboard(request):
 
     if request.method == 'POST':
         data = request.POST.copy()
-        for field in ['slug', 'country', 'region', 'city', 'postal_code', 'street', 'number', 'door', 'prefijo', 'phone', 'email']:
+        if 'logo' not in request.FILES:
+            data.setdefault('logo', club.logo)
+        for field in [
+            'slug', 'country', 'region', 'city', 'postal_code', 'street',
+            'number', 'door', 'prefijo', 'phone', 'email'
+        ]:
             data.setdefault(field, getattr(club, field))
         form = ClubForm(
             data,


### PR DESCRIPTION
## Summary
- Keep existing club logo when editing dashboard without uploading a new file
- Ensure ClubForm receives `request.FILES`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fe772a9248321a714303cecde7246