### PR TITLE
Ajustes de registro para entrenadores

### DIFF
--- a/apps/core/test_registro_profesional.py
+++ b/apps/core/test_registro_profesional.py
@@ -2,7 +2,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth.models import User
-from apps.clubs.models import Feature, Club
+from apps.clubs.models import Feature, Club, CoachFeature
 from io import BytesIO
 from PIL import Image
 import tempfile
@@ -16,7 +16,7 @@ class RegistroProfesionalTests(TestCase):
 
     @override_settings(MEDIA_ROOT=tempfile.mkdtemp())
     def test_entrenador_creates_club_and_updates_profile(self):
-        feature = Feature.objects.create(name="Ring")
+        cfeature = CoachFeature.objects.create(name="Tecnica")
         user = User.objects.create_user(username="olduser", password="pass", email="old@example.com")
         self.client.login(username="olduser", password="pass")
 
@@ -39,10 +39,9 @@ class RegistroProfesionalTests(TestCase):
             "puerta": 1,
             "codigo_postal": "28001",
             "username": "newuser",
-            "name": "Club Coach",
             "about": "Algo",
-            "features": [str(feature.id)],
             "logotipo": self._create_image(),
+            "coach_features": [str(cfeature.id)],
         }
 
         response = self.client.post(url, data)
@@ -55,7 +54,8 @@ class RegistroProfesionalTests(TestCase):
         club = Club.objects.get(owner=user)
         self.assertEqual(club.category, "entrenador")
         self.assertEqual(club.plan, "oro")
-        self.assertEqual(club.features.count(), 1)
+        self.assertEqual(club.name, "Juan Perez")
+        self.assertEqual(club.coach_features.count(), 1)
         self.assertTrue(club.logo)
         self.assertTrue(club.profilepic)
 

--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -53,7 +53,12 @@ def registro_profesional(request):
         pro_form = ProRegisterForm(request.POST)
         extra_form = ProExtraForm(request.POST, request.FILES)
         coach_formset = CoachFormSet(request.POST, prefix="coaches")
-        if form.is_valid() and pro_form.is_valid() and extra_form.is_valid():
+        form_valid = form.is_valid()
+        if form_valid and form.cleaned_data["tipo"] == "entrenador":
+            extra_form.fields["name"].required = False
+            extra_form.fields["features"].required = False
+            extra_form.fields["coach_features"].required = True
+        if form_valid and pro_form.is_valid() and extra_form.is_valid():
             coach_valid = True
             if form.cleaned_data["tipo"] == "club":
                 coach_valid = coach_formset.is_valid()
@@ -69,9 +74,10 @@ def registro_profesional(request):
                 user.save()
 
                 if form.cleaned_data["tipo"] == "entrenador":
+                    club_name = f"{pro_form.cleaned_data['nombre']} {pro_form.cleaned_data['apellidos']}".strip()
                     club = Club.objects.create(
                         owner=user,
-                        name=extra_form.cleaned_data["name"],
+                        name=club_name,
                         about=extra_form.cleaned_data["about"],
                         logo=extra_form.cleaned_data.get("logotipo"),
                         profilepic=extra_form.cleaned_data.get("logotipo"),
@@ -88,8 +94,8 @@ def registro_profesional(request):
                         category="entrenador",
                         plan=form.cleaned_data["plan"],
                     )
-                    club.features.set(extra_form.cleaned_data["features"])
-                    club.coach_features.set(extra_form.cleaned_data["coach_features"])
+                    club.features.set(extra_form.cleaned_data.get("features"))
+                    club.coach_features.set(extra_form.cleaned_data.get("coach_features"))
                 elif form.cleaned_data["tipo"] == "club":
                     club = Club.objects.create(
                         owner=user,
@@ -110,8 +116,8 @@ def registro_profesional(request):
                         category="club",
                         plan=form.cleaned_data["plan"],
                     )
-                    club.features.set(extra_form.cleaned_data["features"])
-                    club.coach_features.set(extra_form.cleaned_data["coach_features"])
+                    club.features.set(extra_form.cleaned_data.get("features"))
+                    club.coach_features.set(extra_form.cleaned_data.get("coach_features"))
                     for coach_data in coach_formset.cleaned_data:
                         if coach_data:
                             Entrenador.objects.create(

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -13,8 +13,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const stripeBtn = document.getElementById('stripe-connect-btn');
   const clubFeaturesForm = document.getElementById('club-feature-form');
   const coachFeaturesForm = document.getElementById('coach-feature-form');
-
-  function updateFeatureForm() {
+  const logoTitle = document.getElementById('logo-title');
+  const nameField = document.getElementById('name-field');
+  const coachesSection = document.getElementById('coaches-section');
+  function updateForms() {
     const selectedTipo = document.querySelector('input[name="tipo"]:checked');
     const tipoVal = selectedTipo ? selectedTipo.value : null;
     if (clubFeaturesForm) {
@@ -22,6 +24,23 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (coachFeaturesForm) {
       coachFeaturesForm.classList.toggle('d-none', tipoVal !== 'entrenador');
+    }
+    if (logoTitle) {
+      logoTitle.textContent = tipoVal === 'entrenador' ? 'Foto de perfil' : 'Logotipo';
+    }
+    if (coachesSection) {
+      coachesSection.classList.toggle('d-none', tipoVal === 'entrenador');
+    }
+    if (nameField) {
+      nameField.classList.toggle('d-none', tipoVal === 'entrenador');
+      const nameInput = nameField.querySelector('input');
+      if (nameInput) {
+        if (tipoVal === 'entrenador') {
+          nameInput.removeAttribute('required');
+        } else {
+          nameInput.setAttribute('required', 'required');
+        }
+      }
     }
   }
 
@@ -45,8 +64,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (prevBtn) prevBtn.classList.toggle('d-none', n === 1);
     if (nextBtn) nextBtn.classList.toggle('d-none', n === steps.length);
     if (finishBtn) finishBtn.classList.toggle('d-none', n !== steps.length);
-    if (n === 4) {
-      updateFeatureForm();
+    if ([3, 4].includes(n)) {
+      updateForms();
     }
   }
 
@@ -108,7 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
     card.addEventListener('click', () => {
       input.checked = true;
       tipoCards.forEach(c => c.classList.toggle('active', c === card));
-      updateFeatureForm();
+      updateForms();
     });
   });
 
@@ -143,7 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
   togglePaymentSection();
 
   showStep(current);
-  updateFeatureForm();
+  updateForms();
 
   const coachContainer = document.getElementById('coaches-formset');
   const addCoachBtn = document.getElementById('add-coach-btn');

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -1,7 +1,7 @@
 <h3 class="h6 mb-3">Datos adicionales</h3>
 <div class="row g-3">
   <div class="col-12 col-md-6">
-    <h4 class="mb-3">Logotipo</h4>
+    <h4 class="mb-3" id="logo-title">Logotipo</h4>
     <div class="mb-5 text-center bg-dark p-3 rounded w-100">
       <div class="avatar-dropzone avatar-dropzone-square p-3">
         {{ form.logotipo }}
@@ -26,7 +26,7 @@
           <div class="invalid-feedback d-block">{{ form.username.errors.as_text|striptags }}</div>
         {% endif %}
       </div>
-      <div class="form-field col-md-6">
+      <div class="form-field col-md-6" id="name-field">
         {{ form.name }}
         <button type="button" class="clear-btn bi bi-x"></button>
         <label for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
@@ -43,59 +43,61 @@
         <div class="invalid-feedback d-block">{{ form.about.errors.as_text|striptags }}</div>
       {% endif %}
     </div>
-    <div class="d-flex justify-content-between align-items-center mt-4">
-      <h4 class="mb-0">Entrenadores</h4>
-      <button type="button" class="btn btn-outline-dark btn-sm" id="add-coach-btn">+</button>
-    </div>
-    {% if coach_formset.non_form_errors %}
-      <div class="invalid-feedback d-block">{{ coach_formset.non_form_errors.as_text|striptags }}</div>
-    {% endif %}
-    <div id="coaches-formset">
-      {{ coach_formset.management_form }}
-      {% for cform in coach_formset %}
+    <div id="coaches-section">
+      <div class="d-flex justify-content-between align-items-center mt-4">
+        <h4 class="mb-0">Entrenadores</h4>
+        <button type="button" class="btn btn-outline-dark btn-sm" id="add-coach-btn">+</button>
+      </div>
+      {% if coach_formset.non_form_errors %}
+        <div class="invalid-feedback d-block">{{ coach_formset.non_form_errors.as_text|striptags }}</div>
+      {% endif %}
+      <div id="coaches-formset">
+        {{ coach_formset.management_form }}
+        {% for cform in coach_formset %}
+          <div class="row g-3 coach-form mt-2">
+            <div class="col-md-6">
+              <div class="form-field">
+                {{ cform.nombre }}
+                <button type="button" class="clear-btn bi bi-x"></button>
+                <label for="{{ cform.nombre.id_for_label }}">{{ cform.nombre.label }}</label>
+                {% if cform.nombre.errors %}
+                  <div class="invalid-feedback d-block">{{ cform.nombre.errors.as_text|striptags }}</div>
+                {% endif %}
+              </div>
+            </div>
+            <div class="col-md-6">
+              <div class="form-field">
+                {{ cform.apellidos }}
+                <button type="button" class="clear-btn bi bi-x"></button>
+                <label for="{{ cform.apellidos.id_for_label }}">{{ cform.apellidos.label }}</label>
+                {% if cform.apellidos.errors %}
+                  <div class="invalid-feedback d-block">{{ cform.apellidos.errors.as_text|striptags }}</div>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+      <template id="coach-empty-form-template">
         <div class="row g-3 coach-form mt-2">
           <div class="col-md-6">
             <div class="form-field">
-              {{ cform.nombre }}
+              {{ coach_formset.empty_form.nombre }}
               <button type="button" class="clear-btn bi bi-x"></button>
-              <label for="{{ cform.nombre.id_for_label }}">{{ cform.nombre.label }}</label>
-              {% if cform.nombre.errors %}
-                <div class="invalid-feedback d-block">{{ cform.nombre.errors.as_text|striptags }}</div>
-              {% endif %}
+              <label for="{{ coach_formset.empty_form.nombre.id_for_label }}">{{ coach_formset.empty_form.nombre.label }}</label>
             </div>
           </div>
           <div class="col-md-6">
             <div class="form-field">
-              {{ cform.apellidos }}
+              {{ coach_formset.empty_form.apellidos }}
               <button type="button" class="clear-btn bi bi-x"></button>
-              <label for="{{ cform.apellidos.id_for_label }}">{{ cform.apellidos.label }}</label>
-              {% if cform.apellidos.errors %}
-                <div class="invalid-feedback d-block">{{ cform.apellidos.errors.as_text|striptags }}</div>
-              {% endif %}
+              <label for="{{ coach_formset.empty_form.apellidos.id_for_label }}">
+                {{ coach_formset.empty_form.apellidos.label }}
+              </label>
             </div>
           </div>
         </div>
-      {% endfor %}
+      </template>
     </div>
-    <template id="coach-empty-form-template">
-      <div class="row g-3 coach-form mt-2">
-        <div class="col-md-6">
-          <div class="form-field">
-            {{ coach_formset.empty_form.nombre }}
-            <button type="button" class="clear-btn bi bi-x"></button>
-            <label for="{{ coach_formset.empty_form.nombre.id_for_label }}">{{ coach_formset.empty_form.nombre.label }}</label>
-          </div>
-        </div>
-        <div class="col-md-6">
-          <div class="form-field">
-            {{ coach_formset.empty_form.apellidos }}
-            <button type="button" class="clear-btn bi bi-x"></button>
-            <label for="{{ coach_formset.empty_form.apellidos.id_for_label }}">
-              {{ coach_formset.empty_form.apellidos.label }}
-            </label>
-          </div>
-        </div>
-      </div>
-    </template>
   </div>
 </div>


### PR DESCRIPTION
### Summary
- Ajusta formulario extra para entrenadores: texto Foto de perfil, ocultar nombre y sección de entrenadores
- Muestra formulario de características de entrenador y oculta club en JS
- Actualiza vista y pruebas para usar datos personales como nombre del club y requerir características de entrenador

### Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab9ed5749c8321a8d1116bce0f808b