### PR TITLE
Fix username availability icon behavior

### DIFF
--- a/static/js/username-check.js
+++ b/static/js/username-check.js
@@ -21,12 +21,11 @@ document.addEventListener('DOMContentLoaded', () => {
         statusIcon.classList.add('bi-x-circle', 'text-danger');
         return;
       }
-      statusIcon.classList.remove('d-none');
-      statusIcon.classList.add('bi-check-circle', 'text-success');
       timer = setTimeout(() => {
         fetch(`/users/check-username/?username=${encodeURIComponent(username)}`)
           .then(res => res.json())
           .then(data => {
+            statusIcon.classList.remove('d-none');
             if (data.available) {
               statusIcon.classList.add('bi-check-circle', 'text-success');
               statusIcon.classList.remove('bi-x-circle', 'text-danger');


### PR DESCRIPTION
## Summary
- show username availability icons only after server validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa4772ebc08321a6cf5ad222614526