### PR TITLE
Add fade-in transitions and drag-and-drop logo upload for pro registration

### DIFF
--- a/static/css/registro_pro.css
+++ b/static/css/registro_pro.css
@@ -49,3 +49,23 @@
   background:#000;
   color: white;
 }
+
+.form-step {
+  display: none;
+}
+
+.form-step.active {
+  display: block;
+  animation: fadeIn 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function showStep(n) {
     steps.forEach((step, idx) => {
       if (!step) return;
-      step.classList.toggle('d-none', idx !== n - 1);
+      step.classList.toggle('active', idx === n - 1);
     });
     progress.forEach((item, idx) => {
       if (!item) return;

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -7,10 +7,16 @@
   <div class="invalid-feedback d-block">{{ form.descripcion.errors.as_text|striptags }}</div>
   {% endif %}
 </div>
-<div class="form-field">
-  {{ form.logotipo }}
-  <button type="button" class="clear-btn bi bi-x"></button>
-  <label for="{{ form.logotipo.id_for_label }}">{{ form.logotipo.label }}</label>
+<div class="mb-3 text-center bg-dark p-3 rounded">
+  <div class="avatar-dropzone avatar-dropzone-square p-3">
+    {{ form.logotipo }}
+    <div class="avatar-preview">
+      <div class="avatar-dropzone-msg p-3">
+        <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+        <span>Arrastra una imagen o haz click</span>
+      </div>
+    </div>
+  </div>
   {% if form.logotipo.errors %}
   <div class="invalid-feedback d-block">{{ form.logotipo.errors.as_text|striptags }}</div>
   {% endif %}

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -21,7 +21,7 @@
                        name="current_step"
                        id="current-step"
                        value="{{ start_step }}">
-                <div id="step1" class="step">
+                <div id="step1" class="form-step active">
                     <p class="text-muted text-center">Indícanos qué tipo de profesional eres.</p>
                     <div class="d-flex justify-content-center flex-wrap gap-3">
                         {% for radio in form.tipo %}
@@ -35,7 +35,7 @@
                         <div class="invalid-feedback d-block">{{ form.tipo.errors.as_text|striptags }}</div>
                     {% endif %}
                 </div>
-                <div id="step2" class="step d-none">
+                <div id="step2" class="form-step">
                     <h1 class="text-center mb-3">Nuestros Planes</h1>
                     <p class="text-center text-muted mb-5">
                         Elige la opción que mejor se adapte a tus necesidades y comienza a destacar en nuestro directorio.
@@ -72,15 +72,15 @@
                         <div class="invalid-feedback d-block">{{ form.plan.errors.as_text|striptags }}</div>
                     {% endif %}
                 </div>
-                <div id="step3" class="step d-none">
+                <div id="step3" class="form-step">
                     <p class="text-muted">Rellena la información de tu perfil.</p>
                     {% include 'core/_pro_register_form.html' with form=pro_form %}
                 </div>
-                <div id="step4" class="step d-none">
+                <div id="step4" class="form-step">
                     <p class="text-muted">Datos adicionales obligatorios para completar tu perfil.</p>
                     {% include 'core/_pro_extra_form.html' with form=extra_form %}
                 </div>
-                <div id="step5" class="step d-none text-center">
+                <div id="step5" class="form-step text-center">
                     <h1 class="h5 mb-3">Pasarela de pagos</h1>
                     <p class="text-muted mb-4">Conecta con Stripe para habilitar los cobros.</p>
                     <button type="button" class="btn btn-primary" id="stripe-connect-btn">Conectar con Stripe</button>
@@ -100,6 +100,7 @@
         window.stripePublicKey = "{{ stripe_public_key }}";
     </script>
     <script src="https://js.stripe.com/v3/"></script>
+    <script src="{% static 'js/avatar-dropzone.js' %}"></script>
     <script src="{% static 'js/member-location.js' %}"></script>
     <script src="{% static 'js/pro-registro.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- animate registration steps with a fade-in effect
- allow logo upload via drag-and-drop in step 4
- load avatar dropzone script during professional registration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a924a28744832188786e485c6ed47e