### PR TITLE
Align coach profile with club profile header and actions

### DIFF
--- a/templates/clubs/coach_profile.html
+++ b/templates/clubs/coach_profile.html
@@ -9,6 +9,14 @@
             <div class="d-flex align-items-center" style="font-size:14px; font-style:italic;">
                 {% include 'partials/_breadcrumb.html' %}
             </div>
+            <div class="d-none d-lg-flex ms-auto align-items-center gap-2">
+                <button type="button" class="p-3 booking-btn fw-medium d-flex align-items-center gap-1 ms-2 btn btn-dark" data-club-slug="{{ coach.club.slug }}">
+                     <svg class="w-[48px] h-[48px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h16m-8-3V4M7 7V4m10 3V4M5 20h14a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Zm3-7h.01v.01H8V13Zm4 0h.01v.01H12V13Zm4 0h.01v.01H16V13Zm-8 4h.01v.01H8V17Zm4 0h.01v.01H12V17Zm4 0h.01v.01H16V17Z"/>
+                    </svg>
+                    Reservar clase
+                </button>
+            </div>
         </div>
         <div class="row">
             <!-- Columna Izquierda: Información del entrenador -->
@@ -43,6 +51,13 @@
                                 </span>
                             {% endif %}
                         </h3>
+
+                        <button type="button" class="p-3 booking-btn fw-medium d-flex align-items-center gap-1 btn btn-dark mt-1 mb-1 mx-auto d-lg-none" data-club-slug="{{ coach.club.slug }}">
+                            <svg class="w-[48px] h-[48px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                              <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h16m-8-3V4M7 7V4m10 3V4M5 20h14a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Zm3-7h.01v.01H8V13Zm4 0h.01v.01H12V13Zm4 0h.01v.01H16V13Zm-8 4h.01v.01H8V17Zm4 0h.01v.01H12V17Zm4 0h.01v.01H16V17Z"/>
+                            </svg>
+                          Reservar clase
+                        </button>
 
                         {% if coach.ciudad %}
                             <p class="mb-2 d-flex">
@@ -83,8 +98,56 @@
                         {% endif %}
 
                         <li class="club-actions d-flex flex-row flex-lg-column flex-wrap justify-content-center align-items-center align-items-lg-start gap-2 mb-4">
-                            <button class="fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1" id="coach-share" aria-label="Compartir">
-                                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="none" viewBox="0 0 24 24">
+
+                            <button type="button" class="signup-member-btn fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1" data-club-slug="{{ coach.club.slug }}">
+                                <svg class="w-[48px] h-[48px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="none" viewBox="0 0 24 24">
+                                  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 12h4m-2 2v-4M4 18v-1a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3v1a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1Zm8-10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
+                                </svg>
+                                Inscribirse
+                            </button>
+
+                            <button
+                                type="button"
+                                class="fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1"
+                                onclick="window.open('https://www.google.com/maps/search/?api=1&query={{ coach.club.address|urlencode }}', '_blank')"
+                            >
+
+                                <svg class="w-[100px] h-[100px] text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="none" viewBox="0 0 24 24">
+                                  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 13a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"/>
+                                  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17.8 13.938h-.011a7 7 0 1 0-11.464.144h-.016l.14.171c.1.127.2.251.3.371L12 21l5.13-6.248c.194-.209.374-.429.54-.659l.13-.155Z"/>
+                                </svg>
+                                <span class="fw-medium">Cómo llegar</span>
+                            </button>
+
+                            <button type="button"
+                                    onclick="location.href='{% url 'conversation' %}?club={{ coach.club.slug }}'"
+                                    class="fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1">
+                                <svg class="w-6 h-6 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="none" viewBox="0 0 24 24">
+                                  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 10.5h.01m-4.01 0h.01M8 10.5h.01M5 5h14a1 1 0 0 1 1 1v9a1 1 0 0 1-1 1h-6.6a1 1 0 0 0-.69.275l-2.866 2.723A.5.5 0 0 1 8 18.635V17a1 1 0 0 0-1-1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Z"/>
+                                </svg>
+                                Enviar un mensaje
+                            </button>
+                            <button id="club-heart"
+                                    aria-label="Seguir"
+                                    data-url="{% url 'toggle_follow' 'entrenador' coach.id %}"
+                                    class="fw-medium {% if coach_followed %}liked{% endif %} d-flex flex-column flex-lg-row align-items-center gap-1 mb-1">
+                                <svg aria-hidden="true"
+                                     xmlns="http://www.w3.org/2000/svg"
+                                     width="26"
+                                     height="26"
+                                     fill="none"
+                                     viewBox="0 0 24 24">
+                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12.01 6.001C6.5 1 1 8 5.782 13.001L12.011 20l6.23-7C23 8 17.5 1 12.01 6.002Z" />
+                                </svg>
+                                Añadir a favoritos
+                            </button>
+                            <button class="fw-medium d-flex flex-column flex-lg-row align-items-center gap-1 mb-1" id="club-share" aria-label="Compartir">
+                                <svg aria-hidden="true"
+                                     xmlns="http://www.w3.org/2000/svg"
+                                     width="26"
+                                     height="26"
+                                     fill="none"
+                                     viewBox="0 0 24 24">
                                     <path stroke="currentColor" stroke-linecap="round" stroke-width="1.5" d="M7.926 10.898 15 7.727m-7.074 5.39L15 16.29M8 12a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm12 5.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm0-11a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Z" />
                                 </svg>
                                 Compartir
@@ -188,6 +251,13 @@
 </main>
 
 {% include 'partials/_share_profile_modal.html' %}
+{% include 'partials/_register_modal.html' %}
+{% include 'partials/_member_signup_modal.html' %}
+{% include 'partials/_booking_modal.html' %}
+<script src="{% static 'js/share-like.js' %}"></script>
+<script src="{% static 'js/share-modal.js' %}"></script>
+<script src="{% static 'js/member-signup-modal.js' %}"></script>
+<script src="{% static 'js/booking-modal.js' %}"></script>
 <script src="{% static 'js/gallery-slideshow.js' %}"></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- replace coach profile action links with the same buttons used on club profiles
- add booking button and matching modals/scripts to coach profile page
- build breadcrumbs and follow state for coaches in view logic

## Testing
- `python manage.py test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a153c35bf08321a322517588c4d45c