### PR TITLE
Allow feature selection during professional registration and enforce numeric address fields

### DIFF
--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -63,8 +63,17 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
     )
     ciudad = forms.CharField(label="Ciudad")
     calle = forms.CharField(label="Calle")
-    numero = forms.CharField(label="Número")
-    puerta = forms.CharField(label="Puerta", required=False)
+    numero = forms.IntegerField(
+        label="Número",
+        min_value=0,
+        widget=forms.NumberInput(),
+    )
+    puerta = forms.IntegerField(
+        label="Puerta",
+        required=False,
+        min_value=0,
+        widget=forms.NumberInput(),
+    )
     codigo_postal = forms.CharField(label="Código Postal")
 
     def __init__(self, *args, **kwargs):

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -39,7 +39,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!step) return true;
     const fields = step.querySelectorAll('input, select, textarea');
     for (const field of fields) {
-      if (field.name === 'puerta') continue;
       if (field.type === 'radio') {
         const group = step.querySelectorAll(`input[name="${field.name}"]`);
         if (![...group].some(r => r.checked)) {

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -75,5 +75,6 @@
     <script src="https://js.stripe.com/v3/"></script>
     <script src="{% static 'js/member-location.js' %}"></script>
     <script src="{% static 'js/avatar-dropzone.js' %}"></script>
+    <script src="{% static 'js/feature-select.js' %}"></script>
     <script src="{% static 'js/pro-registro.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Load feature-select script on professional registration to enable click or bulk selection
- Ensure address fields `numero` and `puerta` accept only numbers
- Validate all optional fields including `puerta` in registration flow

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa5bba67408321851e0c41d5fac327