### PR TITLE
Enhance Stripe payment intent metadata

### DIFF
--- a/apps/core/test_payment_intent.py
+++ b/apps/core/test_payment_intent.py
@@ -22,7 +22,11 @@ class PaymentIntentTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertJSONEqual(response.content, {"clientSecret": "cs_test"})
         mock_stripe.PaymentIntent.create.assert_called_once_with(
-            amount=900, currency="eur", payment_method_types=["card"]
+            amount=900,
+            currency="eur",
+            payment_method_types=["card"],
+            description="Registro Pro - Plan plata",
+            metadata={"plan": "plata", "user_id": None},
         )
 
     @patch("apps.core.views.public.get_stripe")

--- a/apps/core/views/public.py
+++ b/apps/core/views/public.py
@@ -182,6 +182,11 @@ def create_payment_intent(request):
             amount=plan["amount"],
             currency="eur",
             payment_method_types=["card"],
+            description=f"Registro Pro - Plan {plan_value}",
+            metadata={
+                "plan": plan_value,
+                "user_id": request.user.id if request.user.is_authenticated else None,
+            },
         )
     except (ImproperlyConfigured, stripe.error.StripeError):
         return JsonResponse({"error": "No se pudo iniciar el pago"}, status=400)


### PR DESCRIPTION
## Summary
- include plan and user metadata when creating Stripe payment intents for registro pro
- test payment intent metadata and description

## Testing
- `python manage.py test apps.core.test_payment_intent -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b122ca87e88321887dda2d637a1967