### PR TITLE
Reject disposable email domains during registration

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -8,6 +8,8 @@ from .models import Profile
 from apps.core.mixins import UniformFieldsMixin
 import os
 
+DISPOSABLE_EMAIL_DOMAINS = ("yopmail", "mohmal")
+
 
 def _validate_avatar(avatar):
     """Validate avatar file size and extension."""
@@ -97,6 +99,9 @@ class RegistroUsuarioForm(UniformFieldsMixin, UserCreationForm):
 
     def clean_email(self):
         email = self.cleaned_data['email']
+        domain = email.split('@')[-1].lower()
+        if any(bad in domain for bad in DISPOSABLE_EMAIL_DOMAINS):
+            raise forms.ValidationError('Introduzca un correo electrónico valido, el dominio usado no está permitido.')
         if User.objects.filter(email=email).exists():
             raise forms.ValidationError('Este correo electrónico ya está registrado')
         return email

--- a/apps/users/tests/test_user.py
+++ b/apps/users/tests/test_user.py
@@ -61,6 +61,18 @@ class RegistrationTests(TestCase):
         self.assertContains(response, "El nombre de usuario debe tener al menos 3 caracteres")
         self.assertFalse(User.objects.filter(username="ab").exists())
 
+    def test_disposable_email_rejected(self):
+        data = {
+            "username": "tempuser",
+            "email": "temp@yopmail.com",
+            "password1": "secretpass123",
+            "password2": "secretpass123",
+        }
+        url = reverse("register")
+        response = self.client.post(url, data)
+        self.assertContains(response, "Introduzca un correo electrónico valido, el dominio usado no está permitido.")
+        self.assertFalse(User.objects.filter(username="tempuser").exists())
+
 
 class LoginRememberMeTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- block registration emails from disposable providers like yopmail and mohmal
- test that disposable domains are rejected with proper error message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7b4784bcc832185519150de17888c