### PR TITLE
Add catch-all 404 route

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,7 +1,7 @@
 # directorio_boxeo/config/urls.py
 
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
@@ -11,6 +11,7 @@ from apps.clubs.views.dashboard import dashboard
 from apps.users.views import profile as user_profile
   
 from apps.users.forms import LoginForm
+from apps.core.views.public import error_404
 
 urlpatterns = [
     path('django-admin/', admin.site.urls),
@@ -51,3 +52,6 @@ handler404 = "apps.core.views.public.error_404"
 # Archivos estáticos en modo DEBUG
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# Catch-all pattern for unmatched URLs
+urlpatterns += [re_path(r"^.*$", error_404)]


### PR DESCRIPTION
## Summary
- Ensure custom 404 page is displayed for any unmatched URL by adding a catch-all pattern

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8f9287cf48321974b8f777fa0670e