### PR TITLE
Fix username icons and birthdate validation

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -375,7 +375,11 @@ class CompetidorForm(UniformFieldsMixin, forms.ModelForm):
         label='Altura (cm)',
         min_value=0,
     )
-    fecha_nacimiento = forms.DateField(required=False, label='Fecha de nacimiento')
+    fecha_nacimiento = forms.DateField(
+        required=False,
+        label='Fecha de nacimiento',
+        widget=forms.DateInput(attrs={'type': 'date', 'min': '1910-01-01'}),
+    )
     tipo_competidor = forms.ChoiceField(
         choices=[('', ''), ('amateur', 'Amateur'), ('profesional', 'Profesional')],
         required=False,
@@ -421,6 +425,7 @@ class CompetidorForm(UniformFieldsMixin, forms.ModelForm):
         fecha_field = self.fields.get('fecha_nacimiento')
         if fecha_field:
             fecha_field.widget.input_type = 'date'
+            fecha_field.widget.attrs.setdefault('min', '1910-01-01')
 
         palmares_field = self.fields.get('palmares')
         if palmares_field:
@@ -463,6 +468,12 @@ class CompetidorForm(UniformFieldsMixin, forms.ModelForm):
         if avatar_widget:
             css = avatar_widget.widget.attrs.get('class', '')
             avatar_widget.widget.attrs['class'] = (css + ' d-none').strip()
+
+    def clean_fecha_nacimiento(self):
+        fecha = self.cleaned_data.get('fecha_nacimiento')
+        if fecha and fecha.year < 1910:
+            raise forms.ValidationError('La fecha de nacimiento no puede ser anterior a 1910.')
+        return fecha
 
     def save(self, commit=True):
         wins = self.cleaned_data.get('victorias') or 0
@@ -579,6 +590,7 @@ class MiembroForm(UniformFieldsMixin, forms.ModelForm):
         fecha_widget = self.fields.get('fecha_nacimiento')
         if fecha_widget:
             fecha_widget.widget.input_type = 'date'
+            fecha_widget.widget.attrs.setdefault('min', '1910-01-01')
 
         sexo_field = self.fields.get('sexo')
         if sexo_field: 
@@ -653,6 +665,12 @@ class MiembroForm(UniformFieldsMixin, forms.ModelForm):
         elif not region:
             cleaned['localidad'] = ''
         return cleaned
+
+    def clean_fecha_nacimiento(self):
+        fecha = self.cleaned_data.get('fecha_nacimiento')
+        if fecha and fecha.year < 1910:
+            raise forms.ValidationError('La fecha de nacimiento no puede ser anterior a 1910.')
+        return fecha
 
     def clean_telefono(self):
         telefono = self.cleaned_data.get('telefono', '')

--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -40,7 +40,8 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
     nombre = forms.CharField(label="Nombre")
     apellidos = forms.CharField(label="Apellidos")
     fecha_nacimiento = forms.DateField(
-        label="Fecha de nacimiento", widget=forms.DateInput(attrs={"type": "date"})
+        label="Fecha de nacimiento",
+        widget=forms.DateInput(attrs={"type": "date", "min": "1910-01-01"}),
     )
     dni = forms.CharField(label="DNI/NIE/CIF")
     prefijo = forms.CharField(label="Prefijo")
@@ -121,6 +122,12 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
             if digits and digits[0] not in '679':
                 raise forms.ValidationError('Introduce un número de teléfono válido')
         return digits
+
+    def clean_fecha_nacimiento(self):
+        fecha = self.cleaned_data['fecha_nacimiento']
+        if fecha and fecha.year < 1910:
+            raise forms.ValidationError('La fecha de nacimiento no puede ser anterior a 1910.')
+        return fecha
 
 
 class ProExtraForm(UniformFieldsMixin, forms.Form):

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -46,10 +46,11 @@
 .tipo-card {
   border: 1px solid #dee2e6;
   border-radius: 0.25rem;
-  padding: 1rem;
+  padding: 2rem;
   cursor: pointer;
   text-align: center;
   position: relative;
+  flex: 0 0 calc(25% - 1rem);
 }
 
 .tipo-card input[type="radio"] {

--- a/static/js/username-check.js
+++ b/static/js/username-check.js
@@ -1,9 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
   const inputs = document.querySelectorAll('input[name="username"], input[id="id_username"]');
   inputs.forEach(input => {
-    const wrapper = input.closest('.form-field');
-    const statusIcon = wrapper ? wrapper.querySelector('.status-icon') : null;
-    if (!statusIcon) return;
+    const wrapper = input.closest('.form-field') || input.parentElement;
+    let statusIcon = wrapper.querySelector('.status-icon');
+    if (!statusIcon) {
+      statusIcon = document.createElement('i');
+      statusIcon.className = 'status-icon bi d-none';
+      wrapper.appendChild(statusIcon);
+    }
     let timer;
     input.addEventListener('input', () => {
       const username = input.value.trim();


### PR DESCRIPTION
## Summary
- ensure username availability icons appear for all username inputs
- reject birth dates before 1910 and set minimum date attributes
- enlarge step-one cards to occupy four columns

## Testing
- `python manage.py test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9361fe1408321b4ad667ab2138bc1