### PR TITLE
Improve pro registration workflow

### DIFF
--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -126,6 +126,14 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
 class ProExtraForm(UniformFieldsMixin, forms.Form):
     """Datos adicionales requeridos para completar el perfil profesional."""
     logotipo = forms.ImageField(label="Logotipo")
-    username = forms.CharField(label="Nombre de usuario")
+    username = forms.CharField(
+        label="Nombre de usuario",
+        min_length=3,
+        error_messages={
+            "required": "Rellene este campo",
+            "min_length": "El nombre de usuario debe tener al menos 3 caracteres",
+        },
+        widget=forms.TextInput(attrs={"minlength": 3, "placeholder": " "}),
+    )
     descripcion = forms.CharField(label="Sobre ti", widget=forms.Textarea)
 

--- a/static/css/registro_pro.css
+++ b/static/css/registro_pro.css
@@ -49,3 +49,18 @@
   background:#000;
   color: white;
 }
+
+.fade-step {
+  animation: fadeIn .4s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const tipoCards = document.querySelectorAll('.tipo-card');
   const planCards = document.querySelectorAll('.plan-card');
   const paymentSection = document.getElementById('payment-section');
+  const cardInputs = ['id_card_number', 'id_card_expiry', 'id_card_cvc'].map(id => document.getElementById(id));
   const nextBtn = document.getElementById('nextBtn');
   const prevBtn = document.getElementById('prevBtn');
   const finishBtn = document.getElementById('finishBtn');
@@ -14,7 +15,13 @@ document.addEventListener('DOMContentLoaded', () => {
   function showStep(n) {
     steps.forEach((step, idx) => {
       if (!step) return;
-      step.classList.toggle('d-none', idx !== n - 1);
+      if (idx === n - 1) {
+        step.classList.remove('d-none');
+        step.classList.add('fade-step');
+        step.addEventListener('animationend', () => step.classList.remove('fade-step'), { once: true });
+      } else {
+        step.classList.add('d-none');
+      }
     });
     progress.forEach((item, idx) => {
       if (!item) return;
@@ -27,8 +34,25 @@ document.addEventListener('DOMContentLoaded', () => {
     if (finishBtn) finishBtn.classList.toggle('d-none', n !== steps.length);
   }
 
+  function validateStep(n) {
+    const step = steps[n - 1];
+    if (!step) return true;
+    const fields = step.querySelectorAll('input, select, textarea');
+    for (const field of fields) {
+      if (!field.checkValidity()) {
+        field.reportValidity();
+        return false;
+      }
+    }
+    return true;
+  }
+
   if (nextBtn) {
-    nextBtn.addEventListener('click', () => showStep(Math.min(current + 1, steps.length)));
+    nextBtn.addEventListener('click', () => {
+      if (validateStep(current)) {
+        showStep(Math.min(current + 1, steps.length));
+      }
+    });
   }
 
   if (prevBtn) {
@@ -68,11 +92,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function togglePaymentSection() {
     const selected = document.querySelector('input[name="plan"]:checked');
-    if (selected && (selected.value === 'plata' || selected.value === 'oro')) {
-      paymentSection && paymentSection.classList.remove('d-none');
-    } else {
-      paymentSection && paymentSection.classList.add('d-none');
+    const needsPayment = selected && (selected.value === 'plata' || selected.value === 'oro');
+    if (paymentSection) {
+      paymentSection.classList.toggle('d-none', !needsPayment);
     }
+    cardInputs.forEach(input => {
+      if (!input) return;
+      if (needsPayment) {
+        input.setAttribute('required', 'required');
+      } else {
+        input.removeAttribute('required');
+      }
+    });
   }
 
   togglePaymentSection();

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -1,11 +1,11 @@
 <h3 class="h6 mb-3">Datos adicionales</h3>
-<div class="form-field mb-3">
-  <div class="avatar-dropzone mx-auto">
+<div class="mb-5 text-center bg-dark p-3 rounded w-100">
+  <div class="avatar-dropzone avatar-dropzone-square p-3">
     {{ form.logotipo }}
     <div class="avatar-preview">
-      <div class="avatar-dropzone-msg">
+      <div class="avatar-dropzone-msg p-3">
         <i class="bi bi-cloud-upload mb-1 fs-4"></i>
-        <span>Sube {{ form.logotipo.label|lower }}</span>
+        <span>Arrastra una imagen o haz click</span>
       </div>
     </div>
   </div>
@@ -13,8 +13,8 @@
   <div class="invalid-feedback d-block">{{ form.logotipo.errors.as_text|striptags }}</div>
   {% endif %}
 </div>
-<div class="form-field mb-3">
-  {{ form.username }}
+<div class="form-field always-active mb-3">
+  <input type="text" name="{{ form.username.name }}" value="{{ form.username.value|default_if_none:'' }}" class="form-control" id="{{ form.username.id_for_label }}" placeholder=" " minlength="3" required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
   <button type="button" class="clear-btn bi bi-x"></button>
   <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
   {% if form.username.errors %}


### PR DESCRIPTION
## Summary
- add fade-in animation and step validation to professional registration
- match step4 dropzone and username field with profile UX

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a929cde60c8321ae6a2a7f7cd75c5c