### PR TITLE
Hide Bio label until focus

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -213,6 +213,9 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
             'email': 'Correo electrónico',
             'features': 'Instalaciones y Equipamiento',
         }
+        widgets = {
+            'about': forms.Textarea(attrs={'placeholder': 'Comparte tu historia aquí...'}),
+        }
 
     def __init__(self, *args, require_all=False, exclude_required=None, **kwargs):
         exclude_required = exclude_required or []

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -130,6 +130,16 @@
   color: #000;
 }
 
+/* Oculta el label "Bio" hasta que el usuario interactúe */
+.profile-form textarea#id_about:placeholder-shown ~ label {
+  opacity: 0;
+}
+
+.profile-form textarea#id_about:focus ~ label,
+.profile-form textarea#id_about:not(:placeholder-shown) ~ label {
+  opacity: 1;
+}
+
 .profile-form .clear-btn {
   position: absolute;
   right:15px;


### PR DESCRIPTION
## Summary
- hide Bio label until textarea is focused and show placeholder
- add placeholder for club about field

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abcecd0acc83219df5bd94748ebcf7