### PR TITLE
Add coach dashboard for profile editing

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -298,7 +298,7 @@ class CoachPermissionTests(TestCase):
 
     def test_coach_can_edit_own_profile(self):
         self.client.login(username='coach', password='pass')
-        url = reverse('entrenador_update', args=[self.coach.id])
+        url = reverse('coach_dashboard')
         response = self.client.post(url, {'nombre': 'Nuevo', 'apellidos': 'User'})
         self.assertRedirects(response, reverse('coach_profile', args=[self.coach.slug]))
         self.coach.refresh_from_db()
@@ -310,6 +310,11 @@ class CoachPermissionTests(TestCase):
         url = reverse('entrenador_update', args=[self.coach.id])
         response = self.client.post(url, {'nombre': 'X', 'apellidos': 'Y'})
         self.assertEqual(response.status_code, 403)
+
+    def test_nav_shows_coach_panel_link(self):
+        self.client.login(username='coach', password='pass')
+        response = self.client.get(reverse('coach_profile', args=[self.coach.slug]))
+        self.assertContains(response, reverse('coach_dashboard'))
 
 
 class UserReviewFirstTests(TestCase):

--- a/apps/clubs/views/__init__.py
+++ b/apps/clubs/views/__init__.py
@@ -4,5 +4,6 @@ from .post import post_create, post_update, post_delete, post_reply, post_toggle
 from .booking import cancel_booking, create_booking, booking_confirm, booking_cancel_admin, booking_delete
 from .dashboard import (
     dashboard,
+    coach_dashboard,
 )
 from .messages import conversation, message_toggle_like

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -526,6 +526,25 @@ def entrenador_update(request, pk):
 
 
 @login_required
+def coach_dashboard(request):
+    coach = getattr(request.user, "coach_profile", None)
+    if not coach:
+        return redirect('home')
+    if request.method == 'POST':
+        form = EntrenadorForm(request.POST, request.FILES, instance=coach)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Entrenador actualizado correctamente.')
+            return redirect('coach_profile', coach.slug)
+    else:
+        form = EntrenadorForm(instance=coach)
+    return render(request, 'clubs/coach_dashboard.html', {
+        'form': form,
+        'coach': coach,
+    })
+
+
+@login_required
 def entrenador_delete(request, pk):
     entrenador = get_object_or_404(Entrenador, pk=pk)
     if not has_club_permission(request.user, entrenador.club):

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,7 +7,7 @@ from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
 from apps.clubs.views import public as club_public
 from apps.clubs.views import messages as club_messages
-from apps.clubs.views.dashboard import dashboard
+from apps.clubs.views.dashboard import dashboard, coach_dashboard
 from apps.users.views import profile as user_profile
   
 from apps.users.forms import LoginForm   
@@ -20,6 +20,7 @@ urlpatterns = [
 
     # Perfil público de clubs
     path('admin/', dashboard, name='club_dashboard'),
+    path('coach-admin/', coach_dashboard, name='coach_dashboard'),
     path('@<slug:slug>/inscribirse/', club_public.member_signup, name='club_member_signup'),
     path('@<slug:slug>/reservar/', club_public.booking_form, name='club_booking'),
     path('@<slug:slug>/', club_public.club_profile, name='club_profile'),

--- a/templates/clubs/coach_dashboard.html
+++ b/templates/clubs/coach_dashboard.html
@@ -1,0 +1,57 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block body_class %}d-flex flex-column min-vh-100 dashboard-page{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h5">Editar perfil de entrenador</h1>
+  <form method="post" enctype="multipart/form-data" class="profile-form">
+    {% csrf_token %}
+    <div class="form-field">
+      <div class="avatar-dropzone">
+        {{ form.avatar }}
+        <div class="avatar-preview{% if coach.avatar %} has-image{% endif %}"{% if coach.avatar %} style="background-image:url('{{ coach.avatar.url }}')"{% endif %}>
+          <div class="avatar-dropzone-msg">
+            <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+            <span>Sube avatar</span>
+          </div>
+        </div>
+      </div>
+      {% if form.avatar.errors %}
+      <div class="invalid-feedback d-block">
+        {{ form.avatar.errors.as_text|striptags }}
+      </div>
+      {% endif %}
+    </div>
+    {% for field in form %}
+      {% if field.name != 'avatar' %}
+        {% if field.field.widget.input_type == 'checkbox' %}
+        <div class="form-field checkbox-field">
+          {{ field }}
+          <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+          {% if field.errors %}
+          <div class="invalid-feedback d-block">
+            {{ field.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+        {% else %}
+        <div class="form-field">
+          {{ field }}
+          <button type="button" class="clear-btn bi bi-x"></button>
+          <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+          {% if field.errors %}
+          <div class="invalid-feedback d-block">
+            {{ field.errors.as_text|striptags }}
+          </div>
+          {% endif %}
+        </div>
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+    <button type="submit" class="btn btn-dark">Guardar</button>
+  </form>
+</div>
+{% endblock %}
+{% block extra_js %}
+<script src="{% static 'js/avatar-dropzone.js' %}"></script>
+{% endblock %}

--- a/templates/partials/_header.html
+++ b/templates/partials/_header.html
@@ -93,7 +93,7 @@
                             >
                             {% elif user.coach_profile %}
                             <a
-                                href="{% url 'entrenador_update' user.coach_profile.id %}"
+                                href="{% url 'coach_dashboard' %}"
                                 class="dropdown-item text-light"
                                 >Panel de control</a
                             >


### PR DESCRIPTION
## Summary
- Add coach dashboard view and route for editing coach profiles
- Update navigation dropdown to link coaches to the new dashboard
- Provide template and tests for coach dashboard access

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a25c92f23c832183e8030ed62d69fd