### PR TITLE
Limit year and postal code input lengths

### DIFF
--- a/apps/clubs/forms.py
+++ b/apps/clubs/forms.py
@@ -10,8 +10,9 @@ from .countries import COUNTRY_CHOICES
 import re
 from django.core.validators import RegexValidator
 
-# Validador para códigos postales numéricos
-CODIGO_POSTAL_VALIDATOR = RegexValidator(r"^\d+$", "Introduce solo números.")
+# Patrón y mensaje para códigos postales de 5 cifras
+CODIGO_POSTAL_REGEX = r"^\d{5}$"
+CODIGO_POSTAL_ERROR = "Introduce un código postal válido de 5 cifras."
 class LoginForm(UniformFieldsMixin, AuthenticationForm):
     username = forms.CharField(
         label="Usuario",
@@ -187,6 +188,14 @@ class ClubForm(UniformFieldsMixin, forms.ModelForm):
     city = forms.CharField(
         label="Ciudad",
         required=False,
+    )
+    postal_code = forms.RegexField(
+        regex=CODIGO_POSTAL_REGEX,
+        max_length=5,
+        required=False,
+        label="Código Postal",
+        error_messages={'invalid': CODIGO_POSTAL_ERROR},
+        widget=forms.TextInput(attrs={"pattern": "[0-9]{5}", "maxlength": "5"}),
     )
     class Meta:
         model = models.Club
@@ -395,7 +404,15 @@ class CompetidorForm(UniformFieldsMixin, forms.ModelForm):
     fecha_nacimiento = forms.DateField(
         required=False,
         label='Fecha de nacimiento',
-        widget=forms.DateInput(attrs={'type': 'date', 'min': '1910-01-01'}),
+        widget=forms.DateInput(
+            attrs={
+                'type': 'date',
+                'min': '1910-01-01',
+                'max': '9999-12-31',
+                'pattern': '[0-9]{4}-[0-9]{2}-[0-9]{2}',
+                'maxlength': '10',
+            }
+        ),
     )
     tipo_competidor = forms.ChoiceField(
         choices=[('', ''), ('amateur', 'Amateur'), ('profesional', 'Profesional')],
@@ -554,11 +571,13 @@ class MiembroForm(UniformFieldsMixin, forms.ModelForm):
         label='Comunidad Autónoma',
     )
     localidad = forms.ChoiceField(required=False, choices=[('', '')])
-    codigo_postal = forms.CharField(
+    codigo_postal = forms.RegexField(
+        regex=CODIGO_POSTAL_REGEX,
+        max_length=5,
         required=False,
         label='Código postal',
-        validators=[CODIGO_POSTAL_VALIDATOR],
-        widget=forms.TextInput(attrs={"pattern": CODIGO_POSTAL_VALIDATOR.regex.pattern}),
+        error_messages={'invalid': CODIGO_POSTAL_ERROR},
+        widget=forms.TextInput(attrs={"pattern": "[0-9]{5}", "maxlength": "5"}),
     )
 
     class Meta:
@@ -612,8 +631,15 @@ class MiembroForm(UniformFieldsMixin, forms.ModelForm):
 
         fecha_widget = self.fields.get('fecha_nacimiento')
         if fecha_widget:
-            fecha_widget.widget.input_type = 'date'
-            fecha_widget.widget.attrs.setdefault('min', '1910-01-01')
+            fecha_widget.widget = forms.DateInput(
+                attrs={
+                    'type': 'date',
+                    'min': '1910-01-01',
+                    'max': '9999-12-31',
+                    'pattern': '[0-9]{4}-[0-9]{2}-[0-9]{2}',
+                    'maxlength': '10',
+                }
+            )
 
         sexo_field = self.fields.get('sexo')
         if sexo_field: 
@@ -708,7 +734,16 @@ class MiembroForm(UniformFieldsMixin, forms.ModelForm):
 
 
 class PagoForm(UniformFieldsMixin, forms.ModelForm):
-    fecha = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}))
+    fecha = forms.DateField(
+        widget=forms.DateInput(
+            attrs={
+                'type': 'date',
+                'max': '9999-12-31',
+                'pattern': '[0-9]{4}-[0-9]{2}-[0-9]{2}',
+                'maxlength': '10',
+            }
+        )
+    )
     monto = forms.DecimalField(
         max_digits=8,
         decimal_places=2,

--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -17,8 +17,9 @@ SOLO_LETRAS = RegexValidator(
 DNI_REGEX = r"^(?:\d{8}[A-Z]|[XYZ]\d{7}[A-Z]|[A-Z]\d{7}[A-Z])$"
 DNI_VALIDATOR = RegexValidator(DNI_REGEX, "Introduce un DNI/NIE/NIF válido.")
 
-# Validador para códigos postales numéricos
-CODIGO_POSTAL_VALIDATOR = RegexValidator(r"^\d+$", "Introduce solo números.")
+# Patrón y mensaje para códigos postales de 5 cifras
+CODIGO_POSTAL_REGEX = r"^\d{5}$"
+CODIGO_POSTAL_ERROR = "Introduce un código postal válido de 5 cifras."
 
 class TipoUsuarioForm(UniformFieldsMixin, forms.Form):
     tipo = forms.ChoiceField(
@@ -64,7 +65,15 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
     )
     fecha_nacimiento = forms.DateField(
         label="Fecha de nacimiento",
-        widget=forms.DateInput(attrs={"type": "date", "min": "1910-01-01"}),
+        widget=forms.DateInput(
+            attrs={
+                "type": "date",
+                "min": "1910-01-01",
+                "max": "9999-12-31",
+                "pattern": "[0-9]{4}-[0-9]{2}-[0-9]{2}",
+                "maxlength": "10",
+            }
+        ),
     )
     dni = forms.CharField(
         label="DNI/NIE/NIF",
@@ -103,10 +112,12 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
         min_value=0,
         widget=forms.NumberInput(),
     )
-    codigo_postal = forms.CharField(
+    codigo_postal = forms.RegexField(
         label="Código Postal",
-        validators=[CODIGO_POSTAL_VALIDATOR],
-        widget=forms.TextInput(attrs={"pattern": CODIGO_POSTAL_VALIDATOR.regex.pattern}),
+        regex=CODIGO_POSTAL_REGEX,
+        max_length=5,
+        error_messages={"invalid": CODIGO_POSTAL_ERROR},
+        widget=forms.TextInput(attrs={"pattern": "[0-9]{5}", "maxlength": "5"}),
     )
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- Enforce 5-digit numeric postal codes across registration and member forms
- Restrict all date inputs to 4-digit years using patterns and max attributes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adb3b1c4388321bd4c753d07392a04