### PR TITLE
Añadir validación de campos y control de entrenadores

### DIFF
--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -59,15 +59,15 @@
         {% for cform in coach_formset %}{% endfor %}
       </div>
       <template id="coach-empty-form-template">
-        <div class="row g-3 coach-form mt-2">
-          <div class="col-md-6">
+        <div class="row g-3 coach-form mt-2 align-items-end">
+          <div class="col-md-5">
             <div class="form-field">
               {{ coach_formset.empty_form.nombre }}
               <button type="button" class="clear-btn bi bi-x"></button>
               <label for="{{ coach_formset.empty_form.nombre.id_for_label }}">{{ coach_formset.empty_form.nombre.label }}</label>
             </div>
           </div>
-          <div class="col-md-6">
+          <div class="col-md-5">
             <div class="form-field">
               {{ coach_formset.empty_form.apellidos }}
               <button type="button" class="clear-btn bi bi-x"></button>
@@ -75,6 +75,11 @@
                 {{ coach_formset.empty_form.apellidos.label }}
               </label>
             </div>
+          </div>
+          <div class="col-md-2 d-flex align-items-center">
+            <button type="button" class="btn remove-coach-btn">
+              <i class="bi bi-dash-circle"></i>
+            </button>
           </div>
         </div>
       </template>


### PR DESCRIPTION
## Summary
- Mostrar asterisco rojo y mensaje bajo los campos obligatorios sin completar en el formulario multipaso
- Vaciar el campo de nombre para clubs y limitar a un formulario de entrenador con opción de eliminar
- Añadir botón para quitar entrenadores y reindexar el formset dinámicamente

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abdfcf4d68832186376a664b7fe22d