### PR TITLE
feat: show success icon for valid usernames

### DIFF
--- a/static/js/username-check.js
+++ b/static/js/username-check.js
@@ -21,18 +21,23 @@ document.addEventListener('DOMContentLoaded', () => {
         statusIcon.classList.add('bi-x-circle', 'text-danger');
         return;
       }
+      statusIcon.classList.remove('d-none');
+      statusIcon.classList.add('bi-check-circle', 'text-success');
       timer = setTimeout(() => {
         fetch(`/users/check-username/?username=${encodeURIComponent(username)}`)
           .then(res => res.json())
           .then(data => {
-            statusIcon.classList.remove('d-none');
+            statusIcon.classList.remove('bi-check-circle', 'text-success', 'bi-x-circle', 'text-danger');
             if (data.available) {
               statusIcon.classList.add('bi-check-circle', 'text-success');
             } else {
               statusIcon.classList.add('bi-x-circle', 'text-danger');
             }
           })
-          .catch(() => {});
+          .catch(() => {
+            statusIcon.classList.remove('bi-check-circle', 'text-success');
+            statusIcon.classList.add('bi-x-circle', 'text-danger');
+          });
       }, 300);
     });
   });


### PR DESCRIPTION
## Summary
- display a green check icon when username pattern is valid
- keep green check when username is available, show red cross otherwise

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa4476799c8321b70016475798fc61