### PR TITLE
Fix conversation list avatars for club owners

### DIFF
--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -13,22 +13,36 @@
             <a href="{% url 'chat' conv.chat_id %}"
                class="p-3 list-group-item list-group-item-action d-flex align-items-center{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %} bg-dark text-white{% endif %}">
                 <span>
-                      {% if conv.club.profilepic %}
-                      <img src="{{ conv.club.profilepic|safe_url }}"
-                          class="rounded-circle me-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}{% endif %}"
-                          style="width:60px;height:60px; min-width:60px; min-height:60px; object-fit:cover;"
-                          alt="{{ conv.club.name }}">
-                    {% elif conv.club.logo %}
-                      <img src="{{ conv.club.logo|safe_url }}"
-                          class="rounded-circle me-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}{% endif %}"
-                          style="width:60px;height:60px; min-width:60px; min-height:60px; object-fit:cover;"
-                          alt="{{ conv.club.name }}">
+                  {% if user == conv.club.owner %}
+                    {% if conv.user.profile.avatar %}
+                      <img src="{{ conv.user.profile.avatar|safe_url }}"
+                           class="rounded-circle me-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}{% endif %}"
+                           style="width:60px;height:60px; min-width:60px; min-height:60px; object-fit:cover;"
+                           alt="{{ conv.user.username }}">
                     {% else %}
                       <div class="rounded-circle d-flex align-items-center justify-content-center me-2 {% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}bg-white text-dark{% else %}bg-dark text-white{% endif %}"
-                          style="width:60px;height:60px; min-width:60px; min-height:60px; ">
+                           style="width:60px;height:60px; min-width:60px; min-height:60px;">
+                        {{ conv.user.username|first|upper }}
+                      </div>
+                    {% endif %}
+                  {% else %}
+                    {% if conv.club.profilepic %}
+                      <img src="{{ conv.club.profilepic|safe_url }}"
+                           class="rounded-circle me-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}{% endif %}"
+                           style="width:60px;height:60px; min-width:60px; min-height:60px; object-fit:cover;"
+                           alt="{{ conv.club.name }}">
+                    {% elif conv.club.logo %}
+                      <img src="{{ conv.club.logo|safe_url }}"
+                           class="rounded-circle me-2{% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}{% endif %}"
+                           style="width:60px;height:60px; min-width:60px; min-height:60px; object-fit:cover;"
+                           alt="{{ conv.club.name }}">
+                    {% else %}
+                      <div class="rounded-circle d-flex align-items-center justify-content-center me-2 {% if conv.club == club and user != conv.club.owner or conv.club == club and conv.user == conversant %}bg-white text-dark{% else %}bg-dark text-white{% endif %}"
+                           style="width:60px;height:60px; min-width:60px; min-height:60px;">
                         {{ conv.club.name|first|upper }}
                       </div>
                     {% endif %}
+                  {% endif %}
                 </span>
               <div class="flex-grow-1 position-relative">
                   <div class="col-md-7 ms-2  fw-bold text-center text-lg-start text-break">


### PR DESCRIPTION
## Summary
- Show conversant user's avatar in conversation list for club owners
- Fallback to club avatar when appropriate

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a143c246bc832194b5d89ee6007fd8