### PR TITLE
Fix Stripe card payment intent

### DIFF
--- a/apps/core/test_payment_intent.py
+++ b/apps/core/test_payment_intent.py
@@ -22,7 +22,7 @@ class PaymentIntentTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertJSONEqual(response.content, {"clientSecret": "cs_test"})
         mock_stripe.PaymentIntent.create.assert_called_once_with(
-            amount=900, currency="eur", automatic_payment_methods={"enabled": True}
+            amount=900, currency="eur", payment_method_types=["card"]
         )
 
     @patch("apps.core.views.public.get_stripe")

--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -175,10 +175,13 @@ def create_payment_intent(request):
 
     try:
         stripe_client = get_stripe()
+        # Usamos los elementos de tarjeta, por lo que especificamos
+        # explícitamente el método de pago "card" en lugar de confiar
+        # en los "automatic_payment_methods" de Stripe.
         intent = stripe_client.PaymentIntent.create(
             amount=plan["amount"],
             currency="eur",
-            automatic_payment_methods={"enabled": True},
+            payment_method_types=["card"],
         )
     except (ImproperlyConfigured, stripe.error.StripeError):
         return JsonResponse({"error": "No se pudo iniciar el pago"}, status=400)


### PR DESCRIPTION
## Summary
- ensure Stripe PaymentIntent uses explicit card method instead of automatic payment methods for compatibility with card elements
- update test expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b12153c4b08321acea008d560e0dc2