### PR TITLE
Show relevant feature form in pro registration

### DIFF
--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -1,6 +1,6 @@
 <h3 class="h6 mb-3">Datos adicionales</h3>
 <div class="row g-3">
-  <div class="col-md-6">
+  <div class="{% if user_type %}col-md-6{% else %}col-md-12{% endif %}">
     <h4 class="mb-3">Logotipo</h4>
     <div class="mb-5 text-center bg-dark p-3 rounded w-100">
       <div class="avatar-dropzone avatar-dropzone-square p-3">
@@ -98,8 +98,13 @@
       </div>
     </template>
   </div>
+  {% if user_type %}
   <div class="col-md-6">
-    {% include 'core/components/_club_features_form.html' %}
-    {% include 'core/components/_coach_feature_form.html' %}
+    {% if user_type == 'club' %}
+      {% include 'core/components/_club_features_form.html' with hide_icons=True %}
+    {% elif user_type == 'entrenador' %}
+      {% include 'core/components/_coach_feature_form.html' with hide_icons=True %}
+    {% endif %}
   </div>
+  {% endif %}
 </div>

--- a/templates/core/components/_club_features_form.html
+++ b/templates/core/components/_club_features_form.html
@@ -13,15 +13,15 @@
     </div>
     <div class="d-flex flex-wrap gap-3" id="features-container">
         {% for feature in form.features.field.queryset %}
-            <div class="feature-option border rounded d-flex align-items-center {% if feature in club.features.all %}selected{% endif %}"
+            <div class="feature-option border rounded d-flex align-items-center {% if club and feature in club.features.all %}selected{% endif %}"
                  style="padding: 8px 16px">
                 <input type="checkbox"
                        name="features"
                        value="{{ feature.id }}"
                        class="d-none"
-                       {% if feature in club.features.all %}checked{% endif %}
+                       {% if club and feature in club.features.all %}checked{% endif %}
                        {% if forloop.first %}required{% endif %} />
-                {% if feature.icon %}
+                {% if feature.icon and not hide_icons %}
                     <img src="{{ feature.icon.url }}"
                          alt="{{ feature.name }}"
                          style="width: 50px;

--- a/templates/core/components/_coach_feature_form.html
+++ b/templates/core/components/_coach_feature_form.html
@@ -21,7 +21,7 @@
                        class="d-none"
                        {% if coach and feature in coach.features.all %}checked{% endif %}
                        {% if forloop.first %}required{% endif %} />
-                {% if feature.icon %}
+                {% if feature.icon and not hide_icons %}
                     <img src="{{ feature.icon.url }}"
                          alt="{{ feature.name }}"
                          style="width: 50px; height: 50px; object-fit: contain; user-select: none"

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -42,7 +42,7 @@
                     </div>
                     <div id="step2" class="step fade-step d-none">{% include 'core/_pro_register_form.html' with form=pro_form %}</div>
                     <div id="step3" class="step fade-step d-none">
-                        {% include 'core/_pro_extra_form.html' with form=extra_form coach_formset=coach_formset %}
+                        {% include 'core/_pro_extra_form.html' with form=extra_form coach_formset=coach_formset user_type=form.tipo.value %}
                     </div>
                     <div id="step4" class="step fade-step d-none text-center">
                         <h1 class="h5 mb-3">Pasarela de pagos</h1>


### PR DESCRIPTION
## Summary
- Only display coach or club feature selectors in pro registration based on chosen user type
- Hide feature icons during registration and show text labels instead

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abab35dccc83219d7f975e44d74b87