### PR TITLE
Use search query and tab names in dynamic titles

### DIFF
--- a/static/js/profile-tabs.js
+++ b/static/js/profile-tabs.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const sections = document.querySelectorAll('.profile-section');
   const selects = document.querySelectorAll('.profile-tabs-select');
   const storageKey = 'activeTab:' + window.location.pathname;
+  const baseTitle = document.title.split('|')[0].trim();
 
   function activate(tab) {
     tabs.forEach(t => t.classList.remove('active'));
@@ -13,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (sec) sec.classList.add('active');
     localStorage.setItem(storageKey, target);
     selects.forEach(s => (s.value = target));
+    document.title = `${baseTitle} | ${tab.textContent.trim()}`;
   }
 
   tabs.forEach(t => {

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static utils_filters %}
 
-{% block title %}Clubs de Boxeo | Panel de control{% endblock %}
+{% block title %}Clubs de Boxeo | Mi Perfil{% endblock %}
 {% block body_class %}d-flex flex-column min-vh-100 dashboard-page{% endblock %}
 
 {% block content %}

--- a/templates/clubs/search_coaches.html
+++ b/templates/clubs/search_coaches.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}Clubs de Boxeo | Resultados de búsqueda{% endblock %}
+{% block title %}Clubs de Boxeo | {{ search_query|default:"Resultados de búsqueda" }}{% endblock %}
 {% block body_class %}search-result-page{% endblock %}
 
 {% block content %}

--- a/templates/clubs/search_results.html
+++ b/templates/clubs/search_results.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static utils_filters %}
 
-{% block title %}Clubs de Boxeo | Resultados de búsqueda{% endblock %}
+{% block title %}Clubs de Boxeo | {{ search_query|default:"Resultados de búsqueda" }}{% endblock %}
 {% block body_class %}search-result-page{% endblock %}
 
 {% block content %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load static utils_filters %}
-{% block title %}Clubs de Boxeo | Mi perfil{% endblock %}
+{% block title %}Clubs de Boxeo | Mi cuenta{% endblock %}
 {% block body_class %}d-flex flex-column min-vh-100 profile-page{% endblock %}
 {% block content %}
     <main class="flex-grow-1">


### PR DESCRIPTION
## Summary
- Show search term in results page titles
- Update profile tab script to set page titles from active tab
- Default titles for profile and dashboard to first tab

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8ed99d3508321a5004fb5f3423266