### PR TITLE
Redirect coaches to their dashboard from admin

### DIFF
--- a/apps/clubs/tests.py
+++ b/apps/clubs/tests.py
@@ -316,6 +316,11 @@ class CoachPermissionTests(TestCase):
         response = self.client.get(reverse('coach_profile', args=[self.coach.slug]))
         self.assertContains(response, reverse('coach_dashboard'))
 
+    def test_coach_access_admin_redirects_to_dashboard(self):
+        self.client.login(username='coach', password='pass')
+        response = self.client.get(reverse('club_dashboard'))
+        self.assertRedirects(response, reverse('coach_dashboard'))
+
 
 class UserReviewFirstTests(TestCase):
     def setUp(self):

--- a/apps/clubs/views/dashboard.py
+++ b/apps/clubs/views/dashboard.py
@@ -76,6 +76,9 @@ def matchmaker_toggle_bookmark(request):
 def dashboard(request):
     club = request.user.owned_clubs.first()
     if not club:
+        coach = getattr(request.user, "coach_profile", None)
+        if coach:
+            return redirect('coach_dashboard')
         return redirect('home')
 
     if request.method == 'POST':


### PR DESCRIPTION
## Summary
- Redirect coaches hitting `/admin` to their dashboard
- Add regression test for coach redirection

## Testing
- `python3 manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a25f8294c08321916b00b015dc4dec