### PR TITLE
Use club profile pictures across site

### DIFF
--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -23,9 +23,9 @@
         <div class="row">
             <!-- Columna Izquierda: Info del Club -->
             <div class="col-lg-2 ">
-         <div class="position-relative bg-black club-logo d-flex align-items-center justify-content-center">
-            {% if club.logo %}
-                <img src="{{ club.logo|safe_url }}"
+        <div class="position-relative bg-black club-logo d-flex align-items-center justify-content-center">
+            {% if club.profilepic %}
+                <img src="{{ club.profilepic|safe_url }}"
                     class="w-100 h-100"
                     style="object-fit:cover;"
                     alt="{{ club.name }}">

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -373,10 +373,18 @@
       <h4>Foto de perfil</h4>
       <form method="post" action="{% url 'club_profilepic_upload' %}" enctype="multipart/form-data">
         {% csrf_token %}
-        <input type="file" name="profilepic" id="id_profilepic" class="form-control mb-3" />
-        {% if club.profilepic %}
-          <img src="{{ club.profilepic.url }}" alt="Foto de perfil" style="width:40px;height:40px;object-fit:cover;" />
-        {% endif %}
+        <div class="mb-5 text-center bg-dark p-3 rounded">
+          <div class="avatar-dropzone avatar-dropzone-square p-3">
+            <input type="file" name="profilepic" id="id_profilepic">
+            <div class="avatar-preview{% if club.profilepic|safe_url %} has-image{% endif %}"
+              {% if club.profilepic|safe_url %}style="background-image:url('{{ club.profilepic|safe_url }}')"{% endif %}>
+              <div class="avatar-dropzone-msg p-3">
+                <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+                <span>Arrastra una imagen o haz click </span>
+              </div>
+            </div>
+          </div>
+        </div>
         <button type="submit" class="btn btn-dark">Guardar</button>
       </form>
     </div>

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -35,9 +35,9 @@
                         id="user-dropdown"
                     >
                         <div class="selected d-flex align-items-center">
-                            {% if user.owned_clubs.first and user.owned_clubs.first.logo %}
+                            {% if user.owned_clubs.first and user.owned_clubs.first.profilepic %}
                             <img
-                                src="{{ user.owned_clubs.first.logo|safe_url }}"
+                                src="{{ user.owned_clubs.first.profilepic|safe_url }}"
                                 alt="{{ user.username }}"
                                 class="nav-avatar-img"
                             />


### PR DESCRIPTION
## Summary
- Show club profile picture on public club pages and in the navigation avatar
- Enable drag-and-drop upload for club profile pictures in the dashboard
- Test that nav avatar updates after uploading club profile picture

## Testing
- `python manage.py migrate`
- `pytest apps/users/tests/test_profile_avatar_persistence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a006777fb08321b67c70ff980c26eb