### PR TITLE
Add profile update confirmation modal and sync username

### DIFF
--- a/apps/users/tests/test_profile_username_update.py
+++ b/apps/users/tests/test_profile_username_update.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+
+class ProfileUsernameUpdateTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='olduser', password='pass')
+
+    def test_username_updates_on_profile_save(self):
+        self.client.login(username='olduser', password='pass')
+        url = reverse('profile')
+        response = self.client.post(url, {'username': 'newuser'})
+        self.assertRedirects(response, url)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'newuser')
+

--- a/apps/users/views/profile.py
+++ b/apps/users/views/profile.py
@@ -53,6 +53,7 @@ def profile(request):
                 profile_obj = form.save()
                 if club_form and club_valid:
                     club_form.save()
+                request.user.refresh_from_db()
                 request.user.profile.refresh_from_db()
                 messages.success(request, 'Perfil actualizado exitosamente.')
                 return redirect('profile')

--- a/static/js/profile-save-confirm.js
+++ b/static/js/profile-save-confirm.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('confirmProfileModal');
+  const form = document.querySelector('.profile-form');
+  if (!modalEl || !form) return;
+  const modal = new bootstrap.Modal(modalEl);
+  let confirmed = false;
+
+  form.addEventListener('submit', e => {
+    if (confirmed) return;
+    e.preventDefault();
+    modal.show();
+  });
+
+  modalEl.querySelector('.confirm-save').addEventListener('click', () => {
+    confirmed = true;
+    form.submit();
+  });
+});
+

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -290,9 +290,23 @@
             </form>  </div>
 
         </div>
-    </div>
+</div>
 </div>
 </main>
+<div class="modal fade" id="confirmProfileModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">¿Seguro que deseas modificar los datos de tu perfil?</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-footer d-flex flex-column gap-2">
+                <button type="button" class="btn btn-secondary w-100" data-bs-dismiss="modal">Descartar</button>
+                <button type="button" class="btn btn-dark w-100 confirm-save">Confirmar</button>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}
@@ -300,6 +314,7 @@
 <script src="{% static 'js/clear-input.js' %}"></script>
 <script src="{% static 'js/avatar-dropzone.js' %}"></script>
 <script src="{% static 'js/plan-cards.js' %}"></script>
+<script src="{% static 'js/profile-save-confirm.js' %}"></script>
 {% if is_owner %}
 <script src="{% static 'js/slug-check.js' %}"></script>
 {% endif %}


### PR DESCRIPTION
## Summary
- Ensure user object refreshes so username changes immediately
- Add confirmation modal and JavaScript to verify profile edits before saving
- Test that updating profile form changes the username

## Testing
- `pytest apps/users/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a29c76cc8321b751a865427d7601