### PR TITLE
feat: show success icon for valid usernames

### DIFF
--- a/static/js/username-check.js
+++ b/static/js/username-check.js
@@ -21,14 +21,17 @@ document.addEventListener('DOMContentLoaded', () => {
         statusIcon.classList.add('bi-x-circle', 'text-danger');
         return;
       }
+      statusIcon.classList.remove('d-none');
+      statusIcon.classList.add('bi-check-circle', 'text-success');
       timer = setTimeout(() => {
         fetch(`/users/check-username/?username=${encodeURIComponent(username)}`)
           .then(res => res.json())
           .then(data => {
-            statusIcon.classList.remove('d-none');
             if (data.available) {
               statusIcon.classList.add('bi-check-circle', 'text-success');
+              statusIcon.classList.remove('bi-x-circle', 'text-danger');
             } else {
+              statusIcon.classList.remove('bi-check-circle', 'text-success');
               statusIcon.classList.add('bi-x-circle', 'text-danger');
             }
           })


### PR DESCRIPTION
## Summary
- display a green check icon when username pattern is valid
- keep green check when username is available, show red cross otherwise

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa4476799c8321b70016475798fc61