### PR TITLE
Improve professional registration UX

### DIFF
--- a/static/css/registro_pro.css
+++ b/static/css/registro_pro.css
@@ -10,6 +10,7 @@
   text-align: center;
   font-weight: 600;
   color: #6c757d;
+  position: relative;
 }
 .progress-steps .step-item.active {
   color: #000;
@@ -29,4 +30,15 @@
 .progress-steps .step-item.active::before {
   background-color: currentColor;
   color: #fff;
+}
+
+.progress-steps .step-item:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  top: 15px;
+  left: calc(50% + 16px);
+  width: calc(100% - 32px);
+  height: 2px;
+  background-color: #dee2e6;
+  z-index: -1;
 }

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -6,6 +6,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const tipoCards = document.querySelectorAll('.tipo-card');
   const planCards = document.querySelectorAll('.plan-card');
   const paymentSection = document.getElementById('payment-section');
+  const nextBtn = document.getElementById('nextBtn');
+  const prevBtn = document.getElementById('prevBtn');
+  const finishBtn = document.getElementById('finishBtn');
 
   function showStep(n) {
     steps.forEach((step, idx) => {
@@ -14,21 +17,22 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     progress.forEach((item, idx) => {
       if (!item) return;
-      item.classList.toggle('active', idx === n - 1);
+      item.classList.toggle('active', idx <= n - 1);
     });
     current = n;
     currentInput.value = current;
+    if (prevBtn) prevBtn.classList.toggle('d-none', n === 1);
+    if (nextBtn) nextBtn.classList.toggle('d-none', n === steps.length);
+    if (finishBtn) finishBtn.classList.toggle('d-none', n !== steps.length);
   }
 
-  const next1 = document.getElementById('next1');
-  const next2 = document.getElementById('next2');
-  const prev2 = document.getElementById('prev2');
-  const prev3 = document.getElementById('prev3');
+  if (nextBtn) {
+    nextBtn.addEventListener('click', () => showStep(Math.min(current + 1, steps.length)));
+  }
 
-  if (next1) next1.addEventListener('click', () => showStep(2));
-  if (next2) next2.addEventListener('click', () => showStep(3));
-  if (prev2) prev2.addEventListener('click', () => showStep(1));
-  if (prev3) prev3.addEventListener('click', () => showStep(2));
+  if (prevBtn) {
+    prevBtn.addEventListener('click', () => showStep(Math.max(current - 1, 1)));
+  }
 
   tipoCards.forEach(card => {
     const input = card.querySelector('input');

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -31,7 +31,6 @@
                     {% if form.tipo.errors %}
                         <div class="invalid-feedback d-block">{{ form.tipo.errors.as_text|striptags }}</div>
                     {% endif %}
-                    <button type="button" class="btn btn-dark mt-3" id="next1">Siguiente</button>
                 </div>
                 <div id="step2" class="step d-none">
                     <div class="mb-3">{{ form.plan.label }}</div>
@@ -66,14 +65,15 @@
                     {% if form.plan.errors %}
                         <div class="invalid-feedback d-block">{{ form.plan.errors.as_text|striptags }}</div>
                     {% endif %}
-                    <button type="button" class="btn btn-outline-dark me-2" id="prev2">Anterior</button>
-                    <button type="button" class="btn btn-dark" id="next2">Siguiente</button>
                 </div>
                 <div id="step3" class="step d-none">
                     <p class="text-muted">Rellena la información de tu perfil.</p>
                     {% include 'core/_pro_register_form.html' with form=pro_form %}
-                    <button type="button" class="btn btn-outline-dark me-2" id="prev3">Anterior</button>
-                    <button type="submit" class="btn btn-dark">Finalizar</button>
+                </div>
+                <div class="d-flex justify-content-end mt-4">
+                    <button type="button" class="btn btn-outline-dark me-2 d-none" id="prevBtn">Atrás</button>
+                    <button type="button" class="btn btn-dark" id="nextBtn">Continuar</button>
+                    <button type="submit" class="btn btn-dark d-none" id="finishBtn">Finalizar</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- Align multistep navigation buttons to the right and reuse a single set of controls
- Highlight completed steps in progress bar and draw grey connectors
- Update step logic to manage new navigation and progress behavior

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a90c21cdd0832189adbde3c3318dc0