### PR TITLE
Fix professional registration validation and layout

### DIFF
--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -39,6 +39,19 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!step) return true;
     const fields = step.querySelectorAll('input, select, textarea');
     for (const field of fields) {
+      if (field.name === 'puerta') continue;
+      if (field.type === 'radio') {
+        const group = step.querySelectorAll(`input[name="${field.name}"]`);
+        if (![...group].some(r => r.checked)) {
+          group[0].reportValidity();
+          return false;
+        }
+        continue;
+      }
+      if (field.hasAttribute('required') && !field.value.trim()) {
+        field.reportValidity();
+        return false;
+      }
       if (!field.checkValidity()) {
         field.reportValidity();
         return false;

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -14,7 +14,7 @@
   {% endif %}
 </div>
 <div class="form-field always-active mb-3">
-  <input type="text" name="{{ form.username.name }}" value="{{ form.username.value|default_if_none:'' }}" class="form-control" id="{{ form.username.id_for_label }}" placeholder=" " minlength="3" required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
+  {{ form.username }}
   <button type="button" class="clear-btn bi bi-x"></button>
   <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
   {% if form.username.errors %}

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -58,10 +58,12 @@
                         <p class="text-muted mb-4">Conecta con Stripe para habilitar los cobros.</p>
                         <button type="button" class="btn btn-primary" id="stripe-connect-btn">Conectar con Stripe</button>
                     </div>
-                    <div class="d-flex justify-content-end mt-4">
-                        <button type="button" class="btn btn-outline-dark me-2 d-none" id="prevBtn">Atrás</button>
-                        <button type="button" class="btn btn-dark" id="nextBtn">Continuar</button>
-                        <button type="submit" class="btn btn-dark d-none" id="finishBtn">Finalizar</button>
+                    <div class="d-flex justify-content-between mt-4">
+                        <button type="button" class="btn btn-outline-dark d-none" id="prevBtn">Atrás</button>
+                        <div class="d-flex gap-2">
+                            <button type="button" class="btn btn-dark" id="nextBtn">Continuar</button>
+                            <button type="submit" class="btn btn-dark d-none" id="finishBtn">Finalizar</button>
+                        </div>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
## Summary
- align back button to the left and group navigation controls
- enforce step validation while skipping optional door field
- reuse profile-style username input in professional registration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a92c36de3c8321b8cc2fc3b7eb34b0