### PR TITLE
Fix professional registration validation

### DIFF
--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -157,13 +157,9 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
 
     def clean_telefono(self):
         telefono = self.cleaned_data.get('telefono', '')
-        prefijo = self.cleaned_data.get('prefijo', '')
         digits = re.sub(r'\D', '', telefono)
-        if prefijo == '+34':
-            if len(digits) != 9:
-                raise forms.ValidationError('El teléfono debe tener 9 dígitos.')
-            if digits[0] not in '67':
-                raise forms.ValidationError('Introduce un número de teléfono válido')
+        if len(digits) != 9 or digits[0] not in '67':
+            raise forms.ValidationError('Introduce un número de teléfono válido')
         return digits
 
     def clean_fecha_nacimiento(self):

--- a/apps/core/test_registro_profesional.py
+++ b/apps/core/test_registro_profesional.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth.models import User
 from apps.clubs.models import Feature, Club
+from apps.core.forms import ProRegisterForm
 from io import BytesIO
 from PIL import Image
 import tempfile
@@ -58,6 +59,26 @@ class RegistroProfesionalTests(TestCase):
         self.assertEqual(club.features.count(), 1)
         self.assertTrue(club.logo)
         self.assertTrue(club.profilepic)
+
+    def test_invalid_telefono(self):
+        form = ProRegisterForm(data={
+            "nombre": "Juan",
+            "apellidos": "Perez",
+            "fecha_nacimiento": "1990-01-01",
+            "dni": "12345678Z",
+            "prefijo": "+34",
+            "telefono": "512345678",
+            "sexo": "hombre",
+            "pais": "España",
+            "comunidad_autonoma": "Madrid",
+            "ciudad": "Madrid",
+            "calle": "Calle Falsa",
+            "numero": 1,
+            "puerta": 1,
+            "codigo_postal": "28001",
+        })
+        self.assertFalse(form.is_valid())
+        self.assertIn("telefono", form.errors)
 
     @override_settings(MEDIA_ROOT=tempfile.mkdtemp())
     def test_club_requires_at_least_one_entrenador(self):

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -114,6 +114,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     let firstInvalid = null;
     for (const field of fields) {
+      if (field.type === 'hidden' || field.offsetParent === null) {
+        continue;
+      }
       if (field.type === 'radio') {
         const group = step.querySelectorAll(`input[name="${field.name}"]`);
         if (![...group].some(r => r.checked)) {
@@ -256,9 +259,9 @@ document.addEventListener('DOMContentLoaded', () => {
         totalCoachForms.value = 0;
         addCoachForm();
       }
-    } else if (value === 'entrenador') {
-      if (coachFeaturesSection) coachFeaturesSection.classList.remove('d-none');
-      if (clubFeaturesSection) clubFeaturesSection.classList.add('d-none');
+      } else if (value === 'entrenador') {
+        if (coachFeaturesSection) coachFeaturesSection.classList.remove('d-none');
+        if (clubFeaturesSection) clubFeaturesSection.classList.remove('d-none');
       if (logoTitle) logoTitle.textContent = 'Foto de perfil';
       if (nameField) nameField.classList.add('d-none');
       if (nameInput) {


### PR DESCRIPTION
## Summary
- Ignore hidden inputs during multi-step validation and show feature selection for trainers
- Enforce 9-digit phone numbers starting with 6 or 7
- Add regression test for phone validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abe4cf4a3083218a203f1a3ea19093