### PR TITLE
Integrate profile picture upload in main dashboard form

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -184,7 +184,6 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
             'category',
             'plan',
             'address',
-            'profilepic',
         )
         labels = {
             'name': 'Nombre del club',
@@ -201,6 +200,7 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
             'phone': 'Teléfono',
             'email': 'Correo electrónico',
             'features': 'Instalaciones y Equipamiento',
+            'profilepic': 'Logotipo',
         }
 
     def __init__(self, *args, require_all=False, exclude_required=None, **kwargs):
@@ -345,12 +345,6 @@ class ClubPhotoForm(UniformFieldsMixin, forms.ModelForm):
     class Meta:
         model = models.ClubPhoto
         fields = ['image']
-
-
-class ClubProfilePicForm(UniformFieldsMixin, forms.ModelForm):
-    class Meta:
-        model = models.Club
-        fields = ['profilepic']
 
 
 class HorarioForm(UniformFieldsMixin, forms.ModelForm):

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -29,7 +29,6 @@ from ..forms import (
     ClubForm,
     ClubPostForm,
     ClubPhotoForm,
-    ClubProfilePicForm,
     HorarioForm,
     CompetidorForm,
     EntrenadorForm,
@@ -83,6 +82,8 @@ def dashboard(request):
         data = request.POST.copy()
         if 'logo' not in request.FILES:
             data.setdefault('logo', club.logo)
+        if 'profilepic' not in request.FILES:
+            data.setdefault('profilepic', club.profilepic)
         for field in [
             'slug', 'country', 'region', 'city', 'postal_code', 'street',
             'number', 'door', 'prefijo', 'phone', 'email'
@@ -93,14 +94,14 @@ def dashboard(request):
             request.FILES,
             instance=club,
             require_all=True,
-            exclude_required=['door', 'logo'],
+            exclude_required=['door', 'logo', 'profilepic'],
         )
         if form.is_valid():
             form.save()
             messages.success(request, 'Club actualizado correctamente.')
             return redirect('club_dashboard')
     else:
-        form = ClubForm(instance=club, require_all=True, exclude_required=['door', 'logo'])
+        form = ClubForm(instance=club, require_all=True, exclude_required=['door', 'logo', 'profilepic'])
 
     bookmarked_ids = set(
         club.bookmarked_competidores.values_list('id', flat=True)
@@ -314,23 +315,6 @@ def photo_upload(request, slug):
         return redirect('club_dashboard')
     form = ClubPhotoForm()
     return render(request, 'clubs/photo_form.html', {'form': form, 'club': club})
-
-
-@login_required
-def profilepic_upload(request):
-    club = request.user.owned_clubs.first()
-    if not club:
-        return HttpResponseForbidden()
-    if request.method == 'POST':
-        form = ClubProfilePicForm(request.POST, request.FILES, instance=club)
-        if form.is_valid():
-            form.save()
-            messages.success(request, 'Foto de perfil actualizada correctamente.')
-        else:
-            messages.error(request, 'Error al subir la foto de perfil.')
-        return redirect('club_dashboard')
-    return HttpResponseForbidden()
-
 
 @login_required
 def photo_delete(request, pk):

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,7 +7,7 @@ from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
 from apps.clubs.views import public as club_public
 from apps.clubs.views import messages as club_messages
-from apps.clubs.views.dashboard import dashboard, profilepic_upload
+from apps.clubs.views.dashboard import dashboard
 from apps.users.views import profile as user_profile
   
 from apps.users.forms import LoginForm   
@@ -20,7 +20,6 @@ urlpatterns = [
 
     # Perfil público de clubs
     path('admin/', dashboard, name='club_dashboard'),
-    path('admin/profilepic/', profilepic_upload, name='club_profilepic_upload'),
     path('@<slug:slug>/inscribirse/', club_public.member_signup, name='club_member_signup'),
     path('@<slug:slug>/reservar/', club_public.booking_form, name='club_booking'),
     path('@<slug:slug>/', club_public.club_profile, name='club_profile'),

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -15,16 +15,16 @@
               {% if conv.club.profilepic %}
                 <img src="{{ conv.club.profilepic.url }}"
                      class="rounded-circle me-3{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %} bg-white p-1{% endif %}"
-                     style="min-width:60px;min-height:60px;object-fit:cover;"
+                     style="width:40px;height:40px;object-fit:cover;"
                      alt="{{ conv.club.name }}">
               {% elif conv.club.logo %}
                 <img src="{{ conv.club.logo.url }}"
                      class="rounded-circle me-3{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %} bg-white p-1{% endif %}"
-                     style="min-width:60px;min-height:60px;object-fit:cover;"
+                     style="width:40px;height:40px;object-fit:cover;"
                      alt="{{ conv.club.name }}">
               {% else %}
                 <div class="rounded-circle d-flex align-items-center justify-content-center me-3 {% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}bg-white text-dark{% else %}bg-dark text-white{% endif %}"
-                     style="min-width:60px;min-height:60px;">
+                     style="width:40px;height:40px;">
                   {{ conv.club.name|first|upper }}
                 </div>
               {% endif %}

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -44,24 +44,23 @@
         {% csrf_token %}
         <div class="row g-3 mt-3">
           <div class="col-lg-6">
-        <h5 class="mb-3  ">Logotipo</h5>
-        <div class="mb-5 text-center bg-dark p-3   rounded">
-           <form method="post" action="{% url 'club_profilepic_upload' %}" enctype="multipart/form-data">
-        {% csrf_token %}
-        <div class="mb-5 text-center bg-dark p-3 rounded">
-          <div class="avatar-dropzone avatar-dropzone-square p-3">
-            <input type="file" name="profilepic" id="id_profilepic">
-            <div class="avatar-preview{% if club.profilepic|safe_url %} has-image{% endif %}"
-              {% if club.profilepic|safe_url %}style="background-image:url('{{ club.profilepic|safe_url }}')"{% endif %}>
-              <div class="avatar-dropzone-msg p-3">
-                <i class="bi bi-cloud-upload mb-1 fs-4"></i>
-                <span>Arrastra una imagen o haz click </span>
+            <h5 class="mb-3">Logotipo</h5>
+            <div class="mb-5 text-center bg-dark p-3 rounded">
+              <div class="avatar-dropzone avatar-dropzone-square p-3">
+                <input type="file" name="profilepic" id="id_profilepic">
+                <div class="avatar-preview{% if club.profilepic|safe_url %} has-image{% endif %}"
+                  {% if club.profilepic|safe_url %}style="background-image:url('{{ club.profilepic|safe_url }}')"{% endif %}>
+                  <div class="avatar-dropzone-msg p-3">
+                    <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+                    <span>Arrastra una imagen o haz click </span>
+                  </div>
+                </div>
               </div>
+              {% if form.profilepic.errors %}
+              <div class="invalid-feedback d-block">{{ form.profilepic.errors.as_text|striptags }}</div>
+              {% endif %}
             </div>
           </div>
-        </div>
-        <button type="submit" class="btn btn-dark">Guardar</button>
-      </form>
         </div>
 
         <div class="row g-3">


### PR DESCRIPTION
## Summary
- Handle club profile picture with the page's main save action
- Make conversation list avatars consistently circular and 40x40px

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a00a72e8588321b815948a88f07434