### PR TITLE
Handle Stripe errors during payment creation

### DIFF
--- a/apps/core/test_stripe_errors.py
+++ b/apps/core/test_stripe_errors.py
@@ -1,0 +1,37 @@
+from django.test import TestCase, Client, override_settings
+from django.urls import reverse
+from django.contrib.auth.models import User
+from unittest.mock import patch
+import stripe
+
+class StripeErrorHandlingTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="user", password="pass")
+        self.client = Client(enforce_csrf_checks=True)
+        self.client.login(username="user", password="pass")
+        self.client.get("/")
+        self.csrftoken = self.client.cookies.get("csrftoken").value
+
+    @override_settings(STRIPE_SECRET_KEY="sk_test")
+    def test_create_payment_intent_handles_error(self):
+        url = reverse("create_payment_intent")
+        with patch("stripe.PaymentIntent.create", side_effect=stripe.error.StripeError("boom")):
+            response = self.client.post(
+                url,
+                {"plan": "plata"},
+                HTTP_X_CSRFTOKEN=self.csrftoken,
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+    @override_settings(STRIPE_SECRET_KEY="sk_test")
+    def test_create_checkout_session_handles_error(self):
+        url = reverse("create_checkout_session")
+        with patch("stripe.checkout.Session.create", side_effect=stripe.error.StripeError("boom")):
+            response = self.client.post(
+                url,
+                {"plan": "plata"},
+                HTTP_X_CSRFTOKEN=self.csrftoken,
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())


### PR DESCRIPTION
## Summary
- Handle Stripe exceptions when creating payment intents and checkout sessions
- Add tests ensuring Stripe errors return JSON instead of crashing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afba09e33083218ca5391cf34a430c