### PR TITLE
Enable separate Stripe card fields in professional registration

### DIFF
--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -22,7 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const summaryPrice = document.getElementById('summary-price');
   const plansData = JSON.parse(document.getElementById('plans-data').textContent);
   let stripe = window.stripePublicKey ? Stripe(window.stripePublicKey) : null;
-  let cardElement = null;
+  let cardNumberElement = null;
+  let cardExpiryElement = null;
+  let cardCvcElement = null;
   let clientSecret = null;
     const nameField = document.getElementById('name-field');
     const nameInput = document.getElementById('id_name');
@@ -204,10 +206,10 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   async function processPayment() {
-    if (!stripe || !cardElement || !clientSecret) return null;
+    if (!stripe || !cardNumberElement || !clientSecret) return null;
     const {error, paymentIntent} = await stripe.confirmCardPayment(clientSecret, {
       payment_method: {
-        card: cardElement,
+        card: cardNumberElement,
         billing_details: { name: cardHolderInput ? cardHolderInput.value : '' }
       }
     });
@@ -279,10 +281,20 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(res => res.json())
         .then(data => {
           clientSecret = data.clientSecret;
-          if (stripe && !cardElement) {
+          if (stripe && !cardNumberElement) {
             const elements = stripe.elements();
-            cardElement = elements.create('card');
-            cardElement.mount('#card-element');
+            cardNumberElement = elements.create('cardNumber');
+            cardNumberElement.mount('#card-number-element');
+            cardExpiryElement = elements.create('cardExpiry');
+            cardExpiryElement.mount('#card-expiry-element');
+            cardCvcElement = elements.create('cardCvc');
+            cardCvcElement.mount('#card-cvc-element');
+            const handleCardErrors = (event) => {
+              if (cardErrors) cardErrors.textContent = event.error ? event.error.message : '';
+            };
+            cardNumberElement.on('change', handleCardErrors);
+            cardExpiryElement.on('change', handleCardErrors);
+            cardCvcElement.on('change', handleCardErrors);
           }
         });
     }

--- a/templates/core/registro_pro.html
+++ b/templates/core/registro_pro.html
@@ -53,10 +53,18 @@
                                     <input type="text" id="card-holder-name" class="form-control" placeholder="Nombre del titular">
                                 </div>
                                 <div class="mb-3">
-                                    <label class="form-label">Detalles de la tarjeta</label>
-                                    <div id="card-element" class="form-control"></div>
-                                    <div id="card-errors" class="text-danger mt-2"></div>
+                                    <label for="card-number-element" class="form-label">Número de tarjeta</label>
+                                    <div id="card-number-element" class="form-control"></div>
                                 </div>
+                                <div class="mb-3">
+                                    <label for="card-expiry-element" class="form-label">Fecha de caducidad</label>
+                                    <div id="card-expiry-element" class="form-control"></div>
+                                </div>
+                                <div class="mb-3">
+                                    <label for="card-cvc-element" class="form-label">CVV</label>
+                                    <div id="card-cvc-element" class="form-control"></div>
+                                </div>
+                                <div id="card-errors" class="text-danger mt-2"></div>
                             </div>
                             <div class="col-md-6">
                                 <h2 class="h6">Resumen de la compra</h2>


### PR DESCRIPTION
## Summary
- Split payment section into separate card number, expiry, and CVC fields
- Initialize individual Stripe Elements and error handling in registration script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b11dfe2a448321be2f1f50da21e99f