### PR TITLE
Refine pro registration fields and logo upload

### DIFF
--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -43,14 +43,14 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
         label="Fecha de nacimiento", widget=forms.DateInput(attrs={"type": "date"})
     )
     dni = forms.CharField(label="DNI/NIE/CIF")
-    prefijo = forms.CharField(label="Prefijo", required=False)
+    prefijo = forms.CharField(label="Prefijo")
     telefono = forms.CharField(label="Teléfono")
     sexo = forms.ChoiceField(
         label="Sexo",
         choices=[
+            ("", ""),
             ("hombre", "Hombre"),
             ("mujer", "Mujer"),
-            ("otro", "Otro"),
         ],
     )
 
@@ -61,7 +61,7 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
     ciudad = forms.CharField(label="Ciudad")
     calle = forms.CharField(label="Calle")
     numero = forms.CharField(label="Número")
-    puerta = forms.CharField(label="Puerta")
+    puerta = forms.CharField(label="Puerta", required=False)
     codigo_postal = forms.CharField(label="Código Postal")
 
     def __init__(self, *args, **kwargs):
@@ -125,7 +125,7 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
 
 class ProExtraForm(UniformFieldsMixin, forms.Form):
     """Datos adicionales requeridos para completar el perfil profesional."""
-
-    descripcion = forms.CharField(label="Sobre ti", widget=forms.Textarea)
     logotipo = forms.ImageField(label="Logotipo")
+    username = forms.CharField(label="Nombre de usuario")
+    descripcion = forms.CharField(label="Sobre ti", widget=forms.Textarea)
 

--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -32,7 +32,7 @@ def registro_profesional(request):
 
     start_step = 1
     pro_form = ProRegisterForm()
-    extra_form = ProExtraForm()
+    extra_form = ProExtraForm(initial={"username": request.user.username})
 
     if request.method == "POST":
         form = RegistroProfesionalForm(request.POST)

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -1,5 +1,27 @@
 <h3 class="h6 mb-3">Datos adicionales</h3>
 <div class="form-field mb-3">
+  <div class="avatar-dropzone mx-auto">
+    {{ form.logotipo }}
+    <div class="avatar-preview">
+      <div class="avatar-dropzone-msg">
+        <i class="bi bi-cloud-upload mb-1 fs-4"></i>
+        <span>Sube {{ form.logotipo.label|lower }}</span>
+      </div>
+    </div>
+  </div>
+  {% if form.logotipo.errors %}
+  <div class="invalid-feedback d-block">{{ form.logotipo.errors.as_text|striptags }}</div>
+  {% endif %}
+</div>
+<div class="form-field mb-3">
+  {{ form.username }}
+  <button type="button" class="clear-btn bi bi-x"></button>
+  <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
+  {% if form.username.errors %}
+  <div class="invalid-feedback d-block">{{ form.username.errors.as_text|striptags }}</div>
+  {% endif %}
+</div>
+<div class="form-field">
   {{ form.descripcion }}
   <button type="button" class="clear-btn bi bi-x"></button>
   <label for="{{ form.descripcion.id_for_label }}">{{ form.descripcion.label }}</label>
@@ -7,11 +29,4 @@
   <div class="invalid-feedback d-block">{{ form.descripcion.errors.as_text|striptags }}</div>
   {% endif %}
 </div>
-<div class="form-field">
-  {{ form.logotipo }}
-  <button type="button" class="clear-btn bi bi-x"></button>
-  <label for="{{ form.logotipo.id_for_label }}">{{ form.logotipo.label }}</label>
-  {% if form.logotipo.errors %}
-  <div class="invalid-feedback d-block">{{ form.logotipo.errors.as_text|striptags }}</div>
-  {% endif %}
-</div>
+

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -101,5 +101,6 @@
     </script>
     <script src="https://js.stripe.com/v3/"></script>
     <script src="{% static 'js/member-location.js' %}"></script>
+    <script src="{% static 'js/avatar-dropzone.js' %}"></script>
     <script src="{% static 'js/pro-registro.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Make pro registration fields mandatory except for door and remove "other" from sex choices
- Add username confirmation and drag-and-drop logo upload in step 4
- Load avatar-dropzone script for new logo drag-and-drop

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a927c912c88321946d484ddee4b68d