### PR TITLE
Align pro registration buttons and add username status

### DIFF
--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     # Registro de usuarios
     path('signup/', auth.register, name='signup'),
     path('register/', auth.register, name='register'),
+    path('check-username/', auth.check_username, name='check_username'),
     path('login/', LoginView.as_view(), name='login'),
     path('logout/', auth_views.LogoutView.as_view(next_page='/'), name='logout'),
     path('profile/', profile_views.profile, name='profile'),

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -5,6 +5,8 @@ from django.shortcuts import render, redirect
 from django.contrib.auth import login, authenticate
 from django.contrib.auth.views import LoginView as DjangoLoginView
 from django.conf import settings
+from django.http import JsonResponse
+from django.contrib.auth.models import User
 from ..forms import RegistroUsuarioForm, LoginForm
 from apps.core.services.email_service import send_welcome_email, send_confirmation_email
 
@@ -62,3 +64,9 @@ class LoginView(DjangoLoginView):
                 next_url = ref
         context['next_url'] = next_url or '/'
         return context
+
+
+def check_username(request):
+    username = request.GET.get('username', '').strip()
+    available = bool(username) and not User.objects.filter(username=username).exists()
+    return JsonResponse({'available': available})

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -158,6 +158,18 @@
   font-size: 1rem;
 }
 
+.profile-form .with-status .clear-btn {
+  right: 40px;
+}
+
+.profile-form .status-icon {
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1rem;
+}
+
 .profile-form textarea + .clear-btn {
   display: none !important;
 }

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -11,6 +11,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const prevBtn = document.getElementById('prevBtn');
   const finishBtn = document.getElementById('finishBtn');
   const stripeBtn = document.getElementById('stripe-connect-btn');
+  const usernameInput = document.getElementById('id_username');
+  const usernameStatus = document.getElementById('username-status');
 
   function showStep(n) {
     steps.forEach((step, idx) => {
@@ -122,5 +124,31 @@ document.addEventListener('DOMContentLoaded', () => {
   togglePaymentSection();
 
   showStep(current);
+
+  if (usernameInput && usernameStatus) {
+    let timer;
+    usernameInput.addEventListener('input', () => {
+      const username = usernameInput.value.trim();
+      clearTimeout(timer);
+      usernameStatus.classList.add('d-none');
+      usernameStatus.classList.remove('bi-person-check-fill', 'text-success', 'bi-person-x-fill', 'text-danger');
+      if (!username) {
+        return;
+      }
+      timer = setTimeout(() => {
+        fetch(`/users/check-username/?username=${encodeURIComponent(username)}`)
+          .then(res => res.json())
+          .then(data => {
+            usernameStatus.classList.remove('d-none');
+            if (data.available) {
+              usernameStatus.classList.add('bi-person-check-fill', 'text-success');
+            } else {
+              usernameStatus.classList.add('bi-person-x-fill', 'text-danger');
+            }
+          })
+          .catch(() => {});
+      }, 300);
+    });
+  }
 });
 

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -13,9 +13,10 @@
   <div class="invalid-feedback d-block">{{ form.logotipo.errors.as_text|striptags }}</div>
   {% endif %}
 </div>
-<div class="form-field always-active mb-3">
+<div class="form-field always-active mb-3 with-status">
   {{ form.username }}
   <button type="button" class="clear-btn bi bi-x"></button>
+  <i id="username-status" class="status-icon bi d-none"></i>
   <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
   {% if form.username.errors %}
   <div class="invalid-feedback d-block">{{ form.username.errors.as_text|striptags }}</div>

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -58,9 +58,9 @@
                         <p class="text-muted mb-4">Conecta con Stripe para habilitar los cobros.</p>
                         <button type="button" class="btn btn-primary" id="stripe-connect-btn">Conectar con Stripe</button>
                     </div>
-                    <div class="d-flex justify-content-between mt-4">
+                    <div class="d-flex mt-4">
                         <button type="button" class="btn btn-outline-dark d-none" id="prevBtn">Atrás</button>
-                        <div class="d-flex gap-2">
+                        <div class="ms-auto d-flex gap-2">
                             <button type="button" class="btn btn-dark" id="nextBtn">Continuar</button>
                             <button type="submit" class="btn btn-dark d-none" id="finishBtn">Finalizar</button>
                         </div>


### PR DESCRIPTION
## Summary
- Keep "Continuar" and "Finalizar" buttons aligned to the right in professional registration flow
- Show username availability with green check or red x icon and new `/users/check-username/` endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a92fb16b9c83218297383710fc7cba