### PR TITLE
Reemplaza campos de perfil en registro pro con formulario unificado

### DIFF
--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 from apps.core.mixins import UniformFieldsMixin
+from apps.clubs.countries import COUNTRY_CHOICES
+from apps.clubs.spain import REGION_CHOICES
 
 class TipoUsuarioForm(UniformFieldsMixin, forms.Form):
     tipo = forms.ChoiceField(
@@ -29,4 +31,34 @@ class RegistroProfesionalForm(UniformFieldsMixin, forms.Form):
 
     tipo = TipoUsuarioForm.base_fields['tipo']
     plan = PlanForm.base_fields['plan']
+
+
+class ProRegisterForm(UniformFieldsMixin, forms.Form):
+    """Formulario para los datos personales y de dirección del profesional."""
+
+    nombre = forms.CharField(label="Nombre")
+    apellidos = forms.CharField(label="Apellidos")
+    fecha_nacimiento = forms.DateField(
+        label="Fecha de nacimiento", widget=forms.DateInput(attrs={"type": "date"})
+    )
+    dni = forms.CharField(label="DNI/NIE/CIF")
+    telefono = forms.CharField(label="Teléfono")
+    sexo = forms.ChoiceField(
+        label="Sexo",
+        choices=[
+            ("hombre", "Hombre"),
+            ("mujer", "Mujer"),
+            ("otro", "Otro"),
+        ],
+    )
+
+    pais = forms.ChoiceField(label="País", choices=COUNTRY_CHOICES)
+    comunidad_autonoma = forms.ChoiceField(
+        label="Comunidad Autónoma", choices=REGION_CHOICES
+    )
+    ciudad = forms.CharField(label="Ciudad")
+    calle = forms.CharField(label="Calle")
+    numero = forms.CharField(label="Número")
+    puerta = forms.CharField(label="Puerta")
+    codigo_postal = forms.CharField(label="Código Postal")
 

--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -1,7 +1,11 @@
 # apps/core/views.py
 from django.shortcuts import render, redirect
-from ..forms import TipoUsuarioForm, PlanForm, RegistroProfesionalForm
-from apps.clubs.forms import ClubForm, EntrenadorForm
+from ..forms import (
+    TipoUsuarioForm,
+    PlanForm,
+    RegistroProfesionalForm,
+    ProRegisterForm,
+)
 from ..utils.plans import PLANS
 
 
@@ -25,23 +29,14 @@ def registro_profesional(request):
         return redirect('login')
 
     start_step = 1
-    club_form = ClubForm(prefix="club")
-    coach_form = EntrenadorForm(prefix="coach")
+    pro_form = ProRegisterForm()
 
     if request.method == "POST":
         form = RegistroProfesionalForm(request.POST)
-        tipo = request.POST.get("tipo")
+        pro_form = ProRegisterForm(request.POST)
 
-        if tipo == "club":
-            club_form = ClubForm(request.POST, request.FILES, prefix="club")
-        elif tipo == "entrenador":
-            coach_form = EntrenadorForm(request.POST, request.FILES, prefix="coach")
-
-        if form.is_valid():
-            if tipo == "club" and club_form.is_valid():
-                return render(request, "core/registro_pro_success.html")
-            if tipo == "entrenador" and coach_form.is_valid():
-                return render(request, "core/registro_pro_success.html")
+        if form.is_valid() and pro_form.is_valid():
+            return render(request, "core/registro_pro_success.html")
         start_step = request.POST.get("current_step", 1)
     else:
         form = RegistroProfesionalForm()
@@ -52,8 +47,7 @@ def registro_profesional(request):
         {
             "form": form,
             "start_step": start_step,
-            "club_form": club_form,
-            "coach_form": coach_form,
+            "pro_form": pro_form,
             "plans": PLANS,
             "current_plan": form["plan"].value(),
         },

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -3,9 +3,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const progress = ['step-label-1', 'step-label-2', 'step-label-3'].map(id => document.getElementById(id));
   const currentInput = document.getElementById('current-step');
   let current = parseInt(currentInput.value, 10) || 1;
-  const clubFields = document.getElementById('club-fields');
-  const coachFields = document.getElementById('coach-fields');
-  const tipoRadios = document.querySelectorAll('input[name="tipo"]');
   const tipoCards = document.querySelectorAll('.tipo-card');
   const planCards = document.querySelectorAll('.plan-card');
   const paymentSection = document.getElementById('payment-section');
@@ -33,23 +30,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (prev2) prev2.addEventListener('click', () => showStep(1));
   if (prev3) prev3.addEventListener('click', () => showStep(2));
 
-  function toggleTipoFields() {
-    const checked = document.querySelector('input[name="tipo"]:checked');
-    if (!checked) return;
-    if (checked.value === 'club') {
-      clubFields && clubFields.classList.remove('d-none');
-      coachFields && coachFields.classList.add('d-none');
-    } else if (checked.value === 'entrenador') {
-      coachFields && coachFields.classList.remove('d-none');
-      clubFields && clubFields.classList.add('d-none');
-    } else {
-      clubFields && clubFields.classList.add('d-none');
-      coachFields && coachFields.classList.add('d-none');
-    }
-  }
-
-  tipoRadios.forEach(radio => radio.addEventListener('change', toggleTipoFields));
-
   tipoCards.forEach(card => {
     const input = card.querySelector('input');
     if (input.checked) {
@@ -58,7 +38,6 @@ document.addEventListener('DOMContentLoaded', () => {
     card.addEventListener('click', () => {
       input.checked = true;
       tipoCards.forEach(c => c.classList.toggle('active', c === card));
-      toggleTipoFields();
     });
   });
 
@@ -84,8 +63,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   togglePaymentSection();
-
-  toggleTipoFields();
 
   showStep(current);
 });

--- a/templates/core/_pro_register_form.html
+++ b/templates/core/_pro_register_form.html
@@ -1,0 +1,22 @@
+<h3 class="h6 mb-3">Datos personales</h3>
+{% for field in (form.nombre, form.apellidos, form.fecha_nacimiento, form.dni, form.telefono, form.sexo) %}
+<div class="form-field">
+  {{ field }}
+  <button type="button" class="clear-btn bi bi-x"></button>
+  <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+  {% if field.errors %}
+  <div class="invalid-feedback d-block">{{ field.errors.as_text|striptags }}</div>
+  {% endif %}
+</div>
+{% endfor %}
+<h3 class="h6 mt-4 mb-3">Dirección</h3>
+{% for field in (form.pais, form.comunidad_autonoma, form.ciudad, form.calle, form.numero, form.puerta, form.codigo_postal) %}
+<div class="form-field">
+  {{ field }}
+  <button type="button" class="clear-btn bi bi-x"></button>
+  <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+  {% if field.errors %}
+  <div class="invalid-feedback d-block">{{ field.errors.as_text|striptags }}</div>
+  {% endif %}
+</div>
+{% endfor %}

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -70,8 +70,7 @@
                 </div>
                 <div id="step3" class="step d-none">
                     <p class="text-muted">Rellena la información de tu perfil.</p>
-                    <div id="club-fields" class="d-none">{% include 'core/_profile_fields.html' with form=club_form %}</div>
-                    <div id="coach-fields" class="d-none">{% include 'core/_profile_fields.html' with form=coach_form %}</div>
+                    {% include 'core/_pro_register_form.html' with form=pro_form %}
                     <button type="button" class="btn btn-outline-dark me-2" id="prev3">Anterior</button>
                     <button type="submit" class="btn btn-dark">Finalizar</button>
                 </div>


### PR DESCRIPTION
## Summary
- Añade `ProRegisterForm` para capturar datos personales y de dirección en el registro profesional
- Actualiza vista, plantilla y JavaScript para usar el nuevo formulario en el último paso

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a7e82c80c48321b0706733f423d244