### PR TITLE
Unify dashboard profile updates

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -184,7 +184,6 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
             'category',
             'plan',
             'address',
-            'profilepic',
         )
         labels = {
             'name': 'Nombre del club',
@@ -289,6 +288,11 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
         if logo_widget:
             css = logo_widget.widget.attrs.get('class', '')
             logo_widget.widget.attrs['class'] = (css + ' d-none').strip()
+
+        profilepic_widget = self.fields.get('profilepic')
+        if profilepic_widget:
+            css = profilepic_widget.widget.attrs.get('class', '')
+            profilepic_widget.widget.attrs['class'] = (css + ' d-none').strip()
 
         if require_all:
             for name, field in self.fields.items():

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -29,7 +29,6 @@ from ..forms import (
     ClubForm,
     ClubPostForm,
     ClubPhotoForm,
-    ClubProfilePicForm,
     HorarioForm,
     CompetidorForm,
     EntrenadorForm,
@@ -83,24 +82,28 @@ def dashboard(request):
         data = request.POST.copy()
         if 'logo' not in request.FILES:
             data.setdefault('logo', club.logo)
+        if 'profilepic' not in request.FILES and not request.POST.get('profilepic-clear'):
+            data.setdefault('profilepic', club.profilepic)
         for field in [
-            'slug', 'country', 'region', 'city', 'postal_code', 'street',
-            'number', 'door', 'prefijo', 'phone', 'email'
+            'name', 'about', 'slug', 'country', 'region', 'city',
+            'postal_code', 'street', 'number', 'door', 'prefijo',
+            'phone', 'email'
         ]:
             data.setdefault(field, getattr(club, field))
+        if 'features' not in data:
+            data.setlist('features', list(club.features.values_list('id', flat=True)))
         form = ClubForm(
             data,
             request.FILES,
             instance=club,
-            require_all=True,
-            exclude_required=['door', 'logo'],
+            require_all=False,
         )
         if form.is_valid():
             form.save()
             messages.success(request, 'Club actualizado correctamente.')
             return redirect('club_dashboard')
     else:
-        form = ClubForm(instance=club, require_all=True, exclude_required=['door', 'logo'])
+        form = ClubForm(instance=club, require_all=False)
 
     bookmarked_ids = set(
         club.bookmarked_competidores.values_list('id', flat=True)
@@ -314,22 +317,6 @@ def photo_upload(request, slug):
         return redirect('club_dashboard')
     form = ClubPhotoForm()
     return render(request, 'clubs/photo_form.html', {'form': form, 'club': club})
-
-
-@login_required
-def profilepic_upload(request):
-    club = request.user.owned_clubs.first()
-    if not club:
-        return HttpResponseForbidden()
-    if request.method == 'POST':
-        form = ClubProfilePicForm(request.POST, request.FILES, instance=club)
-        if form.is_valid():
-            form.save()
-            messages.success(request, 'Foto de perfil actualizada correctamente.')
-        else:
-            messages.error(request, 'Error al subir la foto de perfil.')
-        return redirect('club_dashboard')
-    return HttpResponseForbidden()
 
 
 @login_required

--- a/apps/users/tests/test_profile_avatar_persistence.py
+++ b/apps/users/tests/test_profile_avatar_persistence.py
@@ -49,7 +49,7 @@ class ProfileAvatarPersistenceTests(TestCase):
             name="Club Avatar",
             city="C",
             address="A",
-            phone="1",
+            phone="612345678",
             email="e@e.com",
             owner=self.user,
         )
@@ -83,9 +83,16 @@ class ProfileAvatarPersistenceTests(TestCase):
         """Nav avatar should display club profilepic after upload."""
         club = Club.objects.create(
             name="Club Pic",
-            city="C",
-            address="A",
-            phone="1",
+            about="About",
+            slug="club-pic",
+            country="España",
+            region="Madrid",
+            city="Madrid",
+            street="S",
+            number="1",
+            postal_code="00000",
+            prefijo="+34",
+            phone="612345678",
             email="e@e.com",
             owner=self.user,
         )
@@ -98,7 +105,7 @@ class ProfileAvatarPersistenceTests(TestCase):
                 buf.seek(0)
                 upload = SimpleUploadedFile("clubpic.jpg", buf.getvalue(), content_type="image/jpeg")
                 response = self.client.post(
-                    reverse("club_profilepic_upload"),
+                    reverse("club_dashboard"),
                     {"profilepic": upload},
                     follow=True,
                 )

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,7 +7,7 @@ from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
 from apps.clubs.views import public as club_public
 from apps.clubs.views import messages as club_messages
-from apps.clubs.views.dashboard import dashboard, profilepic_upload
+from apps.clubs.views.dashboard import dashboard
 from apps.users.views import profile as user_profile
   
 from apps.users.forms import LoginForm   
@@ -20,7 +20,6 @@ urlpatterns = [
 
     # Perfil público de clubs
     path('admin/', dashboard, name='club_dashboard'),
-    path('admin/profilepic/', profilepic_upload, name='club_profilepic_upload'),
     path('@<slug:slug>/inscribirse/', club_public.member_signup, name='club_member_signup'),
     path('@<slug:slug>/reservar/', club_public.booking_form, name='club_booking'),
     path('@<slug:slug>/', club_public.club_profile, name='club_profile'),

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -10,7 +10,6 @@
             class="profile-tabs-select form-select  w-auto text-end">
       <option value="tab-profile">Mi Perfil</option>
       <option value="tab-gallery">Galería</option>
-      <option value="tab-profilepic">Foto de Perfil</option>
       <option value="tab-schedule">Horarios</option>
       <option value="tab-clase">Servicios</option>
       <option value="tab-bookings">Reservas</option>
@@ -46,11 +45,8 @@
           <div class="col-lg-6">
         <h5 class="mb-3  ">Logotipo</h5>
         <div class="mb-5 text-center bg-dark p-3   rounded">
-           <form method="post" action="{% url 'club_profilepic_upload' %}" enctype="multipart/form-data">
-        {% csrf_token %}
-        <div class="mb-5 text-center bg-dark p-3 rounded">
           <div class="avatar-dropzone avatar-dropzone-square p-3">
-            <input type="file" name="profilepic" id="id_profilepic">
+            {{ form.profilepic }}
             <div class="avatar-preview{% if club.profilepic|safe_url %} has-image{% endif %}"
               {% if club.profilepic|safe_url %}style="background-image:url('{{ club.profilepic|safe_url }}')"{% endif %}>
               <div class="avatar-dropzone-msg p-3">
@@ -59,9 +55,9 @@
               </div>
             </div>
           </div>
-        </div>
-        <button type="submit" class="btn btn-dark">Guardar</button>
-      </form>
+          {% if form.profilepic.errors %}
+          <div class="invalid-feedback d-block">{{ form.profilepic.errors.as_text|striptags }}</div>
+          {% endif %}
         </div>
 
         <div class="row g-3">


### PR DESCRIPTION
## Summary
- handle club profile pictures in the main dashboard form and remove old upload route
- allow clearing existing profile pictures and use a single save button
- adjust tests for new profile picture flow

## Testing
- `pytest apps/users/tests/test_profile_avatar_persistence.py::ProfileAvatarPersistenceTests::test_nav_avatar_updates_with_club_profilepic -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1400787588321811f317c301588a9