### PR TITLE
Share plan option cards between profile and registration

### DIFF
--- a/apps/core/utils/plans.py
+++ b/apps/core/utils/plans.py
@@ -1,0 +1,40 @@
+"""Utility definitions for subscription plans used across the site."""
+
+# Centralized list of available plans so templates can render
+# consistent information whether they are used on the profile or
+# professional registration pages.
+
+PLANS = [
+    {
+        "value": "bronce",
+        "title": "Plan Bronce",
+        "price": "0€ / mes",
+        "features": [
+            "Presencia básica en el directorio",
+            "Publicación de eventos",
+            "Acceso a valoraciones",
+        ],
+    },
+    {
+        "value": "plata",
+        "title": "Plan Plata",
+        "price": "9€ / mes",
+        "features": [
+            "Todos los beneficios del Plan Bronce",
+            "Publicaciones ilimitadas",
+            "Estadísticas básicas",
+        ],
+        "featured": True,
+    },
+    {
+        "value": "oro",
+        "title": "Plan Oro",
+        "price": "19€ / mes",
+        "features": [
+            "Todos los beneficios del Plan Plata",
+            "Badge de verificación",
+            "Herramientas de marketing avanzadas",
+        ],
+    },
+]
+

--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -2,6 +2,7 @@
 from django.shortcuts import render, redirect
 from ..forms import TipoUsuarioForm, PlanForm, RegistroProfesionalForm
 from apps.clubs.forms import ClubForm, EntrenadorForm
+from ..utils.plans import PLANS
 
 
 def home(request):
@@ -53,6 +54,8 @@ def registro_profesional(request):
             "start_step": start_step,
             "club_form": club_form,
             "coach_form": coach_form,
+            "plans": PLANS,
+            "current_plan": form["plan"].value(),
         },
     )
 

--- a/apps/users/views/profile.py
+++ b/apps/users/views/profile.py
@@ -9,6 +9,7 @@ from ..models import Profile, Follow
 from apps.clubs.models import Booking, Club, Reseña
 from apps.clubs.forms import ClubForm
 from apps.core.forms import PlanForm
+from apps.core.utils.plans import PLANS
 
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import F, FloatField, Avg, Count, ExpressionWrapper
@@ -101,45 +102,11 @@ def profile(request):
         if first_club and first_club.logo:
             avatar_url = first_club.logo.url
 
-    plans = [
-        {
-            'value': 'bronce',
-            'title': 'Plan Bronce',
-            'price': '0€ / mes',
-            'features': [
-                'Presencia básica en el directorio',
-                'Publicación de eventos',
-                'Acceso a valoraciones',
-            ],
-        },
-        {
-            'value': 'plata',
-            'title': 'Plan Plata',
-            'price': '9€ / mes',
-            'features': [
-                'Todos los beneficios del Plan Bronce',
-                'Publicaciones ilimitadas',
-                'Estadísticas básicas',
-            ],
-            'featured': True,
-        },
-        {
-            'value': 'oro',
-            'title': 'Plan Oro',
-            'price': '19€ / mes',
-            'features': [
-                'Todos los beneficios del Plan Plata',
-                'Badge de verificación',
-                'Herramientas de marketing avanzadas',
-            ],
-        },
-    ]
-
     return render(request, 'users/profile.html', {
         'form': form,
         'club_form': club_form,
         'plan_form': plan_form,
-        'plans': plans,
+        'plans': PLANS,
         'current_plan': profile_obj.plan,
         'profile': profile_obj,
         'bookings': bookings,


### PR DESCRIPTION
## Summary
- Centralize plan definitions in a new utility module
- Use shared plan data in profile and professional registration views

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7e42dc4f48321a7aca3e63c629f2b