### PR TITLE
Show success icon for all username checks

### DIFF
--- a/static/js/username-check.js
+++ b/static/js/username-check.js
@@ -24,15 +24,9 @@ document.addEventListener('DOMContentLoaded', () => {
       timer = setTimeout(() => {
         fetch(`/users/check-username/?username=${encodeURIComponent(username)}`)
           .then(res => res.json())
-          .then(data => {
+          .then(() => {
             statusIcon.classList.remove('d-none');
-            if (data.available) {
-              statusIcon.classList.add('bi-check-circle', 'text-success');
-              statusIcon.classList.remove('bi-x-circle', 'text-danger');
-            } else {
-              statusIcon.classList.remove('bi-check-circle', 'text-success');
-              statusIcon.classList.add('bi-x-circle', 'text-danger');
-            }
+            statusIcon.classList.add('bi-check-circle', 'text-success');
           })
           .catch(() => {});
       }, 300);


### PR DESCRIPTION
## Summary
- Simplify username availability script to always display the success icon

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa4a64f1b48321a5918ace243b6934