### PR TITLE
Add Spanish 404 error page

### DIFF
--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -71,3 +71,7 @@ def cookies(request):
  
 
 
+
+def error_404(request, exception):
+    """Display custom 404 page."""
+    return render(request, '404.html', status=404)

--- a/config/urls.py
+++ b/config/urls.py
@@ -10,8 +10,8 @@ from apps.clubs.views import messages as club_messages
 from apps.clubs.views.dashboard import dashboard
 from apps.users.views import profile as user_profile
   
-from apps.users.forms import LoginForm   
- 
+from apps.users.forms import LoginForm
+
 urlpatterns = [
     path('django-admin/', admin.site.urls),
 
@@ -44,6 +44,9 @@ urlpatterns = [
     path('', include('apps.users.urls')),
     path('', include('allauth.urls')),
 ]
+
+# Custom error handlers
+handler404 = "apps.core.views.public.error_404"
 
 # Archivos estáticos en modo DEBUG
 if settings.DEBUG:

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block body_class %}d-flex flex-column min-vh-100{% endblock %}
+{% block header_class %}header-hero-page{% endblock %}
+
+{% block content %}
+<main class="flex-grow-1">
+    <div class="col-10 container-fluid py-1">
+        <section class="hero text-center">
+            <div class="hero-wrapper">
+                <div class="hero-text">
+                    <h1 class="display-1 fw-bold">404</h1>
+                    <p class="fs-5 p-1">Lo sentimos, la página que buscas no existe.</p>
+                    <a href="/" class="btn btn-primary mt-3">Volver al inicio</a>
+                </div>
+            </div>
+        </section>
+    </div>
+</main>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add custom 404 error handler
- serve localized 404 template styled like the homepage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8f13070648321a98b26c4421b22fc