### PR TITLE
Display feature forms based on role

### DIFF
--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -11,6 +11,19 @@ document.addEventListener('DOMContentLoaded', () => {
   const prevBtn = document.getElementById('prevBtn');
   const finishBtn = document.getElementById('finishBtn');
   const stripeBtn = document.getElementById('stripe-connect-btn');
+  const clubFeaturesForm = document.getElementById('club-feature-form');
+  const coachFeaturesForm = document.getElementById('coach-feature-form');
+
+  function updateFeatureForm() {
+    const selectedTipo = document.querySelector('input[name="tipo"]:checked');
+    const tipoVal = selectedTipo ? selectedTipo.value : null;
+    if (clubFeaturesForm) {
+      clubFeaturesForm.classList.toggle('d-none', tipoVal !== 'club');
+    }
+    if (coachFeaturesForm) {
+      coachFeaturesForm.classList.toggle('d-none', tipoVal !== 'entrenador');
+    }
+  }
 
   function showStep(n) {
     steps.forEach((step, idx) => {
@@ -32,6 +45,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (prevBtn) prevBtn.classList.toggle('d-none', n === 1);
     if (nextBtn) nextBtn.classList.toggle('d-none', n === steps.length);
     if (finishBtn) finishBtn.classList.toggle('d-none', n !== steps.length);
+    if (n === 4) {
+      updateFeatureForm();
+    }
   }
 
   function validateStep(n) {
@@ -92,6 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
     card.addEventListener('click', () => {
       input.checked = true;
       tipoCards.forEach(c => c.classList.toggle('active', c === card));
+      updateFeatureForm();
     });
   });
 
@@ -126,6 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
   togglePaymentSection();
 
   showStep(current);
+  updateFeatureForm();
 
   const coachContainer = document.getElementById('coaches-formset');
   const addCoachBtn = document.getElementById('add-coach-btn');

--- a/templates/clubs/dashboard.html
+++ b/templates/clubs/dashboard.html
@@ -135,7 +135,11 @@
               </div>
               <div class="col-lg-6 d-flex justify-content-end ps-5">
                 <!-- Features -->
-                {% include 'core/components/_club_features_form.html' %}
+                {% if club.category == 'entrenador' %}
+                  {% include 'core/components/_coach_feature_form.html' with form=form %}
+                {% else %}
+                  {% include 'core/components/_club_features_form.html' with form=form %}
+                {% endif %}
               </div>
             </div>
             <button type="submit" class="btn btn-dark mt-4">Guardar</button>
@@ -1053,7 +1057,11 @@
   {% endblock %}
   {% block extra_js %}
     <script src="{% static 'js/profile-tabs.js' %}"></script>
+    {% if club.category == 'entrenador' %}
+    <script src="{% static 'js/coach-feature-select.js' %}"></script>
+    {% else %}
     <script src="{% static 'js/feature-select.js' %}"></script>
+    {% endif %}
     <script src="{% static 'js/avatar-dropzone.js' %}"></script>
     <script src="{% static 'js/location-select.js' %}"></script>
     <script src="{% static 'js/member-location.js' %}"></script>

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -1,6 +1,6 @@
 <h3 class="h6 mb-3">Datos adicionales</h3>
 <div class="row g-3">
-  <div class="col-md-6">
+  <div class="col-12 col-md-6">
     <h4 class="mb-3">Logotipo</h4>
     <div class="mb-5 text-center bg-dark p-3 rounded w-100">
       <div class="avatar-dropzone avatar-dropzone-square p-3">
@@ -97,9 +97,5 @@
         </div>
       </div>
     </template>
-  </div>
-  <div class="col-md-6">
-    {% include 'core/components/_club_features_form.html' %}
-    {% include 'core/components/_coach_feature_form.html' %}
   </div>
 </div>

--- a/templates/core/components/_club_features_form.html
+++ b/templates/core/components/_club_features_form.html
@@ -13,13 +13,13 @@
     </div>
     <div class="d-flex flex-wrap gap-3" id="features-container">
         {% for feature in form.features.field.queryset %}
-            <div class="feature-option border rounded d-flex align-items-center {% if feature in club.features.all %}selected{% endif %}"
+            <div class="feature-option border rounded d-flex align-items-center {% if club and feature in club.features.all %}selected{% endif %}"
                  style="padding: 8px 16px">
                 <input type="checkbox"
                        name="features"
                        value="{{ feature.id }}"
                        class="d-none"
-                       {% if feature in club.features.all %}checked{% endif %}
+                       {% if club and feature in club.features.all %}checked{% endif %}
                        {% if forloop.first %}required{% endif %} />
                 {% if feature.icon %}
                     <img src="{{ feature.icon.url }}"

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -11,6 +11,7 @@
                     <li class="step-item" data-step="2" id="step-label-2"></li>
                     <li class="step-item" data-step="3" id="step-label-3"></li>
                     <li class="step-item" data-step="4" id="step-label-4"></li>
+                    <li class="step-item" data-step="5" id="step-label-5"></li>
                 </ul>
                 <form method="post" class="profile-form mt-5" enctype="multipart/form-data">
                     {% csrf_token %}
@@ -44,7 +45,15 @@
                     <div id="step3" class="step fade-step d-none">
                         {% include 'core/_pro_extra_form.html' with form=extra_form coach_formset=coach_formset %}
                     </div>
-                    <div id="step4" class="step fade-step d-none text-center">
+                    <div id="step4" class="step fade-step d-none">
+                        <div id="club-feature-form" class="d-none">
+                            {% include 'core/components/_club_features_form.html' with form=extra_form %}
+                        </div>
+                        <div id="coach-feature-form" class="d-none">
+                            {% include 'core/components/_coach_feature_form.html' with form=extra_form %}
+                        </div>
+                    </div>
+                    <div id="step5" class="step fade-step d-none text-center">
                         <h1 class="h5 mb-3">Pasarela de pagos</h1>
                         <p class="text-muted mb-4">Conecta con Stripe para habilitar los cobros.</p>
                         <button type="button" class="btn btn-primary" id="stripe-connect-btn">Conectar con Stripe</button>


### PR DESCRIPTION
## Summary
- Move feature selection to a new step in professional registration
- Toggle club or coach feature form depending on selected type
- Show matching feature form in dashboard and load corresponding script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa8d74d43c83219595b46dbb5bd8cb