### PR TITLE
Fix 404 handler signature

### DIFF
--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -72,6 +72,6 @@ def cookies(request):
 
 
 
-def error_404(request, exception):
+def error_404(request, exception=None):
     """Display custom 404 page."""
     return render(request, '404.html', status=404)


### PR DESCRIPTION
## Summary
- allow error_404 to be called without exception argument

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a8fd5cc96c83219ff178e2ba26708c