### PR TITLE
Display username availability with icons

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -257,3 +257,16 @@ input[type="checkbox"] {
   background-color: #000;
   border-color: #000;
 }
+
+/* Username availability status icon */
+.form-field.with-status .clear-btn {
+  right: 40px;
+}
+
+.form-field .status-icon {
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1rem;
+}

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -11,8 +11,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const prevBtn = document.getElementById('prevBtn');
   const finishBtn = document.getElementById('finishBtn');
   const stripeBtn = document.getElementById('stripe-connect-btn');
-  const usernameInput = document.getElementById('id_username');
-  const usernameStatus = document.getElementById('username-status');
 
   function showStep(n) {
     steps.forEach((step, idx) => {
@@ -124,31 +122,5 @@ document.addEventListener('DOMContentLoaded', () => {
   togglePaymentSection();
 
   showStep(current);
-
-  if (usernameInput && usernameStatus) {
-    let timer;
-    usernameInput.addEventListener('input', () => {
-      const username = usernameInput.value.trim();
-      clearTimeout(timer);
-      usernameStatus.classList.add('d-none');
-      usernameStatus.classList.remove('bi-person-check-fill', 'text-success', 'bi-person-x-fill', 'text-danger');
-      if (!username) {
-        return;
-      }
-      timer = setTimeout(() => {
-        fetch(`/users/check-username/?username=${encodeURIComponent(username)}`)
-          .then(res => res.json())
-          .then(data => {
-            usernameStatus.classList.remove('d-none');
-            if (data.available) {
-              usernameStatus.classList.add('bi-person-check-fill', 'text-success');
-            } else {
-              usernameStatus.classList.add('bi-person-x-fill', 'text-danger');
-            }
-          })
-          .catch(() => {});
-      }, 300);
-    });
-  }
 });
 

--- a/static/js/username-check.js
+++ b/static/js/username-check.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const inputs = document.querySelectorAll('input[name="username"], input[id="id_username"]');
+  inputs.forEach(input => {
+    const wrapper = input.closest('.form-field');
+    const statusIcon = wrapper ? wrapper.querySelector('.status-icon') : null;
+    if (!statusIcon) return;
+    let timer;
+    input.addEventListener('input', () => {
+      const username = input.value.trim();
+      clearTimeout(timer);
+      statusIcon.classList.add('d-none');
+      statusIcon.classList.remove('bi-check-circle', 'text-success', 'bi-x-circle', 'text-danger');
+      if (!username) return;
+      timer = setTimeout(() => {
+        fetch(`/users/check-username/?username=${encodeURIComponent(username)}`)
+          .then(res => res.json())
+          .then(data => {
+            statusIcon.classList.remove('d-none');
+            if (data.available) {
+              statusIcon.classList.add('bi-check-circle', 'text-success');
+            } else {
+              statusIcon.classList.add('bi-x-circle', 'text-danger');
+            }
+          })
+          .catch(() => {});
+      }, 300);
+    });
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -46,6 +46,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{% static 'js/page-loader.js' %}"></script>
 <script src="{% static 'js/clear-input.js' %}"></script>
+<script src="{% static 'js/username-check.js' %}"></script>
 <script src="{% static 'js/select-label.js' %}"></script>
 <script src="https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.19/build/js/intlTelInput.min.js"></script>
 <script src="{% static 'js/phone-prefix.js' %}"></script>

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -16,7 +16,7 @@
 <div class="form-field always-active mb-3 with-status">
   {{ form.username }}
   <button type="button" class="clear-btn bi bi-x"></button>
-  <i id="username-status" class="status-icon bi d-none"></i>
+  <i class="status-icon bi d-none"></i>
   <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
   {% if form.username.errors %}
   <div class="invalid-feedback d-block">{{ form.username.errors.as_text|striptags }}</div>

--- a/templates/partials/_login-form.html
+++ b/templates/partials/_login-form.html
@@ -4,7 +4,7 @@
                 <input type="hidden" name="next" value="{{ next_url }}">
                 {% csrf_token %}
 
-                <div class="form-field">
+                <div class="form-field with-status">
                     <input type="text"
                            name="{{ form.username.name }}"
                            value="{{ form.username.value|default_if_none:'' }}"
@@ -13,6 +13,7 @@
                            placeholder=" "
                            required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
                     <button type="button" class="clear-btn bi bi-x"></button>
+                    <i class="status-icon bi d-none"></i>
                     <label for="{{ form.username.id_for_label }}">Nombre de usuario o correo electrónico</label>
                     {% if form.username.errors %}
                       <div class="invalid-feedback d-block">

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -45,5 +45,6 @@
 <script src="{% static 'js/page-loader.js' %}"></script>
 <script src="{% static 'js/clear-input.js' %}"></script>
 <script src="{% static 'js/toggle-password.js' %}"></script>
+<script src="{% static 'js/username-check.js' %}"></script>
 </body>
 </html>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -60,9 +60,10 @@
                             </div>
                         {% endif %}
                         <div class="row g-3">
-                            <div class="form-field always-active">
+                            <div class="form-field always-active with-status">
                                 {{ form.username }}
                                 <button type="button" class="clear-btn bi bi-x"></button>
+                                <i class="status-icon bi d-none"></i>
                                 <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
                             </div>
                         </div>

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -51,9 +51,10 @@
             {{ form.non_field_errors }}
 
           <!-- Username -->
-<div class="form-field always-active">
+<div class="form-field always-active with-status">
     <input type="text" name="{{ form.username.name }}" value="{{ form.username.value|default_if_none:'' }}" class="form-control" id="{{ form.username.id_for_label }}" placeholder=" " minlength="3" required oninvalid="this.setCustomValidity('Rellene este campo')" oninput="setCustomValidity('')">
     <button type="button" class="clear-btn bi bi-x"></button>
+    <i class="status-icon bi d-none"></i>
     <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
     {% if form.username.errors %}
       <div class="invalid-feedback d-block">
@@ -137,9 +138,10 @@
   </main>
 </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="{% static 'js/page-loader.js' %}"></script>
-  <script src="{% static 'js/clear-input.js' %}"></script>
-  <script src="{% static 'js/toggle-password.js' %}"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{% static 'js/page-loader.js' %}"></script>
+<script src="{% static 'js/clear-input.js' %}"></script>
+<script src="{% static 'js/toggle-password.js' %}"></script>
+<script src="{% static 'js/username-check.js' %}"></script>
   </body>
   </html>


### PR DESCRIPTION
## Summary
- show green check or red cross next to username inputs depending on availability
- add markup and styles for status icons across registration, login, profile and pro forms
- streamline pro registration script and include global username checker

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a933d0696083219e998b418112ade9