### PR TITLE
Add email preference option to registration

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -64,6 +64,12 @@ class RegistroUsuarioForm(UniformFieldsMixin, UserCreationForm):
         widget=forms.TextInput(attrs={'minlength': 3})
     )
 
+    notifications = forms.BooleanField(
+        label='Recibir actualizaciones ocasionales de productos y anuncios',
+        required=False,
+        widget=forms.CheckboxInput(attrs={'class': 'form-check-input bg-dark border-dark'})
+    )
+
     error_messages = {
         **UserCreationForm.error_messages,
         'password_mismatch': _('Las contraseñas no coinciden'),

--- a/apps/users/tests/test_user.py
+++ b/apps/users/tests/test_user.py
@@ -18,8 +18,24 @@ class RegistrationTests(TestCase):
         response = self.client.post(url, data)
 
         self.assertTrue(User.objects.filter(username="newuser").exists())
+        user = User.objects.get(username="newuser")
+        self.assertFalse(user.profile.notifications)
         # And the view should redirect to home
         self.assertRedirects(response, reverse("home"))
+
+    def test_user_can_opt_in_notifications(self):
+        data = {
+            "username": "notifyuser",
+            "email": "notify@example.com",
+            "password1": "secretpass123",
+            "password2": "secretpass123",
+            "notifications": "on",
+        }
+        url = reverse("register")
+        self.client.post(url, data)
+
+        user = User.objects.get(username="notifyuser")
+        self.assertTrue(user.profile.notifications)
 
     def test_welcome_email_sent(self):
         data = {

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -15,6 +15,10 @@ def register(request):
         form = RegistroUsuarioForm(request.POST)
         if form.is_valid():
             user = form.save()
+            # Set notification preferences based on checkbox
+            user.profile.notifications = form.cleaned_data.get("notifications")
+            user.profile.save()
+
             send_welcome_email(user.email)
             send_confirmation_email(user.email)
             # authenticate to attach backend info before login

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -103,6 +103,14 @@
     {% endif %}
 </div>
 
+<h6>Preferencias de correo electrónico</h6>
+<div class="form-check mb-3">
+    <input class="form-check-input bg-dark border-dark" type="checkbox" name="{{ form.notifications.name }}" id="{{ form.notifications.id_for_label }}" {% if form.notifications.value %}checked{% endif %}>
+    <label class="form-check-label" for="{{ form.notifications.id_for_label }}">
+        <small>Recibir actualizaciones ocasionales de productos y anuncios</small>
+    </label>
+</div>
+
             <button type="submit" class="btn btn-dark w-100">Crear cuenta</button>
         </form>
 


### PR DESCRIPTION
## Summary
- Add optional email preference checkbox on registration form
- Persist notification preference to user profile on sign up
- Test default and opt-in notification states

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a431fcb8dc832190329c4cdc6ebe7c