### PR TITLE
Integrate Stripe checkout in registration

### DIFF
--- a/apps/core/utils/plans.py
+++ b/apps/core/utils/plans.py
@@ -9,6 +9,7 @@ PLANS = [
         "value": "bronce",
         "title": "Plan Bronce",
         "price": "0€ / mes",
+        "amount": 0,
         "features": [
             "Presencia básica en el directorio",
             "Publicación de eventos",
@@ -19,6 +20,7 @@ PLANS = [
         "value": "plata",
         "title": "Plan Plata",
         "price": "9€ / mes",
+        "amount": 900,
         "features": [
             "Todos los beneficios del Plan Bronce",
             "Publicaciones ilimitadas",
@@ -30,6 +32,7 @@ PLANS = [
         "value": "oro",
         "title": "Plan Oro",
         "price": "19€ / mes",
+        "amount": 1900,
         "features": [
             "Todos los beneficios del Plan Plata",
             "Badge de verificación",

--- a/config/urls.py
+++ b/config/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
 
     # Core: Página principal
     path('', include('apps.core.urls')),
+    path('create-payment-intent/', core_public.create_payment_intent, name='create_payment_intent'),
     path('create-checkout-session/', core_public.create_checkout_session, name='create_checkout_session'),
     path('checkout/success/', core_public.checkout_success, name='checkout_success'),
     path('checkout/cancel/', core_public.checkout_cancel, name='checkout_cancel'),

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -44,10 +44,26 @@
                     <div id="step3" class="step fade-step d-none">
                         {% include 'core/_pro_extra_form.html' with form=extra_form coach_formset=coach_formset %}
                     </div> -->
-                    <div id="step4" class="step fade-step d-none text-center">
-                        <h1 class="h5 mb-3">Pasarela de pagos</h1>
-                        <p class="text-muted mb-4">Conecta con Stripe para habilitar los cobros.</p>
-                        <button type="button" class="btn btn-primary" id="stripe-connect-btn">Conectar con Stripe</button>
+                    <div id="step4" class="step fade-step d-none text-start">
+                        <h1 class="h5 mb-4">Pasarela de pagos</h1>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <div class="mb-3">
+                                    <label for="card-holder-name" class="form-label">Titular de la tarjeta</label>
+                                    <input type="text" id="card-holder-name" class="form-control" placeholder="Nombre del titular">
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Detalles de la tarjeta</label>
+                                    <div id="card-element" class="form-control"></div>
+                                    <div id="card-errors" class="text-danger mt-2"></div>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <h2 class="h6">Resumen de la compra</h2>
+                                <p class="mb-1" id="summary-plan"></p>
+                                <p class="mb-0" id="summary-price"></p>
+                            </div>
+                        </div>
                     </div>
                     <div class="d-flex mt-4">
                         <button type="button" class="btn btn-outline-dark d-none" id="prevBtn">Atrás</button>
@@ -62,6 +78,7 @@
     </main>
 {% endblock %}
 {% block extra_js %}
+    {{ plans|json_script:'plans-data' }}
     <script>window.stripePublicKey = "{{ stripe_public_key }}";</script>
     <script src="https://js.stripe.com/v3/"></script>
     <script src="{% static 'js/member-location.js' %}"></script>


### PR DESCRIPTION
## Summary
- add plan pricing amounts and new Stripe payment intent endpoint
- show purchase summary and credit card form in step 4 registration
- handle card payment on final step with Stripe elements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b11adb840c832188a05a5a7a712c5f