### PR TITLE
Improve professional registration form validation

### DIFF
--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -40,8 +40,13 @@ class RegistroProfesionalForm(UniformFieldsMixin, forms.Form):
 class ProRegisterForm(UniformFieldsMixin, forms.Form):
     """Formulario para los datos personales y de dirección del profesional."""
 
-    nombre = forms.CharField(label="Nombre")
-    apellidos = forms.CharField(label="Apellidos")
+    solo_letras = RegexValidator(
+        r"^[A-Za-zÁÉÍÓÚÜáéíóúüÑñ\s]+$",
+        "Solo se permiten letras"
+    )
+
+    nombre = forms.CharField(label="Nombre", validators=[solo_letras])
+    apellidos = forms.CharField(label="Apellidos", validators=[solo_letras])
     fecha_nacimiento = forms.DateField(
         label="Fecha de nacimiento",
         widget=forms.DateInput(attrs={"type": "date", "min": "1910-01-01"}),
@@ -60,10 +65,10 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
 
     pais = forms.ChoiceField(label="País", choices=COUNTRY_CHOICES)
     comunidad_autonoma = forms.ChoiceField(
-        label="Comunidad Autónoma", choices=REGION_CHOICES
+        label="Comunidad Autónoma", choices=[("", "")] + REGION_CHOICES
     )
-    ciudad = forms.CharField(label="Ciudad")
-    calle = forms.CharField(label="Calle")
+    ciudad = forms.ChoiceField(label="Ciudad", choices=[("", "")])
+    calle = forms.CharField(label="Calle", validators=[solo_letras])
     numero = forms.IntegerField(
         label="Número",
         min_value=0,

--- a/static/js/about-placeholder.js
+++ b/static/js/about-placeholder.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const aboutInput = document.getElementById('id_about');
+  if (!aboutInput) return;
+  const original = aboutInput.getAttribute('placeholder');
+  aboutInput.addEventListener('focus', () => {
+    aboutInput.setAttribute('data-placeholder', original);
+    aboutInput.setAttribute('placeholder', '');
+  });
+  aboutInput.addEventListener('blur', () => {
+    if (!aboutInput.value.trim()) {
+      const restore = aboutInput.getAttribute('data-placeholder') || '';
+      aboutInput.setAttribute('placeholder', restore);
+    }
+  });
+});

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -69,4 +69,5 @@
     <script src="{% static 'js/feature-select.js' %}"></script>
     <script src="{% static 'js/coach-feature-select.js' %}"></script>
     <script src="{% static 'js/pro-registro.js' %}"></script>
+    <script src="{% static 'js/about-placeholder.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Enforce letter-only input for nombre, apellidos and calle fields
- Require explicit selection for comunidad autónoma and ciudad
- Hide About placeholder on focus for cleaner UX

## Testing
- `pytest apps/core/test_registro_profesional.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abd6723d7c832191555c602d16c4d5