### PR TITLE
Fix Stripe card payments on professional registration

### DIFF
--- a/apps/core/test_payment_intent.py
+++ b/apps/core/test_payment_intent.py
@@ -1,0 +1,41 @@
+import json
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+from django.urls import reverse
+import stripe
+
+
+class PaymentIntentTests(TestCase):
+    @patch("apps.core.views.public.get_stripe")
+    def test_create_payment_intent_success(self, mock_get_stripe):
+        mock_stripe = Mock()
+        mock_get_stripe.return_value = mock_stripe
+        mock_stripe.PaymentIntent.create.return_value = Mock(client_secret="cs_test")
+
+        response = self.client.post(
+            reverse("create_payment_intent"),
+            data=json.dumps({"plan": "plata"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(response.content, {"clientSecret": "cs_test"})
+        mock_stripe.PaymentIntent.create.assert_called_once_with(
+            amount=900, currency="eur", automatic_payment_methods={"enabled": True}
+        )
+
+    @patch("apps.core.views.public.get_stripe")
+    def test_create_payment_intent_error(self, mock_get_stripe):
+        mock_stripe = Mock()
+        mock_get_stripe.return_value = mock_stripe
+        mock_stripe.PaymentIntent.create.side_effect = stripe.error.StripeError("fail")
+
+        response = self.client.post(
+            reverse("create_payment_intent"),
+            data=json.dumps({"plan": "plata"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())

--- a/static/js/pro-registro.js
+++ b/static/js/pro-registro.js
@@ -280,6 +280,10 @@ document.addEventListener('DOMContentLoaded', () => {
       })
         .then(res => res.json())
         .then(data => {
+          if (!data.clientSecret) {
+            if (cardErrors) cardErrors.textContent = data.error || 'No se pudo iniciar el pago.';
+            return;
+          }
           clientSecret = data.clientSecret;
           if (stripe && !cardNumberElement) {
             const elements = stripe.elements();
@@ -296,6 +300,9 @@ document.addEventListener('DOMContentLoaded', () => {
             cardExpiryElement.on('change', handleCardErrors);
             cardCvcElement.on('change', handleCardErrors);
           }
+        })
+        .catch(() => {
+          if (cardErrors) cardErrors.textContent = 'No se pudo conectar con el servicio de pago.';
         });
     }
   }


### PR DESCRIPTION
## Summary
- handle Stripe PaymentIntent creation errors and enable automatic card methods
- show payment errors in `pro-registro` Stripe form
- add tests covering PaymentIntent creation and error path

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b11f63de108321b5846591df508aa8