### PR TITLE
Enforce required coach details and feature selection

### DIFF
--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const prevBtn = document.getElementById('prevBtn');
   const finishBtn = document.getElementById('finishBtn');
   const stripeBtn = document.getElementById('stripe-connect-btn');
+  const form = document.querySelector('.profile-form');
   const clubFeaturesSection = document.getElementById('club-features-section');
   const coachFeaturesSection = document.getElementById('coach-features-section');
   const logoTitle = document.getElementById('logo-title');
@@ -176,6 +177,14 @@ document.addEventListener('DOMContentLoaded', () => {
       return false;
     }
     return true;
+  }
+
+  if (form) {
+    form.addEventListener('submit', e => {
+      if (!validateStep(current)) {
+        e.preventDefault();
+      }
+    });
   }
 
   if (nextBtn) {

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -67,14 +67,14 @@
         <div class="row g-3 coach-form mt-2 align-items-end">
           <div class="col-md-6">
             <div class="form-field">
-              {{ coach_formset.empty_form.nombre }}
+              {{ coach_formset.empty_form.nombre.as_widget(attrs={'required': 'required'}) }}
               <button type="button" class="clear-btn bi bi-x"></button>
               <label for="{{ coach_formset.empty_form.nombre.id_for_label }}">{{ coach_formset.empty_form.nombre.label }}</label>
             </div>
           </div>
           <div class="col-md-6">
             <div class="form-field">
-              {{ coach_formset.empty_form.apellidos }}
+              {{ coach_formset.empty_form.apellidos.as_widget(attrs={'required': 'required'}) }}
               <button type="button" class="clear-btn bi bi-x"></button>
               <label for="{{ coach_formset.empty_form.apellidos.id_for_label }}">
                 {{ coach_formset.empty_form.apellidos.label }}


### PR DESCRIPTION
## Summary
- Make coach name and surname inputs explicitly required in the extra registration step
- Validate all steps before final submission, blocking completion if fewer than three features are chosen or required coach details are missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad8f2a0f8c8321ad0d493e191cb944