### PR TITLE
Ensure extra coach data and feature selection in pro registration

### DIFF
--- a/apps/core/test_registro_profesional.py
+++ b/apps/core/test_registro_profesional.py
@@ -127,3 +127,43 @@ class RegistroProfesionalTests(TestCase):
         self.assertEqual(coach.nombre, "Pedro")
         self.assertTrue(club.logo)
         self.assertTrue(club.profilepic)
+
+    @override_settings(MEDIA_ROOT=tempfile.mkdtemp())
+    def test_club_requires_three_features(self):
+        features = [Feature.objects.create(name=f"Feature {i}") for i in range(2)]
+        user = User.objects.create_user(username="clubuser2", password="pass", email="club2@example.com")
+        self.client.login(username="clubuser2", password="pass")
+
+        url = reverse("registro_profesional")
+        data = {
+            "tipo": "club",
+            "plan": "plata",
+            "nombre": "Luis",
+            "apellidos": "Gomez",
+            "fecha_nacimiento": "1990-01-01",
+            "dni": "12345678Z",
+            "prefijo": "+34",
+            "telefono": "612345678",
+            "sexo": "hombre",
+            "pais": "España",
+            "comunidad_autonoma": "Madrid",
+            "ciudad": "Madrid",
+            "calle": "Calle Falsa",
+            "numero": 1,
+            "puerta": 1,
+            "codigo_postal": "28001",
+            "username": "clubuser2",
+            "name": "Club Test",
+            "about": "Bio",
+            "features": [str(f.id) for f in features],
+            "logotipo": self._create_image(),
+            "coaches-TOTAL_FORMS": "1",
+            "coaches-INITIAL_FORMS": "0",
+            "coaches-MIN_NUM_FORMS": "1",
+            "coaches-MAX_NUM_FORMS": "1000",
+            "coaches-0-nombre": "Pedro",
+            "coaches-0-apellidos": "López",
+        }
+
+        response = self.client.post(url, data)
+        self.assertContains(response, "Selecciona al menos 3 características.")

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -36,6 +36,9 @@ document.addEventListener('DOMContentLoaded', () => {
       const temp = document.createElement('div');
       temp.innerHTML = newForm.trim();
       const formElem = temp.firstElementChild;
+      formElem.querySelectorAll('input').forEach(input => {
+        input.setAttribute('required', 'required');
+      });
       coachContainer.appendChild(formElem);
       totalCoachForms.value = index + 1;
     }
@@ -147,9 +150,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     let featureInvalid = false;
-    if (!firstInvalid && n === 3) {
+    if (n === 3) {
       const checkGroup = (section, name) => {
-        if (!section || section.classList.contains('d-none') || firstInvalid) return;
+        if (!section || section.classList.contains('d-none')) return;
         const selected = section.querySelectorAll(`input[name="${name}"]:checked`).length;
         let error = section.querySelector('.min-select-alert');
         if (selected < 3) {
@@ -159,8 +162,10 @@ document.addEventListener('DOMContentLoaded', () => {
             error.textContent = 'Selecciona al menos 3 opciones.';
             section.appendChild(error);
           }
-          const input = section.querySelector(`input[name="${name}"]`);
-          if (input) firstInvalid = input;
+          if (!firstInvalid) {
+            const input = section.querySelector(`input[name="${name}"]`);
+            if (input) firstInvalid = input;
+          }
           featureInvalid = true;
         } else if (error) {
           error.remove();
@@ -172,7 +177,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (firstInvalid || featureInvalid) {
       if (alert) alert.classList.remove('d-none');
-      if (firstInvalid) firstInvalid.reportValidity();
+      if (firstInvalid && firstInvalid.offsetParent !== null) firstInvalid.reportValidity();
       return false;
     }
     return true;

--- a/templates/core/_pro_extra_form.html
+++ b/templates/core/_pro_extra_form.html
@@ -48,11 +48,11 @@
       <div class="d-flex justify-content-between align-items-center mt-4">
         <h4 class="mb-0">Entrenadores</h4>
         <div>
-          <button type="button" class="btn me-2" id="remove-coach-btn">
-            <i class="bi bi-dash-circle"></i>
-          </button>
-          <button type="button" class="btn" id="add-coach-btn">
+          <button type="button" class="btn me-2" id="add-coach-btn">
             <i class="bi bi-plus-circle"></i>
+          </button>
+          <button type="button" class="btn" id="remove-coach-btn">
+            <i class="bi bi-dash-circle"></i>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Reverse order of add/remove coach buttons and enforce coach name and surname as required
- Validate that at least three features are selected during registration
- Add regression test for feature requirement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9362ce48832195515fbc2db85c14