### PR TITLE
Fix Stripe test card payments and drop postal code field

### DIFF
--- a/apps/core/forms.py
+++ b/apps/core/forms.py
@@ -17,9 +17,6 @@ SOLO_LETRAS = RegexValidator(
 DNI_REGEX = r"^(?:\d{8}[A-Z]|[XYZ]\d{7}[A-Z]|[A-Z]\d{7}[A-Z])$"
 DNI_VALIDATOR = RegexValidator(DNI_REGEX, "Introduce un DNI/NIE/NIF válido.")
 
-# Patrón y mensaje para códigos postales de 5 cifras
-CODIGO_POSTAL_REGEX = r"^\d{5}$"
-CODIGO_POSTAL_ERROR = "Introduce un código postal válido de 5 cifras."
 
 class TipoUsuarioForm(UniformFieldsMixin, forms.Form):
     tipo = forms.ChoiceField(
@@ -111,13 +108,6 @@ class ProRegisterForm(UniformFieldsMixin, forms.Form):
         required=False,
         min_value=0,
         widget=forms.NumberInput(),
-    )
-    codigo_postal = forms.RegexField(
-        label="Código Postal",
-        regex=CODIGO_POSTAL_REGEX,
-        max_length=5,
-        error_messages={"invalid": CODIGO_POSTAL_ERROR},
-        widget=forms.TextInput(attrs={"pattern": "[0-9]{5}", "maxlength": "5"}),
     )
 
     def __init__(self, *args, **kwargs):

--- a/apps/core/test_registro_profesional.py
+++ b/apps/core/test_registro_profesional.py
@@ -39,7 +39,6 @@ class RegistroProfesionalTests(TestCase):
             "calle": "Calle Falsa",
             "numero": 1,
             "puerta": 1,
-            "codigo_postal": "28001",
             "username": "newuser",
             "name": "Club Coach",
             "about": "Algo",
@@ -77,7 +76,6 @@ class RegistroProfesionalTests(TestCase):
             "calle": "Calle Falsa",
             "numero": 1,
             "puerta": 1,
-            "codigo_postal": "28001",
         })
         self.assertFalse(form.is_valid())
         self.assertIn("telefono", form.errors)
@@ -105,7 +103,6 @@ class RegistroProfesionalTests(TestCase):
             "calle": "Calle Falsa",
             "numero": 1,
             "puerta": 1,
-            "codigo_postal": "28001",
             "username": "clubuser",
             "name": "Club Test",
             "about": "Bio",
@@ -152,7 +149,6 @@ class RegistroProfesionalTests(TestCase):
             "calle": "Calle Falsa",
             "numero": 1,
             "puerta": 1,
-            "codigo_postal": "28001",
             "username": "clubuser2",
             "name": "Club Test",
             "about": "Bio",
@@ -181,3 +177,4 @@ class StripePaymentIntentTests(TestCase):
         _, kwargs = mock_create.call_args
         self.assertEqual(kwargs["amount"], 900)
         self.assertEqual(kwargs["currency"], "eur")
+        self.assertEqual(kwargs["payment_method_types"], ["card"])

--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -84,7 +84,6 @@ def registro_profesional(request):
                         street=pro_form.cleaned_data.get("calle", ""),
                         number=pro_form.cleaned_data.get("numero"),
                         door=pro_form.cleaned_data.get("puerta", ""),
-                        postal_code=pro_form.cleaned_data.get("codigo_postal", ""),
                         category="entrenador",
                         plan=form.cleaned_data["plan"],
                     )
@@ -106,7 +105,6 @@ def registro_profesional(request):
                         street=pro_form.cleaned_data.get("calle", ""),
                         number=pro_form.cleaned_data.get("numero"),
                         door=pro_form.cleaned_data.get("puerta", ""),
-                        postal_code=pro_form.cleaned_data.get("codigo_postal", ""),
                         category="club",
                         plan=form.cleaned_data["plan"],
                     )
@@ -195,7 +193,9 @@ def create_payment_intent(request):
         return JsonResponse({"error": "Invalid plan"}, status=400)
 
     stripe.api_key = settings.STRIPE_SECRET_KEY
-    intent = stripe.PaymentIntent.create(amount=amount, currency="eur")
+    intent = stripe.PaymentIntent.create(
+        amount=amount, currency="eur", payment_method_types=["card"]
+    )
     return JsonResponse({"clientSecret": intent.client_secret})
 
 

--- a/templates/core/_pro_register_form.html
+++ b/templates/core/_pro_register_form.html
@@ -129,14 +129,4 @@
       {% endif %}
     </div>
   </div>
-  <div class="col-md-2">
-    <div class="form-field">
-      {{ form.codigo_postal }}
-      <button type="button" class="clear-btn bi bi-x"></button>
-      <label for="{{ form.codigo_postal.id_for_label }}">{{ form.codigo_postal.label }}</label>
-      {% if form.codigo_postal.errors %}
-      <div class="invalid-feedback d-block">{{ form.codigo_postal.errors.as_text|striptags }}</div>
-      {% endif %}
-    </div>
-  </div>
 </div>


### PR DESCRIPTION
## Summary
- Fix Stripe PaymentIntent creation by specifying card payment method
- Remove postal code field from professional registration form and backend logic
- Update tests for PaymentIntent parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af97c4043083219c1b4bf37abdabcd