### PR TITLE
Adapt step 3 for coach registration

### DIFF
--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -13,6 +13,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const stripeBtn = document.getElementById('stripe-connect-btn');
   const clubFeaturesSection = document.getElementById('club-features-section');
   const coachFeaturesSection = document.getElementById('coach-features-section');
+  const logoTitle = document.getElementById('logo-title');
+  const nameField = document.getElementById('name-field');
+  const nameInput = document.getElementById('id_name');
+  const firstNameInput = document.getElementById('id_nombre');
+  const lastNameInput = document.getElementById('id_apellidos');
+  const coachesSection = document.getElementById('coaches-section');
 
   function showStep(n) {
     steps.forEach((step, idx) => {
@@ -148,18 +154,38 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function updateFeatureForms() {
-    if (!clubFeaturesSection || !coachFeaturesSection) return;
     const selected = document.querySelector('input[name="tipo"]:checked');
     const value = selected ? selected.value : null;
+
     if (value === 'club') {
-      clubFeaturesSection.classList.remove('d-none');
-      coachFeaturesSection.classList.add('d-none');
+      if (clubFeaturesSection) clubFeaturesSection.classList.remove('d-none');
+      if (coachFeaturesSection) coachFeaturesSection.classList.add('d-none');
+      if (logoTitle) logoTitle.textContent = 'Logotipo';
+      if (nameField) nameField.classList.remove('d-none');
+      if (nameInput) nameInput.setAttribute('required', 'required');
+      if (coachesSection) coachesSection.classList.remove('d-none');
     } else if (value === 'entrenador') {
-      coachFeaturesSection.classList.remove('d-none');
-      clubFeaturesSection.classList.add('d-none');
+      if (coachFeaturesSection) coachFeaturesSection.classList.remove('d-none');
+      if (clubFeaturesSection) clubFeaturesSection.classList.add('d-none');
+      if (logoTitle) logoTitle.textContent = 'Foto de perfil';
+      if (nameField) nameField.classList.add('d-none');
+      if (nameInput) {
+        const first = firstNameInput ? firstNameInput.value.trim() : '';
+        const last = lastNameInput ? lastNameInput.value.trim() : '';
+        nameInput.value = `${first} ${last}`.trim();
+        nameInput.removeAttribute('required');
+      }
+      if (coachesSection) {
+        coachesSection.classList.add('d-none');
+        const totalForms = document.querySelector('#id_coaches-TOTAL_FORMS');
+        if (totalForms) totalForms.value = 0;
+        coachesSection.querySelectorAll('input').forEach(input => {
+          input.removeAttribute('required');
+        });
+      }
     } else {
-      clubFeaturesSection.classList.add('d-none');
-      coachFeaturesSection.classList.add('d-none');
+      if (clubFeaturesSection) clubFeaturesSection.classList.add('d-none');
+      if (coachFeaturesSection) coachFeaturesSection.classList.add('d-none');
     }
   }
 });

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -1,7 +1,7 @@
 <h3 class="h6 mb-3">Datos adicionales</h3>
 <div class="row g-3">
   <div class="col-md-6">
-    <h4 class="mb-3">Logotipo</h4>
+    <h4 class="mb-3" id="logo-title">Logotipo</h4>
     <div class="mb-5 text-center bg-dark p-3 rounded w-100">
       <div class="avatar-dropzone avatar-dropzone-square p-3">
         {{ form.logotipo }}
@@ -26,7 +26,7 @@
           <div class="invalid-feedback d-block">{{ form.username.errors.as_text|striptags }}</div>
         {% endif %}
       </div>
-      <div class="form-field col-md-6">
+      <div class="form-field col-md-6" id="name-field">
         {{ form.name }}
         <button type="button" class="clear-btn bi bi-x"></button>
         <label for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
@@ -43,60 +43,62 @@
         <div class="invalid-feedback d-block">{{ form.about.errors.as_text|striptags }}</div>
       {% endif %}
     </div>
-    <div class="d-flex justify-content-between align-items-center mt-4">
-      <h4 class="mb-0">Entrenadores</h4>
-      <button type="button" class="btn btn-outline-dark btn-sm" id="add-coach-btn">+</button>
-    </div>
-    {% if coach_formset.non_form_errors %}
-      <div class="invalid-feedback d-block">{{ coach_formset.non_form_errors.as_text|striptags }}</div>
-    {% endif %}
-    <div id="coaches-formset">
-      {{ coach_formset.management_form }}
-      {% for cform in coach_formset %}
+    <div id="coaches-section">
+      <div class="d-flex justify-content-between align-items-center mt-4">
+        <h4 class="mb-0">Entrenadores</h4>
+        <button type="button" class="btn btn-outline-dark btn-sm" id="add-coach-btn">+</button>
+      </div>
+      {% if coach_formset.non_form_errors %}
+        <div class="invalid-feedback d-block">{{ coach_formset.non_form_errors.as_text|striptags }}</div>
+      {% endif %}
+      <div id="coaches-formset">
+        {{ coach_formset.management_form }}
+        {% for cform in coach_formset %}
+          <div class="row g-3 coach-form mt-2">
+            <div class="col-md-6">
+              <div class="form-field">
+                {{ cform.nombre }}
+                <button type="button" class="clear-btn bi bi-x"></button>
+                <label for="{{ cform.nombre.id_for_label }}">{{ cform.nombre.label }}</label>
+                {% if cform.nombre.errors %}
+                  <div class="invalid-feedback d-block">{{ cform.nombre.errors.as_text|striptags }}</div>
+                {% endif %}
+              </div>
+            </div>
+            <div class="col-md-6">
+              <div class="form-field">
+                {{ cform.apellidos }}
+                <button type="button" class="clear-btn bi bi-x"></button>
+                <label for="{{ cform.apellidos.id_for_label }}">{{ cform.apellidos.label }}</label>
+                {% if cform.apellidos.errors %}
+                  <div class="invalid-feedback d-block">{{ cform.apellidos.errors.as_text|striptags }}</div>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+      <template id="coach-empty-form-template">
         <div class="row g-3 coach-form mt-2">
           <div class="col-md-6">
             <div class="form-field">
-              {{ cform.nombre }}
+              {{ coach_formset.empty_form.nombre }}
               <button type="button" class="clear-btn bi bi-x"></button>
-              <label for="{{ cform.nombre.id_for_label }}">{{ cform.nombre.label }}</label>
-              {% if cform.nombre.errors %}
-                <div class="invalid-feedback d-block">{{ cform.nombre.errors.as_text|striptags }}</div>
-              {% endif %}
+              <label for="{{ coach_formset.empty_form.nombre.id_for_label }}">{{ coach_formset.empty_form.nombre.label }}</label>
             </div>
           </div>
           <div class="col-md-6">
             <div class="form-field">
-              {{ cform.apellidos }}
+              {{ coach_formset.empty_form.apellidos }}
               <button type="button" class="clear-btn bi bi-x"></button>
-              <label for="{{ cform.apellidos.id_for_label }}">{{ cform.apellidos.label }}</label>
-              {% if cform.apellidos.errors %}
-                <div class="invalid-feedback d-block">{{ cform.apellidos.errors.as_text|striptags }}</div>
-              {% endif %}
+              <label for="{{ coach_formset.empty_form.apellidos.id_for_label }}">
+                {{ coach_formset.empty_form.apellidos.label }}
+              </label>
             </div>
           </div>
         </div>
-      {% endfor %}
+      </template>
     </div>
-    <template id="coach-empty-form-template">
-      <div class="row g-3 coach-form mt-2">
-        <div class="col-md-6">
-          <div class="form-field">
-            {{ coach_formset.empty_form.nombre }}
-            <button type="button" class="clear-btn bi bi-x"></button>
-            <label for="{{ coach_formset.empty_form.nombre.id_for_label }}">{{ coach_formset.empty_form.nombre.label }}</label>
-          </div>
-        </div>
-        <div class="col-md-6">
-          <div class="form-field">
-            {{ coach_formset.empty_form.apellidos }}
-            <button type="button" class="clear-btn bi bi-x"></button>
-            <label for="{{ coach_formset.empty_form.apellidos.id_for_label }}">
-              {{ coach_formset.empty_form.apellidos.label }}
-            </label>
-          </div>
-        </div>
-      </div>
-    </template>
   </div>
   <div class="col-md-6">
     <div id="club-features-section" class="d-none">


### PR DESCRIPTION
## Summary
- Dynamically hide name and coaches list on step 3 when registering as a coach
- Switch logo heading to "Foto de perfil" for coaches and auto-fill name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb841132c8321a393f05b2b14fd0d