### PR TITLE
Show username availability status icon by default

### DIFF
--- a/apps/users/tests/test_check_username.py
+++ b/apps/users/tests/test_check_username.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+
+class CheckUsernameTests(TestCase):
+    def setUp(self):
+        self.url = reverse('check_username')
+        self.user = User.objects.create_user(username='existing', password='pass')
+
+    def test_available_for_new_username(self):
+        response = self.client.get(self.url, {'username': 'unique'})
+        self.assertEqual(response.json(), {'available': True})
+
+    def test_unavailable_for_taken_username(self):
+        response = self.client.get(self.url, {'username': 'existing'})
+        self.assertEqual(response.json(), {'available': False})
+
+    def test_current_user_username_is_available(self):
+        self.client.login(username='existing', password='pass')
+        response = self.client.get(self.url, {'username': 'existing'})
+        self.assertEqual(response.json(), {'available': True})

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -71,5 +71,10 @@ def check_username(request):
     username = request.GET.get('username', '').strip()
     pattern = r'^[A-Za-z0-9_-]{3,}$'
     is_valid = bool(re.fullmatch(pattern, username))
-    available = is_valid and not User.objects.filter(username=username).exists()
+    available = False
+    if is_valid:
+        if request.user.is_authenticated and request.user.username == username:
+            available = True
+        else:
+            available = not User.objects.filter(username=username).exists()
     return JsonResponse({'available': available})

--- a/static/js/username-check.js
+++ b/static/js/username-check.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
       wrapper.appendChild(statusIcon);
     }
     let timer;
-    input.addEventListener('input', () => {
+    const runCheck = () => {
       const username = input.value.trim();
       clearTimeout(timer);
       statusIcon.classList.add('d-none');
@@ -34,6 +34,10 @@ document.addEventListener('DOMContentLoaded', () => {
           })
           .catch(() => {});
       }, 300);
-    });
+    };
+    input.addEventListener('input', runCheck);
+    if (input.value.trim()) {
+      runCheck();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Show username availability indicator for current value on forms and when editing
- Allow user to keep their current username without warning it is taken
- Add coverage for username availability API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa42426e0083219394a7ba84152b77