### PR TITLE
Enable Stripe card inputs during pro registration

### DIFF
--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -226,7 +226,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-    if (paymentForm && window.stripePublicKey) {
+  if (paymentForm && submitPaymentBtn && window.stripePublicKey) {
       const stripe = Stripe(window.stripePublicKey);
       const elements = stripe.elements();
       cardNumberElement = elements.create('cardNumber');
@@ -236,7 +236,7 @@ document.addEventListener('DOMContentLoaded', () => {
       cardCvcElement = elements.create('cardCvc');
       cardCvcElement.mount('#card-cvc-element');
 
-      paymentForm.addEventListener('submit', async (e) => {
+      submitPaymentBtn.addEventListener('click', async (e) => {
         e.preventDefault();
         if (cardErrors) {
           cardErrors.textContent = '';
@@ -244,10 +244,8 @@ document.addEventListener('DOMContentLoaded', () => {
           cardErrors.classList.add('text-danger');
         }
         if (step4Alert) step4Alert.classList.add('d-none');
-        if (submitPaymentBtn) {
-          submitPaymentBtn.disabled = true;
-          submitPaymentBtn.textContent = 'Procesando...';
-        }
+        submitPaymentBtn.disabled = true;
+        submitPaymentBtn.textContent = 'Procesando...';
         try {
           const response = await fetch('/create-payment-intent/', { method: 'POST' });
           const data = await response.json();
@@ -267,10 +265,8 @@ document.addEventListener('DOMContentLoaded', () => {
               step4Alert.textContent = 'Se produjo un error al procesar la tarjeta.';
               step4Alert.classList.remove('d-none');
             }
-            if (submitPaymentBtn) {
-              submitPaymentBtn.disabled = false;
-              submitPaymentBtn.textContent = 'Pagar';
-            }
+            submitPaymentBtn.disabled = false;
+            submitPaymentBtn.textContent = 'Pagar';
           } else if (paymentIntent && paymentIntent.status === 'succeeded') {
             paymentCompleted = true;
             if (cardErrors) {
@@ -278,11 +274,9 @@ document.addEventListener('DOMContentLoaded', () => {
               cardErrors.classList.add('text-success');
               cardErrors.textContent = 'Pago realizado con éxito.';
             }
-            if (submitPaymentBtn) {
-              submitPaymentBtn.classList.add('d-none');
-              submitPaymentBtn.disabled = false;
-              submitPaymentBtn.textContent = 'Pagar';
-            }
+            submitPaymentBtn.classList.add('d-none');
+            submitPaymentBtn.disabled = false;
+            submitPaymentBtn.textContent = 'Pagar';
             showStep(maxStep);
           }
         } catch (err) {
@@ -291,10 +285,8 @@ document.addEventListener('DOMContentLoaded', () => {
             step4Alert.textContent = 'Se produjo un error al procesar la tarjeta.';
             step4Alert.classList.remove('d-none');
           }
-          if (submitPaymentBtn) {
-            submitPaymentBtn.disabled = false;
-            submitPaymentBtn.textContent = 'Pagar';
-          }
+          submitPaymentBtn.disabled = false;
+          submitPaymentBtn.textContent = 'Pagar';
         }
       });
     }

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -49,7 +49,7 @@
                         <p class="text-muted mb-4 text-center">Ingresa los datos de tu tarjeta para completar el registro.</p>
                         <div class="row">
                             <div class="col-md-6">
-                                <form id="payment-form">
+                                <div id="payment-form">
                                     <div class="form-field">
                                         <input type="text" id="card-holder-name" class="form-control" required>
                                         <button type="button" class="clear-btn bi bi-x"></button>
@@ -75,7 +75,7 @@
                                     </div>
                                     <div id="card-errors" class="text-danger mb-3" role="alert"></div>
                                     <button id="submit-payment" class="btn btn-primary w-100">Pagar</button>
-                                </form>
+                                </div>
                                 <div id="step4-alert" class="alert alert-danger mt-3 d-none" role="alert">
                                     Por favor verifica los datos de la tarjeta.
                                 </div>


### PR DESCRIPTION
## Summary
- Remove nested payment form so Stripe card fields are interactive
- Handle payment button click to confirm card with Stripe

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b118064a488321aa0d95b2606c6520