### PR TITLE
Show alert for invalid professional registration forms

### DIFF
--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const steps = ['step1', 'step2', 'step3', 'step4', 'step5'].map(id => document.getElementById(id));
   const progress = ['step-label-1', 'step-label-2', 'step-label-3', 'step-label-4', 'step-label-5'].map(id => document.getElementById(id));
+  const alerts = ['step1-alert', 'step2-alert', 'step3-alert', 'step4-alert', 'step5-alert'].map(id => document.getElementById(id));
   const currentInput = document.getElementById('current-step');
   let current = parseInt(currentInput.value, 10) || 1;
   const tipoCards = document.querySelectorAll('.tipo-card');
@@ -66,22 +67,27 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function validateStep(n) {
     const step = steps[n - 1];
+    const alert = alerts[n - 1];
+    if (alert) alert.classList.add('d-none');
     if (!step) return true;
     const fields = step.querySelectorAll('input, select, textarea');
     for (const field of fields) {
       if (field.type === 'radio') {
         const group = step.querySelectorAll(`input[name="${field.name}"]`);
         if (![...group].some(r => r.checked)) {
+          if (alert) alert.classList.remove('d-none');
           group[0].reportValidity();
           return false;
         }
         continue;
       }
       if (field.hasAttribute('required') && !field.value.trim()) {
+        if (alert) alert.classList.remove('d-none');
         field.reportValidity();
         return false;
       }
       if (!field.checkValidity()) {
+        if (alert) alert.classList.remove('d-none');
         field.reportValidity();
         return false;
       }

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -89,3 +89,6 @@
     </div>
   </div>
 </div>
+<div id="step3-alert" class="alert alert-danger mt-3{% if not form.errors and not coach_formset.errors and not coach_formset.non_form_errors %} d-none{% endif %}" role="alert">
+  Por favor completa todos los campos obligatorios.
+</div>

--- a/templates/core/_pro_register_form.html
+++ b/templates/core/_pro_register_form.html
@@ -140,3 +140,6 @@
     </div>
   </div>
 </div>
+<div id="step2-alert" class="alert alert-danger mt-3{% if not form.errors %} d-none{% endif %}" role="alert">
+  Por favor completa todos los campos obligatorios.
+</div>


### PR DESCRIPTION
## Summary
- Display red error alerts below professional registration and extra forms when validation fails
- Add client-side logic to toggle alerts during step validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abd89826d48321831bda02a3294d78