### PR TITLE
Add additional profile step and Stripe test setup

### DIFF
--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -122,3 +122,10 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
                 raise forms.ValidationError('Introduce un número de teléfono válido')
         return digits
 
+
+class ProExtraForm(UniformFieldsMixin, forms.Form):
+    """Datos adicionales requeridos para completar el perfil profesional."""
+
+    descripcion = forms.CharField(label="Sobre ti", widget=forms.Textarea)
+    logotipo = forms.ImageField(label="Logotipo")
+

--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -1,10 +1,12 @@
 # apps/core/views.py
 from django.shortcuts import render, redirect
+from django.conf import settings
 from ..forms import (
     TipoUsuarioForm,
     PlanForm,
     RegistroProfesionalForm,
     ProRegisterForm,
+    ProExtraForm,
 )
 from ..utils.plans import PLANS
 
@@ -30,12 +32,14 @@ def registro_profesional(request):
 
     start_step = 1
     pro_form = ProRegisterForm()
+    extra_form = ProExtraForm()
 
     if request.method == "POST":
         form = RegistroProfesionalForm(request.POST)
         pro_form = ProRegisterForm(request.POST)
+        extra_form = ProExtraForm(request.POST, request.FILES)
 
-        if form.is_valid() and pro_form.is_valid():
+        if form.is_valid() and pro_form.is_valid() and extra_form.is_valid():
             return render(request, "core/registro_pro_success.html")
         start_step = request.POST.get("current_step", 1)
     else:
@@ -48,8 +52,10 @@ def registro_profesional(request):
             "form": form,
             "start_step": start_step,
             "pro_form": pro_form,
+            "extra_form": extra_form,
             "plans": PLANS,
             "current_plan": form["plan"].value(),
+            "stripe_public_key": settings.STRIPE_PUBLIC_KEY,
         },
     )
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -187,3 +187,8 @@ ACCOUNT_SIGNUP_FIELDS = [
 ]
 # Skip email verification for local development
 ACCOUNT_EMAIL_VERIFICATION = 'none'
+
+# Stripe configuration
+STRIPE_PUBLIC_KEY = os.environ.get("STRIPE_PUBLIC_KEY", "")
+STRIPE_SECRET_KEY = os.environ.get("STRIPE_SECRET_KEY", "")
+STRIPE_CONNECT_CLIENT_ID = os.environ.get("STRIPE_CONNECT_CLIENT_ID", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ PyJWT
 Faker
 django-cities-light
 disposable-email-domains
+stripe
 

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const steps = ['step1', 'step2', 'step3'].map(id => document.getElementById(id));
-  const progress = ['step-label-1', 'step-label-2', 'step-label-3'].map(id => document.getElementById(id));
+  const steps = ['step1', 'step2', 'step3', 'step4', 'step5'].map(id => document.getElementById(id));
+  const progress = ['step-label-1', 'step-label-2', 'step-label-3', 'step-label-4', 'step-label-5'].map(id => document.getElementById(id));
   const currentInput = document.getElementById('current-step');
   let current = parseInt(currentInput.value, 10) || 1;
   const tipoCards = document.querySelectorAll('.tipo-card');
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const nextBtn = document.getElementById('nextBtn');
   const prevBtn = document.getElementById('prevBtn');
   const finishBtn = document.getElementById('finishBtn');
+  const stripeBtn = document.getElementById('stripe-connect-btn');
 
   function showStep(n) {
     steps.forEach((step, idx) => {
@@ -32,6 +33,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (prevBtn) {
     prevBtn.addEventListener('click', () => showStep(Math.max(current - 1, 1)));
+  }
+
+  if (stripeBtn && window.stripePublicKey) {
+    const stripe = Stripe(window.stripePublicKey);
+    stripeBtn.addEventListener('click', () => {
+      // Placeholder para el flujo de Stripe Connect en modo prueba
+      console.log('Stripe Connect init in test mode');
+    });
   }
 
   tipoCards.forEach(card => {

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -1,0 +1,17 @@
+<h3 class="h6 mb-3">Datos adicionales</h3>
+<div class="form-field mb-3">
+  {{ form.descripcion }}
+  <button type="button" class="clear-btn bi bi-x"></button>
+  <label for="{{ form.descripcion.id_for_label }}">{{ form.descripcion.label }}</label>
+  {% if form.descripcion.errors %}
+  <div class="invalid-feedback d-block">{{ form.descripcion.errors.as_text|striptags }}</div>
+  {% endif %}
+</div>
+<div class="form-field">
+  {{ form.logotipo }}
+  <button type="button" class="clear-btn bi bi-x"></button>
+  <label for="{{ form.logotipo.id_for_label }}">{{ form.logotipo.label }}</label>
+  {% if form.logotipo.errors %}
+  <div class="invalid-feedback d-block">{{ form.logotipo.errors.as_text|striptags }}</div>
+  {% endif %}
+</div>

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -11,8 +11,10 @@
                 <li class="step-item active" data-step="1" id="step-label-1"></li>
                 <li class="step-item" data-step="2" id="step-label-2"></li>
                 <li class="step-item" data-step="3" id="step-label-3"></li>
+                <li class="step-item" data-step="4" id="step-label-4"></li>
+                <li class="step-item" data-step="5" id="step-label-5"></li>
             </ul>
-            <form method="post" class="profile-form mt-5">
+            <form method="post" class="profile-form mt-5" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ form.non_field_errors }}
                 <input type="hidden"
@@ -74,6 +76,15 @@
                     <p class="text-muted">Rellena la información de tu perfil.</p>
                     {% include 'core/_pro_register_form.html' with form=pro_form %}
                 </div>
+                <div id="step4" class="step d-none">
+                    <p class="text-muted">Datos adicionales obligatorios para completar tu perfil.</p>
+                    {% include 'core/_pro_extra_form.html' with form=extra_form %}
+                </div>
+                <div id="step5" class="step d-none text-center">
+                    <h1 class="h5 mb-3">Pasarela de pagos</h1>
+                    <p class="text-muted mb-4">Conecta con Stripe para habilitar los cobros.</p>
+                    <button type="button" class="btn btn-primary" id="stripe-connect-btn">Conectar con Stripe</button>
+                </div>
                 <div class="d-flex justify-content-end mt-4">
                     <button type="button" class="btn btn-outline-dark me-2 d-none" id="prevBtn">Atrás</button>
                     <button type="button" class="btn btn-dark" id="nextBtn">Continuar</button>
@@ -85,6 +96,10 @@
 </main>
 {% endblock %}
 {% block extra_js %}
+    <script>
+        window.stripePublicKey = "{{ stripe_public_key }}";
+    </script>
+    <script src="https://js.stripe.com/v3/"></script>
     <script src="{% static 'js/member-location.js' %}"></script>
     <script src="{% static 'js/pro-registro.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add ProExtraForm and extra step for about and logo in registration
- include Stripe Connect placeholder as fifth step
- prepare Stripe settings and dependency

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement stripe)*
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a92288fc5c8321a9eed3ff6fb7a337