### PR TITLE
Add dynamic page titles

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Clubs De Boxeo</title>
+    <title>{% block title %}Clubs de Boxeo{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/svg+xml" href="{% static 'img/logo.svg' %}">
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css">

--- a/templates/blog/post_list.html
+++ b/templates/blog/post_list.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% block title %}Clubs de Boxeo | Blog{% endblock %}
 {% block body_class %}d-flex flex-column min-vh-100{% endblock %}
 {% block content %}
 <main class="flex-grow-1 py-5">

--- a/templates/clubs/club_profile.html
+++ b/templates/clubs/club_profile.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% block title %}Clubs de Boxeo | {{ club.name }}{% endblock %}
 {% block body_class %}club-profile-page d-flex flex-column min-vh-100{% endblock %}
 {% load static  utils_filters %}
 {% block content %}

--- a/templates/clubs/coach_profile.html
+++ b/templates/clubs/coach_profile.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% block title %}Clubs de Boxeo | {{ coach.name }}{% endblock %}
 {% block body_class %}club-profile-page d-flex flex-column min-vh-100{% endblock %}
 {% load static star_rating utils_filters %}
 {% block content %}

--- a/templates/clubs/conversation.html
+++ b/templates/clubs/conversation.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 {% load utils_filters %}
+{% block title %}Clubs de Boxeo | Mensajes{% endblock %}
 {% block body_class %}d-flex flex-column vh-100  {% endblock %}
 {% block content %}
 <main class="flex-grow-1 m-4 overflow-hidden">

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load static utils_filters %}
 
+{% block title %}Clubs de Boxeo | Panel de control{% endblock %}
 {% block body_class %}d-flex flex-column min-vh-100 dashboard-page{% endblock %}
 
 {% block content %}

--- a/templates/clubs/message_inbox.html
+++ b/templates/clubs/message_inbox.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% block title %}Clubs de Boxeo | Mensajes{% endblock %}
 {% block body_class %}d-flex flex-column min-vh-100{% endblock %}
 {% block content %}
 <div class="container col-5 my-4">

--- a/templates/clubs/search_coaches.html
+++ b/templates/clubs/search_coaches.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
+{% block title %}Clubs de Boxeo | Resultados de búsqueda{% endblock %}
 {% block body_class %}search-result-page{% endblock %}
 
 {% block content %}

--- a/templates/clubs/search_results.html
+++ b/templates/clubs/search_results.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load static utils_filters %}
 
+{% block title %}Clubs de Boxeo | Resultados de búsqueda{% endblock %}
 {% block body_class %}search-result-page{% endblock %}
 
 {% block content %}

--- a/templates/core/ayuda.html
+++ b/templates/core/ayuda.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% block title %}Clubs de Boxeo | Ayuda{% endblock %}
 {% block body_class %}d-flex flex-column min-vh-100{% endblock %}
 {% block content %}
 <main class="flex-grow-1 py-4">

--- a/templates/core/politica_cookies.html
+++ b/templates/core/politica_cookies.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% block title %}Clubs de Boxeo | Política de cookies{% endblock %}
 {% block body_class %}d-flex flex-column min-vh-100{% endblock %}
 {% block content %}
 <main class="flex-grow-1 py-4">

--- a/templates/core/politica_privacidad.html
+++ b/templates/core/politica_privacidad.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% block title %}Clubs de Boxeo | Política de privacidad{% endblock %}
 {% block body_class %}d-flex flex-column min-vh-100{% endblock %}
 {% block content %}
 <main class="flex-grow-1 py-4">

--- a/templates/core/pro.html
+++ b/templates/core/pro.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% block title %}Clubs de Boxeo | Planes{% endblock %}
 {% block body_class %}d-flex flex-column min-vh-100{% endblock %}
 
 {% block content %}

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% block title %}Clubs de Boxeo | Registro Pro{% endblock %}
 {% block content %}
     <div class="container-fluid  px-3 my-5 col-8">
         <div class="mx-auto">

--- a/templates/core/registro_pro_success.html
+++ b/templates/core/registro_pro_success.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% block title %}Clubs de Boxeo | Registro Pro{% endblock %}
 {% block content %}
 <div class="container py-5 text-center">
     <h1 class="mb-4">Registro completado</h1>

--- a/templates/core/terminos_condiciones.html
+++ b/templates/core/terminos_condiciones.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% block title %}Clubs de Boxeo | Términos y condiciones{% endblock %}
 {% block body_class %}d-flex flex-column min-vh-100{% endblock %}
 {% block content %}
 <main class="flex-grow-1 py-4">

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -5,7 +5,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Clubs De Boxeo</title>
+    <title>Clubs de Boxeo | Iniciar sesión</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/svg+xml" href="{% static 'img/logo.svg' %}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css">

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static utils_filters %}
+{% block title %}Clubs de Boxeo | Mi perfil{% endblock %}
 {% block body_class %}d-flex flex-column min-vh-100 profile-page{% endblock %}
 {% block content %}
     <main class="flex-grow-1">

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -5,7 +5,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Clubs De Boxeo</title>
+    <title>Clubs de Boxeo | Registro</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/svg+xml" href="{% static 'img/logo.svg' %}">
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css">


### PR DESCRIPTION
## Summary
- Add a `title` block in the base template to support dynamic page titles
- Set descriptive titles for search results, profile, dashboard, messages, and footer-linked pages
- Update login and registration templates to include contextual titles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8eb14acdc8321a7eb3762d942b8f9