### PR TITLE
Fix password field icons and alert messages

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -186,7 +186,12 @@ p {
     border-radius: 5px;
 }
 
- .form-field label {
+.form-field {
+  position: relative;
+  margin-bottom: 1.3rem;
+}
+
+.form-field label {
   font-size: 12px;
   position: absolute;
   left: 0;
@@ -198,6 +203,43 @@ p {
   color: #666;
   pointer-events: none;
   transition: transform 0.2s, font-size 0.2s, color 0.2s;
+}
+
+/* Password field icons */
+.form-field .input-wrapper {
+  position: relative;
+}
+
+.form-field .clear-btn {
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1rem;
+  display: none;
+  margin-right: 3px;
+}
+
+.form-field.with-toggle .clear-btn {
+  right: 45px;
+}
+
+.form-field .toggle-password {
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.form-field.with-toggle input {
+  padding-right: 60px;
 }
 
 .form-control, select   {
@@ -228,6 +270,8 @@ p {
 /* Estilo para checkboxes en negro y blanco */
 input[type="checkbox"] {
     accent-color: #000;
+    width: 1rem;
+    height: 1rem;
 }
 
 .button-dark-outline {

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -32,11 +32,6 @@
   display: block;
   opacity: 1;
 }
-.profile-form .form-field {
-  position: relative;
-  margin-bottom: 1.3rem;
-
-}
 
  .profile-form .form-field input:not([type="checkbox"]),
  .profile-form .form-field textarea,
@@ -128,34 +123,6 @@
   transform: translateY(-50%);
   font-size: 0.7rem;
   color: #000;
-}
-
-.profile-form .clear-btn {
-  position: absolute;
-  right:15px;
-  top: 50%;
-  transform: translateY(-50%);
-  border: none;
-  background: none;
-  cursor: pointer;
-  font-size: 1rem;
-  display: none;
-  margin-right: 3px;
-}
-
-.profile-form .with-toggle .clear-btn {
-  right: 40px;
-}
-
-.profile-form .toggle-password {
-  position: absolute;
-  right: 15px;
-  top: 50%;
-  transform: translateY(-50%);
-  border: none;
-  background: none;
-  cursor: pointer;
-  font-size: 1rem;
 }
 
 .profile-form textarea + .clear-btn {

--- a/templates/partials/_login-form.html
+++ b/templates/partials/_login-form.html
@@ -11,7 +11,7 @@
                            class="form-control"
                            id="{{ form.username.id_for_label }}"
                            placeholder=" "
-                           required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
+                           required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
                     <button type="button" class="clear-btn bi bi-x"></button>
                     <label for="{{ form.username.id_for_label }}">Nombre de usuario o correo electrónico</label>
                     {% if form.username.errors %}
@@ -23,15 +23,16 @@
 
 
                 <div class="form-field with-toggle">
-                  <button type="button" class="clear-btn bi bi-x"></button>
-                  <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
+                  <div class="input-wrapper">
+                    <button type="button" class="clear-btn bi bi-x"></button>
+                    <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
                     <input type="password"
                            name="{{ form.password.name }}"
                            class="form-control"
                            id="{{ form.password.id_for_label }}"
                            placeholder=" "
-                           required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
-
+                           required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
+                  </div>
                     <label for="{{ form.password.id_for_label }}">Contraseña</label>
                     {% if form.password.errors %}
                       <div class="invalid-feedback d-block">

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -86,14 +86,20 @@
                 </div>
 
                 <div class="row g-3">
-                    <div class="form-field col-md-6">
-                    {{ form.new_password1 }}
-                    <button type="button" class="clear-btn bi bi-x"></button>
-                    <label for="{{ form.new_password1.id_for_label }}">{{ form.new_password1.label }}</label>
+                    <div class="form-field col-md-6 with-toggle">
+                        <div class="input-wrapper">
+                            <button type="button" class="clear-btn bi bi-x"></button>
+                            <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
+                            {{ form.new_password1 }}
+                        </div>
+                        <label for="{{ form.new_password1.id_for_label }}">{{ form.new_password1.label }}</label>
                     </div>
-                    <div class="form-field col-md-6">
-                        {{ form.new_password2 }}
-                        <button type="button" class="clear-btn bi bi-x"></button>
+                    <div class="form-field col-md-6 with-toggle">
+                        <div class="input-wrapper">
+                            <button type="button" class="clear-btn bi bi-x"></button>
+                            <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
+                            {{ form.new_password2 }}
+                        </div>
                         <label for="{{ form.new_password2.id_for_label }}">{{ form.new_password2.label }}</label>
                     </div>
 
@@ -297,6 +303,7 @@
 <script src="{% static 'js/clear-input.js' %}"></script>
 <script src="{% static 'js/avatar-dropzone.js' %}"></script>
 <script src="{% static 'js/plan-cards.js' %}"></script>
+<script src="{% static 'js/toggle-password.js' %}"></script>
 {% if is_owner %}
 <script src="{% static 'js/slug-check.js' %}"></script>
 {% endif %}

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -53,7 +53,7 @@
           <!-- Username -->
 <div class="form-field slug-field always-active">
     <span class="username-prefix">@</span>
-    <input type="text" name="{{ form.username.name }}" value="{{ form.username.value|default_if_none:'' }}" class="form-control" id="{{ form.username.id_for_label }}" placeholder=" " minlength="3" required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
+    <input type="text" name="{{ form.username.name }}" value="{{ form.username.value|default_if_none:'' }}" class="form-control" id="{{ form.username.id_for_label }}" placeholder=" " minlength="3" required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
     <button type="button" class="clear-btn bi bi-x"></button>
     <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
     {% if form.username.errors %}
@@ -65,7 +65,7 @@
 
 <!-- Email -->
 <div class="form-field">
-    <input type="email" name="{{ form.email.name }}" value="{{ form.email.value|default_if_none:'' }}" class="form-control" id="{{ form.email.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
+    <input type="email" name="{{ form.email.name }}" value="{{ form.email.value|default_if_none:'' }}" class="form-control" id="{{ form.email.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
     <button type="button" class="clear-btn bi bi-x"></button>
     <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
     {% if form.email.errors %}
@@ -77,10 +77,11 @@
 
 <!-- Password1 -->
 <div class="form-field with-toggle">
-    <button type="button" class="clear-btn bi bi-x"></button>
-    <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
-    <input type="password" name="{{ form.password1.name }}" class="form-control" id="{{ form.password1.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
-
+    <div class="input-wrapper">
+        <button type="button" class="clear-btn bi bi-x"></button>
+        <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
+        <input type="password" name="{{ form.password1.name }}" class="form-control" id="{{ form.password1.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
+    </div>
     <label for="{{ form.password1.id_for_label }}">{{ form.password1.label }}</label>
     {% if form.password1.errors %}
       <div class="invalid-feedback d-block">
@@ -93,9 +94,11 @@
 
 <!-- Password2 -->
 <div class="form-field with-toggle">
-    <button type="button" class="clear-btn bi bi-x"></button>
-    <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
-    <input type="password" name="{{ form.password2.name }}" class="form-control" id="{{ form.password2.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('rellene este campo')" oninput="setCustomValidity('')">
+    <div class="input-wrapper">
+        <button type="button" class="clear-btn bi bi-x"></button>
+        <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
+        <input type="password" name="{{ form.password2.name }}" class="form-control" id="{{ form.password2.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
+    </div>
     <label for="{{ form.password2.id_for_label }}">{{ form.password2.label }}</label>
     {% if form.password2.errors %}
       <div class="invalid-feedback d-block">


### PR DESCRIPTION
## Summary
- Keep password eye icon inside inputs
- Capitalize required field alerts
- Standardize checkbox styling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a108d6a5f083218fb0d5a45f3cb99c