### PR TITLE
Ensure conversation avatars are 60x60 and truncate preview text

### DIFF
--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -12,35 +12,35 @@
           {% for conv in conversations %}
             <a href="{% url 'chat' conv.chat_id %}"
                class="p-3 list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %} bg-dark text-white{% endif %}">
-              <span class="me-1">
-                    {% if conv.club.profilepic %}
-                    <img src="{{ conv.club.profilepic.url }}"
-                        class="rounded-circle me-3{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}{% endif %}"
-                        style="width:60px;height:60px;object-fit:cover;"
-                        alt="{{ conv.club.name }}">
-                  {% elif conv.club.logo %}
-                    <img src="{{ conv.club.logo.url }}"
-                        class="rounded-circle me-3{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}{% endif %}"
-                        style="width:60px;height:60px;object-fit:cover;"
-                        alt="{{ conv.club.name }}">
-                  {% else %}
-                    <div class="rounded-circle d-flex align-items-center justify-content-center me-3 {% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}bg-white text-dark{% else %}bg-dark text-white{% endif %}"
-                        style="width:60px;height:60px;">
-                      {{ conv.club.name|first|upper }}
-                    </div>
-                  {% endif %}
-              </span>
+                <span>
+                      {% if conv.club.profilepic %}
+                      <img src="{{ conv.club.profilepic.url }}"
+                          class="rounded-circle me-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}{% endif %}"
+                          style="width:60px;height:60px;object-fit:cover;"
+                          alt="{{ conv.club.name }}">
+                    {% elif conv.club.logo %}
+                      <img src="{{ conv.club.logo.url }}"
+                          class="rounded-circle me-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}{% endif %}"
+                          style="width:60px;height:60px;object-fit:cover;"
+                          alt="{{ conv.club.name }}">
+                    {% else %}
+                      <div class="rounded-circle d-flex align-items-center justify-content-center me-2 {% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}bg-white text-dark{% else %}bg-dark text-white{% endif %}"
+                          style="width:60px;height:60px;">
+                        {{ conv.club.name|first|upper }}
+                      </div>
+                    {% endif %}
+                </span>
               <div class="flex-grow-1 position-relative">
-                    <h6 class="col-md-6 mt-1 mb-1 h6 fw-bold text-center text-lg-start text-break">
+                      <h6 class="col-md-5 mt-1 mb-1 h6 fw-bold text-center text-lg-start text-break">
                     <span class="text-break fw-bold">{{ conv.club.name }}</span>
                     <span class="ms-1 align-middle">
                       {% if conv.club.plan == 'oro' %}{% include 'partials/_verified-gold.html' %}{% elif conv.club.plan == 'plata' %}{% include 'partials/_verified-silver.html' %}{% elif conv.club.plan == 'bronce' %}{% include 'partials/_verified-bronze.html' %}{% endif %}
                     </span>
                   </h6>
 
-                <div class="col-md-6 {% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}text-white small{% else %}text-muted small{% endif %} text-truncate">
-                  {{ conv.content }}...
-                </div>
+                  <div class="col-md-7 {% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}text-white small{% else %}text-muted small{% endif %} text-truncate">
+                    {{ conv.content|truncatechars:50 }}
+                  </div>
                 <small style="font-size:12px;" class="col-md-2 position-absolute end-0 top-50 translate-middle-y text-wrap ms-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %} text-white{% else %} text-muted{% endif %}">
                   {{ conv.created_at|time_since_short }}
                 </small>


### PR DESCRIPTION
## Summary
- Ensure avatars in the conversations list are 60x60 with Bootstrap spacing `me-2`
- Truncate last message previews within a `col-md-7` container for better layout

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a12ee576408321bf72b198b5a6dafe