### PR TITLE
Sync pro registration with user profile and dashboard

### DIFF
--- a/apps/core/test_registro_profesional.py
+++ b/apps/core/test_registro_profesional.py
@@ -1,0 +1,58 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.contrib.auth.models import User
+from apps.clubs.models import Feature, Club
+from io import BytesIO
+from PIL import Image
+import tempfile
+
+class RegistroProfesionalTests(TestCase):
+    def _create_image(self):
+        buf = BytesIO()
+        Image.new("RGB", (1, 1)).save(buf, format="JPEG")
+        buf.seek(0)
+        return SimpleUploadedFile("test.jpg", buf.read(), content_type="image/jpeg")
+
+    @override_settings(MEDIA_ROOT=tempfile.mkdtemp())
+    def test_entrenador_creates_club_and_updates_profile(self):
+        feature = Feature.objects.create(name="Ring")
+        user = User.objects.create_user(username="olduser", password="pass", email="old@example.com")
+        self.client.login(username="olduser", password="pass")
+
+        url = reverse("registro_profesional")
+        data = {
+            "tipo": "entrenador",
+            "plan": "oro",
+            "nombre": "Juan",
+            "apellidos": "Perez",
+            "fecha_nacimiento": "1990-01-01",
+            "dni": "12345678Z",
+            "prefijo": "+34",
+            "telefono": "612345678",
+            "sexo": "hombre",
+            "pais": "España",
+            "comunidad_autonoma": "Madrid",
+            "ciudad": "Madrid",
+            "calle": "Calle Falsa",
+            "numero": 1,
+            "puerta": 1,
+            "codigo_postal": "28001",
+            "username": "newuser",
+            "name": "Club Coach",
+            "about": "Algo",
+            "features": [str(feature.id)],
+            "logotipo": self._create_image(),
+        }
+
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+
+        user.refresh_from_db()
+        self.assertEqual(user.username, "newuser")
+        self.assertEqual(user.profile.plan, "oro")
+
+        club = Club.objects.get(owner=user)
+        self.assertEqual(club.category, "entrenador")
+        self.assertEqual(club.plan, "oro")
+        self.assertEqual(club.features.count(), 1)

--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -15,6 +15,7 @@ from ..forms import (
     ProExtraForm,
 )
 from ..utils.plans import PLANS
+from apps.clubs.models import Club
 
 
 def home(request):
@@ -51,6 +52,36 @@ def registro_profesional(request):
         extra_form = ProExtraForm(request.POST, request.FILES)
 
         if form.is_valid() and pro_form.is_valid() and extra_form.is_valid():
+            user = request.user
+            profile = user.profile
+            profile.plan = form.cleaned_data["plan"]
+            profile.save()
+
+            user.username = extra_form.cleaned_data["username"]
+            user.first_name = pro_form.cleaned_data["nombre"]
+            user.last_name = pro_form.cleaned_data["apellidos"]
+            user.save()
+
+            if form.cleaned_data["tipo"] == "entrenador":
+                club = Club.objects.create(
+                    owner=user,
+                    name=extra_form.cleaned_data["name"],
+                    about=extra_form.cleaned_data["about"],
+                    logo=extra_form.cleaned_data.get("logotipo"),
+                    prefijo=pro_form.cleaned_data.get("prefijo", ""),
+                    phone=pro_form.cleaned_data.get("telefono", ""),
+                    email=user.email,
+                    country=pro_form.cleaned_data.get("pais", ""),
+                    region=pro_form.cleaned_data.get("comunidad_autonoma", ""),
+                    city=pro_form.cleaned_data.get("ciudad", ""),
+                    street=pro_form.cleaned_data.get("calle", ""),
+                    number=pro_form.cleaned_data.get("numero"),
+                    door=pro_form.cleaned_data.get("puerta", ""),
+                    postal_code=pro_form.cleaned_data.get("codigo_postal", ""),
+                    category="entrenador",
+                    plan=form.cleaned_data["plan"],
+                )
+                club.features.set(extra_form.cleaned_data["features"])
             return render(request, "core/registro_pro_success.html")
         start_step = request.POST.get("current_step", 1)
     else:


### PR DESCRIPTION
## Summary
- Update professional registration to create a club and update the user's profile
- Add test ensuring entrenador registration saves club and plan

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa5edf29048321a1ad3431753018d8