### PR TITLE
Fix Stripe test card failure and modernize checkout

### DIFF
--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -182,7 +182,11 @@ def create_payment_intent(request):
 
     stripe.api_key = settings.STRIPE_SECRET_KEY
     try:
-        intent = stripe.PaymentIntent.create(amount=amount, currency="eur")
+        intent = stripe.PaymentIntent.create(
+            amount=amount,
+            currency="eur",
+            automatic_payment_methods={"enabled": True},
+        )
     except stripe.error.StripeError as e:
         return JsonResponse({"error": str(e)}, status=400)
     return JsonResponse({"clientSecret": intent.client_secret})

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -20,6 +20,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const cardholderName = document.getElementById('cardholder-name');
   const paymentMessage = document.getElementById('payment-message');
   const paymentIntentInput = document.getElementById('payment_intent_id');
+  const billingSame = document.getElementById('billing-same');
+  const billingFields = document.getElementById('billing-fields');
+  const billingLine1 = document.getElementById('billing-line1');
+  const billingPostal = document.getElementById('billing-postal');
+  const billingCity = document.getElementById('billing-city');
+  const billingCountry = document.getElementById('billing-country');
   const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
   const form = document.querySelector('.profile-form');
   let stripe = null;
@@ -243,10 +249,26 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         const data = await response.json();
         if (!data.clientSecret) throw new Error('no client secret');
+        const billingAddress = billingSame && billingSame.checked
+          ? {
+              line1: document.getElementById('id_calle')?.value || '',
+              postal_code: document.getElementById('id_codigo_postal')?.value || '',
+              city: document.getElementById('id_ciudad')?.value || '',
+              country: document.getElementById('id_pais')?.value || '',
+            }
+          : {
+              line1: billingLine1 ? billingLine1.value : '',
+              postal_code: billingPostal ? billingPostal.value : '',
+              city: billingCity ? billingCity.value : '',
+              country: billingCountry ? billingCountry.value : '',
+            };
         const result = await stripe.confirmCardPayment(data.clientSecret, {
           payment_method: {
             card: cardElement,
-            billing_details: { name: cardholderName ? cardholderName.value : '' }
+            billing_details: {
+              name: cardholderName ? cardholderName.value : '',
+              address: billingAddress,
+            }
           }
         });
         if (result.error) {
@@ -317,6 +339,13 @@ document.addEventListener('DOMContentLoaded', () => {
   showStep(current);
   updateFeatureForms();
   updatePlanSummary();
+
+  if (billingSame && billingFields) {
+    billingFields.classList.toggle('d-none', billingSame.checked);
+    billingSame.addEventListener('change', () => {
+      billingFields.classList.toggle('d-none', billingSame.checked);
+    });
+  }
 
     function updateFeatureForms() {
     const selected = document.querySelector('input[name="tipo"]:checked');

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -51,6 +51,27 @@
                             <div id="plan-summary" class="fw-medium"></div>
                         </div>
                         <div class="mb-3">
+                            <p class="mb-1">Dirección de facturación</p>
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" id="billing-same" checked>
+                                <label class="form-check-label" for="billing-same">Usar la dirección anterior</label>
+                            </div>
+                            <div id="billing-fields" class="row g-2 mt-2 d-none">
+                                <div class="col-md-8">
+                                    <input type="text" id="billing-line1" class="form-control" placeholder="Dirección">
+                                </div>
+                                <div class="col-md-4">
+                                    <input type="text" id="billing-postal" class="form-control" placeholder="Código postal">
+                                </div>
+                                <div class="col-md-6">
+                                    <input type="text" id="billing-city" class="form-control" placeholder="Ciudad">
+                                </div>
+                                <div class="col-md-6">
+                                    <input type="text" id="billing-country" class="form-control" placeholder="País">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="mb-3">
                             <label for="cardholder-name" class="form-label">Nombre y apellidos</label>
                             <input type="text" id="cardholder-name" class="form-control" required>
                         </div>


### PR DESCRIPTION
## Summary
- enable automatic payment methods when creating Stripe PaymentIntent to avoid test-card failures
- add minimalist billing address section with option to reuse profile address on checkout step
- wire billing address into payment flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afbc6be6108321b34571f9ddd1be2b