### PR TITLE
Add Stripe billing and purchase summary to pro registration

### DIFF
--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -44,16 +44,37 @@
                     <div id="step3" class="step fade-step d-none">
                         {% include 'core/_pro_extra_form.html' with form=extra_form coach_formset=coach_formset %}
                     </div>
-                    <div id="step4" class="step fade-step d-none text-center">
-                        <h1 class="h5 mb-3">Pasarela de pagos</h1>
-                        <p class="text-muted mb-4">Ingresa los datos de tu tarjeta para completar el registro.</p>
-                        <form id="payment-form" class="mx-auto" style="max-width: 400px;">
-                            <div id="card-element" class="mb-3"></div>
-                            <div id="card-errors" class="text-danger mb-3" role="alert"></div>
-                            <button id="submit-payment" class="btn btn-primary w-100">Pagar</button>
-                        </form>
-                        <div id="step4-alert" class="alert alert-danger mt-3 d-none" role="alert">
-                            Por favor verifica los datos de la tarjeta.
+                    <div id="step4" class="step fade-step d-none">
+                        <h1 class="h5 mb-3 text-center">Pasarela de pagos</h1>
+                        <p class="text-muted mb-4 text-center">Ingresa los datos de facturación y de tu tarjeta para completar el registro.</p>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <form id="billing-form" class="mb-4">
+                                    <div class="mb-3">
+                                        <label for="billing-name" class="form-label">Nombre</label>
+                                        <input type="text" class="form-control" id="billing-name" placeholder="Nombre completo" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="billing-email" class="form-label">Correo electrónico</label>
+                                        <input type="email" class="form-control" id="billing-email" placeholder="correo@example.com" required>
+                                    </div>
+                                </form>
+                                <form id="payment-form">
+                                    <div id="card-element" class="mb-3"></div>
+                                    <div id="card-errors" class="text-danger mb-3" role="alert"></div>
+                                    <button id="submit-payment" class="btn btn-primary w-100">Pagar</button>
+                                </form>
+                                <div id="step4-alert" class="alert alert-danger mt-3 d-none" role="alert">
+                                    Por favor verifica los datos de la tarjeta.
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div id="purchase-summary" class="border p-3 rounded">
+                                    <h2 class="h6 mb-3">Resumen de la compra</h2>
+                                    <p class="mb-1"><strong>Plan:</strong> <span id="summary-plan">-</span></p>
+                                    <p class="mb-0"><strong>Precio:</strong> <span id="summary-price">-</span></p>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <div class="d-flex mt-4">


### PR DESCRIPTION
## Summary
- Add billing details and card payment forms to professional registration checkout
- Display purchase summary alongside payment form
- Send billing details to Stripe when confirming card payment

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b10cd052048321b4e92ca5130aab98