### PR TITLE
Improve checkbox and password field styling

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -292,3 +292,13 @@ input[type="checkbox"] {
     font-size: 16px;
 
 }
+
+/* Form check styling */
+.form-check-label {
+  color: #000;
+}
+
+.form-check-input:checked {
+  background-color: #000;
+  border-color: #000;
+}

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -111,6 +111,7 @@
   position: static;
   transform: none;
   padding: 0;
+  color: #000;
 }
 
 .profile-form .form-field input:not(:placeholder-shown) ~ label,

--- a/templates/partials/_login-form.html
+++ b/templates/partials/_login-form.html
@@ -23,16 +23,14 @@
 
 
                 <div class="form-field with-toggle">
-                  <div class="input-wrapper">
-                    <button type="button" class="clear-btn bi bi-x"></button>
-                    <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
                     <input type="password"
                            name="{{ form.password.name }}"
                            class="form-control"
                            id="{{ form.password.id_for_label }}"
                            placeholder=" "
                            required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
-                  </div>
+                    <button type="button" class="clear-btn bi bi-x"></button>
+                    <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
                     <label for="{{ form.password.id_for_label }}">Contraseña</label>
                     {% if form.password.errors %}
                       <div class="invalid-feedback d-block">

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -87,19 +87,15 @@
 
                 <div class="row g-3">
                     <div class="form-field col-md-6 with-toggle">
-                        <div class="input-wrapper">
-                            <button type="button" class="clear-btn bi bi-x"></button>
-                            <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
-                            {{ form.new_password1 }}
-                        </div>
+                        {{ form.new_password1 }}
+                        <button type="button" class="clear-btn bi bi-x"></button>
+                        <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
                         <label for="{{ form.new_password1.id_for_label }}">{{ form.new_password1.label }}</label>
                     </div>
                     <div class="form-field col-md-6 with-toggle">
-                        <div class="input-wrapper">
-                            <button type="button" class="clear-btn bi bi-x"></button>
-                            <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
-                            {{ form.new_password2 }}
-                        </div>
+                        {{ form.new_password2 }}
+                        <button type="button" class="clear-btn bi bi-x"></button>
+                        <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
                         <label for="{{ form.new_password2.id_for_label }}">{{ form.new_password2.label }}</label>
                     </div>
 

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -77,11 +77,9 @@
 
 <!-- Password1 -->
 <div class="form-field with-toggle">
-    <div class="input-wrapper">
-        <button type="button" class="clear-btn bi bi-x"></button>
-        <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
-        <input type="password" name="{{ form.password1.name }}" class="form-control" id="{{ form.password1.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
-    </div>
+    <input type="password" name="{{ form.password1.name }}" class="form-control" id="{{ form.password1.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
+    <button type="button" class="clear-btn bi bi-x"></button>
+    <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
     <label for="{{ form.password1.id_for_label }}">{{ form.password1.label }}</label>
     {% if form.password1.errors %}
       <div class="invalid-feedback d-block">
@@ -94,11 +92,9 @@
 
 <!-- Password2 -->
 <div class="form-field with-toggle">
-    <div class="input-wrapper">
-        <button type="button" class="clear-btn bi bi-x"></button>
-        <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
-        <input type="password" name="{{ form.password2.name }}" class="form-control" id="{{ form.password2.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
-    </div>
+    <input type="password" name="{{ form.password2.name }}" class="form-control" id="{{ form.password2.id_for_label }}" placeholder=" " required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
+    <button type="button" class="clear-btn bi bi-x"></button>
+    <button type="button" class="toggle-password"><i class="bi bi-eye"></i></button>
     <label for="{{ form.password2.id_for_label }}">{{ form.password2.label }}</label>
     {% if form.password2.errors %}
       <div class="invalid-feedback d-block">


### PR DESCRIPTION
## Summary
- Style checkbox labels in black and checked boxes with white tick
- Allow password field labels to float by removing inner wrappers

## Testing
- `python manage.py test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a10b5340c48321b875901b7113a173