### PR TITLE
Ensure username availability check applies to all username fields

### DIFF
--- a/static/js/username-check.js
+++ b/static/js/username-check.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const inputs = document.querySelectorAll('input[name="username"], input[id="id_username"]');
+  const inputs = document.querySelectorAll('input[name*="username"], input[id*="username"]');
   inputs.forEach(input => {
     const wrapper = input.closest('.form-field') || input.parentElement;
     let statusIcon = wrapper.querySelector('.status-icon');


### PR DESCRIPTION
## Summary
- Expand username field selector so availability status works on any input with `username` in its name or id

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9454f55288321b1b32efb8d6c1f88