### PR TITLE
Verify Stripe payment before professional registration

### DIFF
--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -5,6 +5,7 @@ from django.http import JsonResponse
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 from django.views.decorators.csrf import csrf_exempt
+from django.contrib import messages
 
 import stripe
 from ..forms import (
@@ -58,68 +59,85 @@ def registro_profesional(request):
             if form.cleaned_data["tipo"] == "club":
                 coach_valid = coach_formset.is_valid()
             if coach_valid:
-                user = request.user
-                profile = user.profile
-                profile.plan = form.cleaned_data["plan"]
-                profile.save()
+                payment_valid = True
+                plan = form.cleaned_data["plan"]
+                if plan in ["plata", "oro"]:
+                    amount_lookup = {"plata": 900, "oro": 1900}
+                    payment_intent_id = request.POST.get("payment_intent_id")
+                    stripe.api_key = settings.STRIPE_SECRET_KEY
+                    try:
+                        intent = stripe.PaymentIntent.retrieve(payment_intent_id)
+                        expected_amount = amount_lookup.get(plan)
+                        if intent.status != "succeeded" or intent.amount_received != expected_amount:
+                            payment_valid = False
+                    except Exception:
+                        payment_valid = False
+                if payment_valid:
+                    user = request.user
+                    profile = user.profile
+                    profile.plan = form.cleaned_data["plan"]
+                    profile.save()
 
-                user.username = extra_form.cleaned_data["username"]
-                user.first_name = pro_form.cleaned_data["nombre"]
-                user.last_name = pro_form.cleaned_data["apellidos"]
-                user.save()
+                    user.username = extra_form.cleaned_data["username"]
+                    user.first_name = pro_form.cleaned_data["nombre"]
+                    user.last_name = pro_form.cleaned_data["apellidos"]
+                    user.save()
 
-                if form.cleaned_data["tipo"] == "entrenador":
-                    club = Club.objects.create(
-                        owner=user,
-                        name=extra_form.cleaned_data["name"],
-                        about=extra_form.cleaned_data["about"],
-                        logo=extra_form.cleaned_data.get("logotipo"),
-                        profilepic=extra_form.cleaned_data.get("logotipo"),
-                        prefijo=pro_form.cleaned_data.get("prefijo", ""),
-                        phone=pro_form.cleaned_data.get("telefono", ""),
-                        email=user.email,
-                        country=pro_form.cleaned_data.get("pais", ""),
-                        region=pro_form.cleaned_data.get("comunidad_autonoma", ""),
-                        city=pro_form.cleaned_data.get("ciudad", ""),
-                        street=pro_form.cleaned_data.get("calle", ""),
-                        number=pro_form.cleaned_data.get("numero"),
-                        door=pro_form.cleaned_data.get("puerta", ""),
-                        postal_code=pro_form.cleaned_data.get("codigo_postal", ""),
-                        category="entrenador",
-                        plan=form.cleaned_data["plan"],
-                    )
-                    club.features.set(extra_form.cleaned_data["features"])
-                    club.coach_features.set(extra_form.cleaned_data["coach_features"])
-                elif form.cleaned_data["tipo"] == "club":
-                    club = Club.objects.create(
-                        owner=user,
-                        name=extra_form.cleaned_data["name"],
-                        about=extra_form.cleaned_data["about"],
-                        logo=extra_form.cleaned_data.get("logotipo"),
-                        profilepic=extra_form.cleaned_data.get("logotipo"),
-                        prefijo=pro_form.cleaned_data.get("prefijo", ""),
-                        phone=pro_form.cleaned_data.get("telefono", ""),
-                        email=user.email,
-                        country=pro_form.cleaned_data.get("pais", ""),
-                        region=pro_form.cleaned_data.get("comunidad_autonoma", ""),
-                        city=pro_form.cleaned_data.get("ciudad", ""),
-                        street=pro_form.cleaned_data.get("calle", ""),
-                        number=pro_form.cleaned_data.get("numero"),
-                        door=pro_form.cleaned_data.get("puerta", ""),
-                        postal_code=pro_form.cleaned_data.get("codigo_postal", ""),
-                        category="club",
-                        plan=form.cleaned_data["plan"],
-                    )
-                    club.features.set(extra_form.cleaned_data["features"])
-                    club.coach_features.set(extra_form.cleaned_data["coach_features"])
-                    for coach_data in coach_formset.cleaned_data:
-                        if coach_data:
-                            Entrenador.objects.create(
-                                club=club,
-                                nombre=coach_data["nombre"],
-                                apellidos=coach_data["apellidos"],
-                            )
-                return render(request, "core/registro_pro_success.html")
+                    if form.cleaned_data["tipo"] == "entrenador":
+                        club = Club.objects.create(
+                            owner=user,
+                            name=extra_form.cleaned_data["name"],
+                            about=extra_form.cleaned_data["about"],
+                            logo=extra_form.cleaned_data.get("logotipo"),
+                            profilepic=extra_form.cleaned_data.get("logotipo"),
+                            prefijo=pro_form.cleaned_data.get("prefijo", ""),
+                            phone=pro_form.cleaned_data.get("telefono", ""),
+                            email=user.email,
+                            country=pro_form.cleaned_data.get("pais", ""),
+                            region=pro_form.cleaned_data.get("comunidad_autonoma", ""),
+                            city=pro_form.cleaned_data.get("ciudad", ""),
+                            street=pro_form.cleaned_data.get("calle", ""),
+                            number=pro_form.cleaned_data.get("numero"),
+                            door=pro_form.cleaned_data.get("puerta", ""),
+                            postal_code=pro_form.cleaned_data.get("codigo_postal", ""),
+                            category="entrenador",
+                            plan=form.cleaned_data["plan"],
+                        )
+                        club.features.set(extra_form.cleaned_data["features"])
+                        club.coach_features.set(extra_form.cleaned_data["coach_features"])
+                    elif form.cleaned_data["tipo"] == "club":
+                        club = Club.objects.create(
+                            owner=user,
+                            name=extra_form.cleaned_data["name"],
+                            about=extra_form.cleaned_data["about"],
+                            logo=extra_form.cleaned_data.get("logotipo"),
+                            profilepic=extra_form.cleaned_data.get("logotipo"),
+                            prefijo=pro_form.cleaned_data.get("prefijo", ""),
+                            phone=pro_form.cleaned_data.get("telefono", ""),
+                            email=user.email,
+                            country=pro_form.cleaned_data.get("pais", ""),
+                            region=pro_form.cleaned_data.get("comunidad_autonoma", ""),
+                            city=pro_form.cleaned_data.get("ciudad", ""),
+                            street=pro_form.cleaned_data.get("calle", ""),
+                            number=pro_form.cleaned_data.get("numero"),
+                            door=pro_form.cleaned_data.get("puerta", ""),
+                            postal_code=pro_form.cleaned_data.get("codigo_postal", ""),
+                            category="club",
+                            plan=form.cleaned_data["plan"],
+                        )
+                        club.features.set(extra_form.cleaned_data["features"])
+                        club.coach_features.set(extra_form.cleaned_data["coach_features"])
+                        for coach_data in coach_formset.cleaned_data:
+                            if coach_data:
+                                Entrenador.objects.create(
+                                    club=club,
+                                    nombre=coach_data["nombre"],
+                                    apellidos=coach_data["apellidos"],
+                                )
+                    return render(request, "core/registro_pro_success.html")
+                else:
+                    form.add_error(None, "Error al verificar el pago.")
+                    messages.error(request, "Hubo un problema con el pago. Inténtalo de nuevo.")
         start_step = request.POST.get("current_step", 1)
     else:
         form = RegistroProfesionalForm()


### PR DESCRIPTION
## Summary
- Validate Stripe PaymentIntent on professional registration, ensuring succeeded status and correct amount before creating club or coach profiles
- Surface payment verification errors through form non-field errors and toast messages
- Update and extend tests to cover successful payments and failed verification scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afadcfc65083219b294b3265594cda