### PR TITLE
Reject disposable email domains during registration and profile update

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -8,6 +8,8 @@ from .models import Profile
 from apps.core.mixins import UniformFieldsMixin
 import os
 
+DISPOSABLE_EMAIL_DOMAINS = ("yopmail", "mohmal")
+
 
 def _validate_avatar(avatar):
     """Validate avatar file size and extension."""
@@ -97,6 +99,9 @@ class RegistroUsuarioForm(UniformFieldsMixin, UserCreationForm):
 
     def clean_email(self):
         email = self.cleaned_data['email']
+        domain = email.split('@')[-1].lower()
+        if any(bad in domain for bad in DISPOSABLE_EMAIL_DOMAINS):
+            raise forms.ValidationError('Introduzca un correo electrónico valido, el dominio usado no está permitido.')
         if User.objects.filter(email=email).exists():
             raise forms.ValidationError('Este correo electrónico ya está registrado')
         return email
@@ -170,6 +175,14 @@ class AccountForm(UniformFieldsMixin, forms.ModelForm):
         if not avatar:
             return avatar
         return _validate_avatar(avatar)
+
+    def clean_email(self):
+        email = self.cleaned_data.get('email')
+        if email:
+            domain = email.split('@')[-1].lower()
+            if any(bad in domain for bad in DISPOSABLE_EMAIL_DOMAINS):
+                raise forms.ValidationError('Introduzca un correo electrónico valido, el dominio usado no está permitido.')
+        return email
 
     def clean(self):
         cleaned = super().clean()

--- a/apps/users/tests/test_user.py
+++ b/apps/users/tests/test_user.py
@@ -61,6 +61,18 @@ class RegistrationTests(TestCase):
         self.assertContains(response, "El nombre de usuario debe tener al menos 3 caracteres")
         self.assertFalse(User.objects.filter(username="ab").exists())
 
+    def test_disposable_email_rejected(self):
+        data = {
+            "username": "tempuser",
+            "email": "temp@yopmail.com",
+            "password1": "secretpass123",
+            "password2": "secretpass123",
+        }
+        url = reverse("register")
+        response = self.client.post(url, data)
+        self.assertContains(response, "Introduzca un correo electrónico valido, el dominio usado no está permitido.")
+        self.assertFalse(User.objects.filter(username="tempuser").exists())
+
 
 class LoginRememberMeTests(TestCase):
     def setUp(self):
@@ -101,4 +113,23 @@ class ProfileCreationTests(TestCase):
     def test_profile_created_on_user_creation(self):
         user = User.objects.create_user(username="signaluser", password="pass")
         self.assertTrue(Profile.objects.filter(user=user).exists())
+
+
+class ProfileEmailTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="profileupdate", email="old@example.com", password="pass"
+        )
+
+    def test_disposable_email_rejected_on_update(self):
+        self.client.login(username="profileupdate", password="pass")
+        url = reverse("profile")
+        data = {"username": "profileupdate", "email": "temp@yopmail.com"}
+        response = self.client.post(url, data)
+        self.assertContains(
+            response,
+            "Introduzca un correo electrónico valido, el dominio usado no está permitido.",
+        )
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, "old@example.com")
 

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -88,6 +88,11 @@
                         {{ form.email }}
                         <button type="button" class="clear-btn bi bi-x"></button>
                         <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
+                        {% if form.email.errors %}
+                        <div class="invalid-feedback d-block">
+                            {{ form.email.errors.as_text|striptags }}
+                        </div>
+                        {% endif %}
                     </div>
                     <div class="form-field col-md-6 phone-field">
                         {{ club_form.prefijo }}


### PR DESCRIPTION
## Summary
- block registration emails from disposable providers like yopmail and mohmal
- prevent profile email updates using disposable domains and display form error
- test that disposable domains are rejected in profile update with proper error message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7b4784bcc832185519150de17888c