### PR TITLE
fix: update avatar images in messages

### DIFF
--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -14,12 +14,12 @@
                class="p-3 list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %} bg-dark text-white{% endif %}">
                 <span>
                       {% if conv.club.profilepic %}
-                      <img src="{{ conv.club.profilepic.url }}"
+                      <img src="{{ conv.club.profilepic|safe_url }}"
                           class="rounded-circle me-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}{% endif %}"
                           style="width:60px;height:60px; min-width:60px; min-height:60px; object-fit:cover;"
                           alt="{{ conv.club.name }}">
                     {% elif conv.club.logo %}
-                      <img src="{{ conv.club.logo.url }}"
+                      <img src="{{ conv.club.logo|safe_url }}"
                           class="rounded-circle me-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}{% endif %}"
                           style="width:60px;height:60px; min-width:60px; min-height:60px; object-fit:cover;"
                           alt="{{ conv.club.name }}">
@@ -57,16 +57,16 @@
           <div class="border-bottom p-3 d-flex align-items-center">
             {% if user == club.owner %}
               {% if conversant.profile.avatar %}
-                <img src="{{ conversant.profile.avatar.url }}" class="rounded-circle me-2" style="width:40px;height:40px;object-fit:cover;" alt="{{ conversant.username }}">
+                <img src="{{ conversant.profile.avatar|safe_url }}" class="rounded-circle me-2" style="width:40px;height:40px;object-fit:cover;" alt="{{ conversant.username }}">
               {% else %}
                 <div class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center me-2" style="width:40px;height:40px;">{{ conversant.username|first|upper }}</div>
               {% endif %}
               <span class="fw-bold">{{ conversant.username }}</span>
             {% else %}
               {% if club.profilepic %}
-                <img src="{{ club.profilepic.url }}" class="rounded-circle me-2" style="width:40px;height:40px;object-fit:cover;" alt="{{ club.name }}">
+                <img src="{{ club.profilepic|safe_url }}" class="rounded-circle me-2" style="width:40px;height:40px;object-fit:cover;" alt="{{ club.name }}">
               {% elif club.logo %}
-                <img src="{{ club.logo.url }}" class="rounded-circle me-2" style="width:40px;height:40px;object-fit:cover;" alt="{{ club.name }}">
+                <img src="{{ club.logo|safe_url }}" class="rounded-circle me-2" style="width:40px;height:40px;object-fit:cover;" alt="{{ club.name }}">
               {% else %}
                 <div class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center me-2" style="width:40px;height:40px;">{{ club.name|first|upper }}</div>
               {% endif %}

--- a/templates/clubs/message_inbox.html
+++ b/templates/clubs/message_inbox.html
@@ -8,9 +8,9 @@
     {% for m in conversations %}
       <a href="{% url 'chat' m.chat_id %}" class="list-group-item list-group-item-action d-flex align-items-center">
           {% if m.club.profilepic %}
-            <img src="{{ m.club.profilepic.url }}" class="rounded-circle me-3" style="width:40px;height:40px;object-fit:cover;" alt="{{ m.club.name }}">
+            <img src="{{ m.club.profilepic|safe_url }}" class="rounded-circle me-3" style="width:40px;height:40px;object-fit:cover;" alt="{{ m.club.name }}">
           {% elif m.club.logo %}
-            <img src="{{ m.club.logo.url }}" class="rounded-circle me-3" style="width:40px;height:40px;object-fit:cover;" alt="{{ m.club.name }}">
+            <img src="{{ m.club.logo|safe_url }}" class="rounded-circle me-3" style="width:40px;height:40px;object-fit:cover;" alt="{{ m.club.name }}">
           {% else %}
             <div class="rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center me-3" style="width:40px;height:40px;">
               {{ m.club.name|first|upper }}


### PR DESCRIPTION
## Summary
- use cache-busting safe_url for avatar and club images in conversation and inbox templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a13a94ca308321b425fe3da9e74055