### PR TITLE
Enable coach profile management from dropdown

### DIFF
--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -83,7 +83,7 @@
                             <a
                                 href="{% url 'profile' %}"
                                 class="dropdown-item text-light"
-                                >Mi Cuenta</a
+                                >Perfil</a
                             >
                             {% if user.owned_clubs.exists %}
                             <a
@@ -91,11 +91,17 @@
                                 class="dropdown-item text-light"
                                 >Panel de control</a
                             >
+                            {% elif user.coach_profile %}
+                            <a
+                                href="{% url 'entrenador_update' user.coach_profile.id %}"
+                                class="dropdown-item text-light"
+                                >Panel de control</a
+                            >
                             {% endif %}
                             <a
                                 href="{% url 'conversation' %}"
                                 class="dropdown-item text-light"
-                                >Mis mensajes</a
+                                >Mensajes</a
                             >
                             <a
                                 href="#"


### PR DESCRIPTION
## Summary
- Show Perfil link in user dropdown
- Add Panel de control link for coaches alongside club owners
- Rename messaging link to Mensajes

## Testing
- `python manage.py test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a257e8f27883218d4f865031379209