### PR TITLE
Usar logo sin filtrar en condicionales

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -24,7 +24,7 @@
             <!-- Columna Izquierda: Info del Club -->
             <div class="col-lg-2 ">
          <div class="position-relative bg-black club-logo d-flex align-items-center justify-content-center">
-            {% if club.logo|safe_url %}
+            {% if club.logo %}
                 <img src="{{ club.logo|safe_url }}"
                     class="w-100 h-100"
                     style="object-fit:cover;"

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -49,8 +49,8 @@
 
             {{ form.logo }}
             <div
-              class="avatar-preview{% if club.logo|safe_url %} has-image{% endif %}"
-              {% if club.logo|safe_url %}
+              class="avatar-preview{% if club.logo %} has-image{% endif %}"
+              {% if club.logo %}
               style="background-image:url('{{ club.logo|safe_url }}')"
               {% endif %}
             >


### PR DESCRIPTION
## Summary
- Evitar evaluar `club.logo` filtrado con `safe_url` en el perfil del club
- Ajustar carga de imagen del tablero del club para usar la imagen sin filtrar

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fe773ca1c83218292e84489bcc5ac