### PR TITLE
Restrict username characters and improve availability feedback

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -8,6 +8,7 @@ from apps.core.mixins import UniformFieldsMixin
 from .spain import REGION_CHOICES
 from .countries import COUNTRY_CHOICES
 import re
+from django.core.validators import RegexValidator
 
 class LoginForm(UniformFieldsMixin, AuthenticationForm):
     username = forms.CharField(
@@ -22,6 +23,17 @@ class LoginForm(UniformFieldsMixin, AuthenticationForm):
 
 class RegistroUsuarioForm(UniformFieldsMixin, UserCreationForm):
     email = forms.EmailField(label='Correo electrónico', required=True)
+    username = forms.CharField(
+        label='Nombre de usuario',
+        min_length=3,
+        validators=[RegexValidator(r'^[A-Za-z0-9_-]+$', 'El nombre de usuario solo puede contener letras, números, guiones y guiones bajos.')],
+        error_messages={
+            'required': 'Rellene este campo',
+            'min_length': 'El nombre de usuario debe tener al menos 3 caracteres',
+            'invalid': 'El nombre de usuario solo puede contener letras, números, guiones y guiones bajos.'
+        },
+        widget=forms.TextInput(attrs={'minlength':3, 'pattern':'^[A-Za-z0-9_-]+$'})
+    )
 
     class Meta:
         model = User

--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -3,6 +3,7 @@ import re
 from apps.core.mixins import UniformFieldsMixin
 from apps.clubs.countries import COUNTRY_CHOICES
 from apps.clubs.spain import REGION_CHOICES
+from django.core.validators import RegexValidator
 
 class TipoUsuarioForm(UniformFieldsMixin, forms.Form):
     tipo = forms.ChoiceField(
@@ -136,11 +137,13 @@ class ProExtraForm(UniformFieldsMixin, forms.Form):
     username = forms.CharField(
         label="Nombre de usuario",
         min_length=3,
+        validators=[RegexValidator(r'^[A-Za-z0-9_-]+$', 'El nombre de usuario solo puede contener letras, números, guiones y guiones bajos.')],
         error_messages={
             "required": "Rellene este campo",
             "min_length": "El nombre de usuario debe tener al menos 3 caracteres",
+            "invalid": "El nombre de usuario solo puede contener letras, números, guiones y guiones bajos.",
         },
-        widget=forms.TextInput(attrs={"minlength": 3, "placeholder": " "}),
+        widget=forms.TextInput(attrs={"minlength": 3, "placeholder": " ", "pattern": '^[A-Za-z0-9_-]+$'}),
     )
     descripcion = forms.CharField(label="Sobre ti", widget=forms.Textarea)
 

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -7,6 +7,7 @@ from django.contrib.auth import password_validation
 from django.utils.translation import gettext_lazy as _
 from .models import Profile
 from apps.core.mixins import UniformFieldsMixin
+from django.core.validators import RegexValidator
 import os
 import re
 
@@ -73,17 +74,19 @@ class LoginForm(UniformFieldsMixin, AuthenticationForm):
         super().__init__(*args, **kwargs)
         # Mark "recordar contraseña" checked by default
         self.fields["remember_me"].initial = True
- 
+
 class RegistroUsuarioForm(UniformFieldsMixin, UserCreationForm):
     email = forms.EmailField(label='Correo electrónico', required=True, error_messages={"required": "Rellene este campo"})
     username = forms.CharField(
         label='Nombre de usuario',
         min_length=3,
+        validators=[RegexValidator(r'^[A-Za-z0-9_-]+$', 'El nombre de usuario solo puede contener letras, números, guiones y guiones bajos.')],
         error_messages={
             'required': 'Rellene este campo',
-            'min_length': 'El nombre de usuario debe tener al menos 3 caracteres'
+            'min_length': 'El nombre de usuario debe tener al menos 3 caracteres',
+            'invalid': 'El nombre de usuario solo puede contener letras, números, guiones y guiones bajos.'
         },
-        widget=forms.TextInput(attrs={'minlength': 3})
+        widget=forms.TextInput(attrs={'minlength': 3, 'pattern': '^[A-Za-z0-9_-]+$'})
     )
 
     notifications = forms.BooleanField(
@@ -158,11 +161,13 @@ class AccountForm(UniformFieldsMixin, forms.ModelForm):
     username = forms.CharField(
         label='Nombre de usuario',
         min_length=3,
+        validators=[RegexValidator(r'^[A-Za-z0-9_-]+$', 'El nombre de usuario solo puede contener letras, números, guiones y guiones bajos.')],
         error_messages={
             'required': 'Rellene este campo',
-            'min_length': 'El nombre de usuario debe tener al menos 3 caracteres'
+            'min_length': 'El nombre de usuario debe tener al menos 3 caracteres',
+            'invalid': 'El nombre de usuario solo puede contener letras, números, guiones y guiones bajos.'
         },
-        widget=forms.TextInput(attrs={'minlength': 3})
+        widget=forms.TextInput(attrs={'minlength': 3, 'pattern': '^[A-Za-z0-9_-]+$'})
     )
     notifications = forms.BooleanField(
         label='Recibir notificaciones', required=False

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -9,6 +9,7 @@ from django.http import JsonResponse
 from django.contrib.auth.models import User
 from ..forms import RegistroUsuarioForm, LoginForm
 from apps.core.services.email_service import send_welcome_email, send_confirmation_email
+import re
 
 
 def register(request):
@@ -68,5 +69,7 @@ class LoginView(DjangoLoginView):
 
 def check_username(request):
     username = request.GET.get('username', '').strip()
-    available = bool(username) and not User.objects.filter(username=username).exists()
+    pattern = r'^[A-Za-z0-9_-]+$'
+    is_valid = bool(re.fullmatch(pattern, username))
+    available = is_valid and not User.objects.filter(username=username).exists()
     return JsonResponse({'available': available})

--- a/static/js/username-check.js
+++ b/static/js/username-check.js
@@ -15,6 +15,12 @@ document.addEventListener('DOMContentLoaded', () => {
       statusIcon.classList.add('d-none');
       statusIcon.classList.remove('bi-check-circle', 'text-success', 'bi-x-circle', 'text-danger');
       if (!username) return;
+      const pattern = /^[A-Za-z0-9_-]+$/;
+      if (!pattern.test(username)) {
+        statusIcon.classList.remove('d-none');
+        statusIcon.classList.add('bi-x-circle', 'text-danger');
+        return;
+      }
       timer = setTimeout(() => {
         fetch(`/users/check-username/?username=${encodeURIComponent(username)}`)
           .then(res => res.json())


### PR DESCRIPTION
## Summary
- Validate usernames to only allow letters, numbers, dashes and underscores across registration and profile forms
- Harden username availability check with server-side pattern validation
- Show immediate red/green icons for username availability and validity

## Testing
- `pytest` *(fails: No module named 'stripe')*
- `pip install stripe` *(fails: Could not find a version that satisfies the requirement stripe)*

------
https://chatgpt.com/codex/tasks/task_e_68a9409bf8ec8321bd0d011f4f43466a