### PR TITLE
Ensure username availability check validates format and length

### DIFF
--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -69,7 +69,7 @@ class LoginView(DjangoLoginView):
 
 def check_username(request):
     username = request.GET.get('username', '').strip()
-    pattern = r'^[A-Za-z0-9_-]+$'
+    pattern = r'^[A-Za-z0-9_-]{3,}$'
     is_valid = bool(re.fullmatch(pattern, username))
     available = is_valid and not User.objects.filter(username=username).exists()
     return JsonResponse({'available': available})

--- a/static/js/username-check.js
+++ b/static/js/username-check.js
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
       statusIcon.classList.add('d-none');
       statusIcon.classList.remove('bi-check-circle', 'text-success', 'bi-x-circle', 'text-danger');
       if (!username) return;
-      const pattern = /^[A-Za-z0-9_-]+$/;
+      const pattern = /^[A-Za-z0-9_-]{3,}$/;
       if (!pattern.test(username)) {
         statusIcon.classList.remove('d-none');
         statusIcon.classList.add('bi-x-circle', 'text-danger');


### PR DESCRIPTION
## Summary
- enforce 3+ character usernames in availability endpoint
- show availability indicator only for valid usernames

## Testing
- `pytest` *(fails: No module named 'stripe')*

------
https://chatgpt.com/codex/tasks/task_e_68a9435c226883218f847c1536e2730e